### PR TITLE
Document wxp initialization flow in gain example

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -65,6 +65,17 @@ Channel コールバック        ◄──────    RunLoopSender → Cha
 5. JS: Channel コールバックで render() が呼ばれ、UI が更新される
 ```
 
+## wxp 初期化フロー（CLAP コンテキスト）
+
+CLAP の `set_parent()` コールバック内で WebView を生成します（実装は `gui.rs` 参照）。
+
+1. `WebContext::new(data_dir).build_wry_context()` — ユーザーデータディレクトリを設定。返した `wry::WebContext` は WebView の生存期間中保持し続ける必要があるため `self` に格納する
+2. `wxp_clack::window::clack_to_wry_window_handle(&parent)` — CLAP の `Window` を wry の `WindowHandle` に変換
+3. `WxpWebViewBuilder::new(&mut wry_context)` でビルダーを作成し、コマンドハンドラ・URL・サイズ等を設定
+4. `.build_as_child(&parent_handle)` で `WebViewRef` を取得して `self` に格納
+
+`destroy()` では `reset_webview()` を通じて GUI 通知チャネルのクリア、`WebViewRef` の drop による WebView 破棄、`wry::WebContext` の破棄を順に行います。
+
 ## 主要な依存クレート
 
 | クレート | 役割 |

--- a/src-plugin/src/params.rs
+++ b/src-plugin/src/params.rs
@@ -30,7 +30,7 @@ use crate::plugin::{
 
 /// プラグイン状態の保存・復元（CLAP state 拡張）。
 /// DAW がプロジェクトを保存/読み込みする際に呼ばれる。
-/// フォーマットは自由だが、ここでは [長さ(4byte LE)] + [JSON バイト列] を使用。
+/// フォーマットは自由だが、ここでは `[長さ (4 byte LE)] + [JSON バイト列]` を使用。
 impl PluginStateImpl for WxpExampleGainMainThread<'_> {
     fn save(&mut self, output: &mut OutputStream) -> Result<(), PluginError> {
         let bytes = to_vec(&SavedPluginState {


### PR DESCRIPTION
## Summary
- add a step-by-step explanation of the CLAP-side wxp initialization flow and teardown order
- tighten the saved-state format wording in the parameter documentation

## Validation
- cargo check --workspace --all-targets