### PR TITLE
chore: translate scripts and clap_wrapper_builder to English

### DIFF
--- a/clap_wrapper_builder/CMakeLists.txt
+++ b/clap_wrapper_builder/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.21)
 project(clap_wrapper_builder)
 # enable_language(OBJCXX)
 
-# C++23 以上を要求（clap-wrapper と AudioUnitSDK の要件に合わせる）
+# Require C++23 or later (required by clap-wrapper and AudioUnitSDK)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_OSX_DEPLOYMENT_TARGET 10.15)
@@ -11,7 +11,7 @@ set(CLAP_SDK_ROOT "${CMAKE_CURRENT_LIST_DIR}/clap")
 
 set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
-# キャッシュ変数として静的リンクライブラリのパスを受け取る
+# Receive the static library path as a cache variable
 set(CLAP_WRAPPER_BUILDER_TARGET_LIB "" CACHE FILEPATH "Path to the static library to wrap")
 option(CLAP_WRAPPER_BUILDER_BUILD_STANDALONE "Build standalone app target in clap_wrapper_builder" OFF)
 option(CLAP_WRAPPER_BUILDER_BUILD_VST3 "Build VST3 target in clap_wrapper_builder" ON)
@@ -23,7 +23,7 @@ endif()
 set(CLAP_WRAPPER_BUILDER_STANDALONE_OUTPUT_NAME "" CACHE STRING "Output name for standalone app")
 set(CLAP_WRAPPER_BUILDER_STANDALONE_PLUGIN_ID "" CACHE STRING "Plugin ID used by standalone app")
 
-# 必須パラメータの検証
+# Validate required parameters
 if(NOT CLAP_WRAPPER_BUILDER_TARGET_LIB)
     message(FATAL_ERROR "CLAP_WRAPPER_BUILDER_TARGET_LIB must be specified. Use: -DCLAP_WRAPPER_BUILDER_TARGET_LIB=/path/to/your/plugin.a")
 endif()
@@ -32,7 +32,7 @@ if(NOT EXISTS ${CLAP_WRAPPER_BUILDER_TARGET_LIB})
     message(FATAL_ERROR "Static library not found: ${CLAP_WRAPPER_BUILDER_TARGET_LIB}")
 endif()
 
-# プラグイン名の取得（静的ライブラリのファイル名から）
+# Derive plugin name from the static library filename
 get_filename_component(PLUGIN_NAME ${CLAP_WRAPPER_BUILDER_TARGET_LIB} NAME_WE)
 string(REGEX REPLACE "^lib" "" PLUGIN_NAME ${PLUGIN_NAME})
 string(REGEX REPLACE "[^A-Za-z0-9_]" "_" PLUGIN_NAME_SAFE ${PLUGIN_NAME})
@@ -43,15 +43,15 @@ message(STATUS "  Target Library: ${CLAP_WRAPPER_BUILDER_TARGET_LIB}")
 message(STATUS "  Plugin Name: ${PLUGIN_NAME}")
 message(STATUS "  Safe Plugin Name: ${PLUGIN_NAME_SAFE}")
 
-# clap-wrapper サブプロジェクトを追加
+# Add the clap-wrapper subproject
 add_subdirectory(clap-wrapper)
 
 if(APPLE AND TARGET clap-wrapper-compile-options)
   target_compile_options(clap-wrapper-compile-options INTERFACE -Wno-shorten-64-to-32)
 endif()
 
-# 静的ライブラリターゲットの作成
-# 外部の静的ライブラリをインポートライブラリとして設定
+# Create the static library target
+# Set up the external static library as an imported library
 add_library(${PLUGIN_NAME_SAFE}_impl STATIC IMPORTED)
 
 if(MSVC)
@@ -67,12 +67,11 @@ if(APPLE)
       INTERFACE_LINK_LIBRARIES "-framework AppKit;-framework Foundation"
   )
 endif()
-# CLAP エントリーポイント用のソースファイルを生成
-# ただし、 CLAP のエントリーポイントは clack が用意したものが
-# CLAP_WRAPPER_BUILDER_TARGET_LIB の中に存在していて、
-# ここでは CLAP_WRAPPER_BUILDER_TARGET_LIB の中の get_clap_entry() 関数を呼び出すことで
-# CLAP_WRAPPER_BUILDER_TARGET_LIB の中の clap_entry のシンボルが strip されずに
-# 正しく DLL 中にも残るようにしている。
+# Generate the source file for the CLAP entry point.
+# The CLAP entry point itself is provided by clack and lives inside
+# CLAP_WRAPPER_BUILDER_TARGET_LIB. Calling get_clap_entry() from here
+# prevents the clap_entry symbol inside CLAP_WRAPPER_BUILDER_TARGET_LIB
+# from being stripped, ensuring it is correctly retained in the DLL.
 set(ENTRY_SOURCE_FILE "${CMAKE_CURRENT_BINARY_DIR}/${PLUGIN_NAME_SAFE}_entry.cpp")
 file(WRITE ${ENTRY_SOURCE_FILE} "
 #include <clap/clap.h>
@@ -87,7 +86,7 @@ extern \"C\" {
 #endif
 ")
 
-# ビルドするプラグインフォーマットを設定
+# Configure plugin formats to build
 set(PLUGIN_FORMATS "CLAP")
 if(CLAP_WRAPPER_BUILDER_BUILD_VST3)
     list(APPEND PLUGIN_FORMATS "VST3")
@@ -96,11 +95,11 @@ if(APPLE AND CLAP_WRAPPER_BUILDER_BUILD_AUV2)
     list(APPEND PLUGIN_FORMATS "AUV2")
 endif()
 
-# プラグインのバンドル情報
+# Plugin bundle metadata
 set(BUNDLE_ID "org.wrapper.${PLUGIN_NAME_BUNDLE}")
 set(BUNDLE_VERSION "1.0.0")
 
-# make_clapfirst_plugins を使用してマルチフォーマットプラグインを作成
+# Create multi-format plugins using make_clapfirst_plugins
 set(CLAPFIRST_COMMON_ARGS
     TARGET_NAME ${PLUGIN_NAME_SAFE}
     IMPL_TARGET ${PLUGIN_NAME_SAFE}_impl

--- a/clap_wrapper_builder/README.md
+++ b/clap_wrapper_builder/README.md
@@ -1,21 +1,21 @@
 # clap_wrapper_builder
 
-`clap_wrapper_builder` は、`wrac-plugin-template` の参照実装から
-CLAP プラグインを VST3 / AUv2 / Standalone にラップするための補助ビルド環境です。
+`clap_wrapper_builder` is a helper build environment for wrapping a CLAP plugin
+from the `wrac-plugin-template` reference implementation into VST3 / AUv2 / Standalone.
 
-これは正式な安定 API ではありません。ルートの gain plugin などの
-サンプル実装を支えるための例示用コードとして扱い、破壊的変更が入る可能性があります。
+This is not a stable public API. Treat it as example code that supports sample
+implementations such as the root gain plugin — breaking changes may be introduced.
 
-## 含まれるもの
+## Contents
 
-- `build_wrapper_plugin.sh` - CLAP バンドルから VST3 / AUv2 ラッパーをビルド
-- `build_wrapper_plugin_static.sh` - 静的ライブラリから VST3 / AUv2 / Standalone をビルド
-- `install_wrapper_plugin.sh` - 生成済み VST3 をインストール
-- `clap-wrapper` / `clap` / `vst3sdk` / `AudioUnitSDK` - 依存 SDK / ツールチェーン
+- `build_wrapper_plugin.sh` - Build a VST3 / AUv2 wrapper from a CLAP bundle
+- `build_wrapper_plugin_static.sh` - Build VST3 / AUv2 / Standalone from a static library
+- `install_wrapper_plugin.sh` - Install the generated VST3
+- `clap-wrapper` / `clap` / `vst3sdk` / `AudioUnitSDK` - Dependency SDKs / toolchain
 
-## 想定用途
+## Intended use
 
-- `wrac-plugin-template` の参照プラグインを複数フォーマットで配布する
-- `xdevice-private` など別プロジェクトから参照実装として利用する
+- Distribute the reference plugin of `wrac-plugin-template` in multiple formats
+- Use as a reference implementation from other projects such as `xdevice-private`
 
-長期安定な公開インターフェースとしては扱わず、必要に応じて構成やスクリプトを見直します。
+This is not treated as a long-term stable public interface; the configuration and scripts may be revised as needed.

--- a/clap_wrapper_builder/build_wrapper_plugin.sh
+++ b/clap_wrapper_builder/build_wrapper_plugin.sh
@@ -1,29 +1,29 @@
 #!/bin/bash
-# build_wrapper_plugin.sh - 任意のCLAPプラグインからVST3/AUラッパーをビルド
+# build_wrapper_plugin.sh - Build VST3/AU wrapper from any CLAP plugin
 #
-# 使い方:
-#   ./build_wrapper_plugin.sh <CLAPファイル名> <出力プラグイン名> [Debug|Release]
+# Usage:
+#   ./build_wrapper_plugin.sh <CLAP file> <output plugin name> [Debug|Release]
 #
-# 引数:
-#   CLAPファイル名 - CLAPプラグインのファイル名 (例: "example_plugin_nih.clap")
-#   出力プラグイン名 - VST3/AUで使用する表示名 (例: "Example Plugin NIH")
-#   Debug|Release - ビルド構成（省略時は Debug）
+# Arguments:
+#   CLAP file    - CLAP plugin filename (e.g. "example_plugin_nih.clap")
+#   Output name  - Display name used in VST3/AU (e.g. "Example Plugin NIH")
+#   Debug|Release - Build configuration (default: Debug)
 #
-# 例:
+# Examples:
 #   ./build_wrapper_plugin.sh example_plugin_nih.clap "Example Plugin NIH" Release
 #   ./build_wrapper_plugin.sh "XDevice Editor.clap" "XDevice Editor" Debug
 
 set -Eeuo pipefail
 
-# カラー出力用の定数
+# Constants for colored output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
-# エラーメッセージ表示関数
+# Error message function
 error() {
-    echo -e "${RED}エラー: $1${NC}" >&2
+    echo -e "${RED}Error: $1${NC}" >&2
     exit 1
 }
 
@@ -31,37 +31,37 @@ on_error() {
     local exit_code="$1"
     local line_no="$2"
     local command="$3"
-    echo -e "${RED}エラー: ${line_no} 行目のコマンドが失敗しました (exit=${exit_code}): ${command}${NC}" >&2
+    echo -e "${RED}Error: command failed at line ${line_no} (exit=${exit_code}): ${command}${NC}" >&2
     exit "$exit_code"
 }
 
 trap 'on_error $? $LINENO "$BASH_COMMAND"' ERR
 
-# 成功メッセージ表示関数
+# Success message function
 success() {
     echo -e "${GREEN}$1${NC}"
 }
 
-# 警告メッセージ表示関数
+# Warning message function
 warning() {
-    echo -e "${YELLOW}警告: $1${NC}"
+    echo -e "${YELLOW}Warning: $1${NC}"
 }
 
-# 現在のディレクトリを保存
+# Save the directory of this script
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-# 使用方法を表示する関数
+# Usage display function
 usage() {
-    echo "使用方法: $0 <CLAPファイル名> <出力プラグイン名> [Debug|Release]"
-    echo "  引数を指定しない場合、ビルド構成のデフォルトは Debug です"
+    echo "Usage: $0 <CLAP file> <output plugin name> [Debug|Release]"
+    echo "  If omitted, build configuration defaults to Debug"
     echo ""
-    echo "例:"
+    echo "Examples:"
     echo "  $0 example_plugin_nih.clap \"Example Plugin NIH\" Release"
     echo "  $0 \"XDevice Editor.clap\" \"XDevice Editor\" Debug"
     exit 1
 }
 
-# 引数の処理
+# Argument parsing
 if [ $# -lt 2 ]; then
     usage
 fi
@@ -82,52 +82,52 @@ if [ $# -ge 3 ]; then
             usage
             ;;
         *)
-            error "無効なビルド構成: $3"
+            error "Invalid build configuration: $3"
             ;;
     esac
 fi
 
-echo "CLAPファイル: $CLAP_FILE"
-echo "出力プラグイン名: $OUTPUT_NAME"
-echo "ビルド構成: $BUILD_CONFIG"
+echo "CLAP file: $CLAP_FILE"
+echo "Output plugin name: $OUTPUT_NAME"
+echo "Build configuration: $BUILD_CONFIG"
 
-# CLAPファイル名から拡張子を除いた名前を取得し、スペースをアンダースコアに置換
-# パス部分を除去してファイル名のみを取得
+# Strip extension from CLAP filename and replace spaces with underscores
+# Remove path component, keep filename only
 CLAP_FILE_BASENAME=$(basename "$CLAP_FILE")
 CLAP_BASE_NAME="${CLAP_FILE_BASENAME%.clap}"
 CLAP_BASE_NAME="${CLAP_BASE_NAME// /_}"
 
-# clap-wrapper ディレクトリの確認
+# Check for clap-wrapper directory
 if [ ! -d "$SCRIPT_DIR/clap-wrapper" ]; then
-    error "clap-wrapper ディレクトリが見つかりません。先に git clone https://github.com/free-audio/clap-wrapper.git を実行してください。"
+    error "clap-wrapper directory not found. Run: git clone https://github.com/free-audio/clap-wrapper.git"
 fi
 
-# サブモジュールの clap SDK を使用
+# Use the clap SDK submodule
 CLAP_SDK_ROOT="$SCRIPT_DIR/clap"
 if [ ! -d "$CLAP_SDK_ROOT" ]; then
-    error "clap サブモジュールが見つかりません。git submodule update --init --recursive を実行してください。"
+    error "clap submodule not found. Run: git submodule update --init --recursive"
 fi
-success "CLAP SDK サブモジュールを検出: $CLAP_SDK_ROOT"
+success "CLAP SDK submodule found: $CLAP_SDK_ROOT"
 
-# サブモジュールの VST3 SDK を使用
+# Use the VST3 SDK submodule
 VST3_SDK_ROOT="$SCRIPT_DIR/vst3sdk"
 if [ ! -d "$VST3_SDK_ROOT" ]; then
-    error "vst3sdk サブモジュールが見つかりません。git submodule update --init --recursive を実行してください。"
+    error "vst3sdk submodule not found. Run: git submodule update --init --recursive"
 fi
-success "VST3 SDK サブモジュールを検出: $VST3_SDK_ROOT"
+success "VST3 SDK submodule found: $VST3_SDK_ROOT"
 
-# サブモジュールの AU SDK を使用
+# Use the AU SDK submodule
 if [[ "$OSTYPE" == darwin* ]]; then
     AU_SDK_ROOT="$SCRIPT_DIR/AudioUnitSDK"
     if [[ ! -d "$AU_SDK_ROOT" ]]; then
-        error "AudioUnitSDK サブモジュールが見つかりません。git submodule update --init --recursive を実行してください。"
+        error "AudioUnitSDK submodule not found. Run: git submodule update --init --recursive"
     fi
-    success "AU SDK サブモジュールを検出: $AU_SDK_ROOT"
+    success "AU SDK submodule found: $AU_SDK_ROOT"
 else
     AU_SDK_ROOT=
 fi
 
-# OS の検出とジェネレータの選択
+# OS detection and generator selection
 CMAKE_GENERATOR=""
 
 case "$OSTYPE" in
@@ -135,41 +135,41 @@ case "$OSTYPE" in
         # macOS
         if command -v xcodebuild &> /dev/null; then
             CMAKE_GENERATOR="Xcode"
-            success "macOS を検出: Xcode を使用します"
+            success "Detected macOS: using Xcode"
         else
-            error "Xcode が見つかりません。Xcode または Command Line Tools をインストールしてください。"
+            error "Xcode not found. Install Xcode or Command Line Tools."
         fi
         ;;
     linux*)
         # Linux
         CMAKE_GENERATOR="Unix Makefiles"
-        success "Linux を検出: Unix Makefiles を使用します"
+        success "Detected Linux: using Unix Makefiles"
         ;;
     msys*|cygwin*|mingw*)
         # Windows
-        # CMakeが自動的にVisual Studioを検出する
+        # CMake automatically detects Visual Studio
         CMAKE_GENERATOR="Visual Studio 17 2022"
-        success "Windows を検出: Visual Studio 2022 を使用します"
+        success "Detected Windows: using Visual Studio 2022"
         ;;
     *)
         CMAKE_GENERATOR="Unix Makefiles"
-        warning "不明な OS: Unix Makefiles を使用します"
+        warning "Unknown OS: using Unix Makefiles"
         ;;
 esac
 
-# ビルドディレクトリをclap_wrapper_builderに作成
+# Create build directory inside clap_wrapper_builder
 BUILD_DIR="$SCRIPT_DIR/build_$CLAP_BASE_NAME"
 
-# リポジトリ名変更などで CMakeCache に古いソースパスが残っている場合は作り直す
+# Rebuild if the CMakeCache has a stale source path (e.g. after repo rename)
 if [ -f "$BUILD_DIR/CMakeCache.txt" ] && ! grep -Fq "$SCRIPT_DIR/clap-wrapper" "$BUILD_DIR/CMakeCache.txt"; then
-    warning "既存の CMake キャッシュが現在のソースディレクトリと一致しないため削除します: $BUILD_DIR"
+    warning "Removing stale CMake cache that does not match current source directory: $BUILD_DIR"
     rm -rf "$BUILD_DIR"
 fi
 
-# CMake の設定
-echo "CMake を設定中..."
+# CMake configuration
+echo "Configuring CMake..."
 if [[ "$OSTYPE" == darwin* ]]; then
-    # macOS の場合、Universal Binary を作成
+    # On macOS, build a Universal Binary
     cmake -S "$SCRIPT_DIR/clap-wrapper" -B "$BUILD_DIR" \
         -DCLAP_SDK_ROOT="$CLAP_SDK_ROOT" \
         -DVST3_SDK_ROOT="$VST3_SDK_ROOT" \
@@ -181,7 +181,7 @@ if [[ "$OSTYPE" == darwin* ]]; then
         -DCLAP_WRAPPER_CXX_STANDARD=23 \
         -G "$CMAKE_GENERATOR"
 else
-    # その他のプラットフォーム
+    # Other platforms
     cmake -S "$SCRIPT_DIR/clap-wrapper" -B "$BUILD_DIR" \
         -DCLAP_SDK_ROOT="$CLAP_SDK_ROOT" \
         -DVST3_SDK_ROOT="$VST3_SDK_ROOT" \
@@ -190,17 +190,17 @@ else
         -G "$CMAKE_GENERATOR"
 fi
 
-success "CMake の設定が完了しました"
+success "CMake configuration complete"
 
-# ビルドの実行
-echo "ビルド中..."
+# Run the build
+echo "Building..."
 
-# AudioUnitSDK のヘッダーが GNU statement expression を使用しており、
-# clap-wrapper の -Wpedantic -Werror と衝突するため、Xcode ビルド時に抑制する
+# AudioUnitSDK headers use GNU statement expressions which conflict with
+# clap-wrapper's -Wpedantic -Werror; suppress the warning during Xcode builds
 if [[ "$CMAKE_GENERATOR" == "Xcode" ]]; then
     XCODE_FLAGS=('--' 'OTHER_CPLUSPLUSFLAGS=$(inherited) -Wno-gnu-statement-expression-from-macro-expansion -Wno-shorten-64-to-32')
     XCODE_BUILD_ARGS=(--clean-first)
-    # macOS かつ xcbeautify がある場合のみパイプを追加
+    # Pipe through xcbeautify only when on macOS and xcbeautify is available
     if command -v xcbeautify &> /dev/null; then
         cmake --build "$BUILD_DIR" --config "$BUILD_CONFIG" "${XCODE_BUILD_ARGS[@]}" "${XCODE_FLAGS[@]}" 2>&1 | xcbeautify --quiet
     else
@@ -211,19 +211,19 @@ elif [[ "$CMAKE_GENERATOR" == "Visual Studio 17 2022" ]]; then
 else
     cmake --build "$BUILD_DIR"
 fi
-success "ビルドが完了しました"
+success "Build complete"
 
-# ビルド結果の確認
+# Verify build output
 VST3_OUTPUT=""
 if [[ "$CMAKE_GENERATOR" == "Xcode" ]] || [[ "$CMAKE_GENERATOR" == "Visual Studio 17 2022" ]]; then
-    # マルチコンフィギュレーションジェネレータの場合、Configuration サブディレクトリを探す
+    # For multi-configuration generators, look in the Configuration subdirectory
     if [[ "$OSTYPE" == darwin* ]]; then
         VST3_OUTPUT=$(find "$BUILD_DIR/$BUILD_CONFIG" -name "*.vst3" -type d 2>/dev/null | head -n 1)
     else
         VST3_OUTPUT=$(find "$BUILD_DIR/$BUILD_CONFIG" -name "*.vst3" -type f 2>/dev/null | head -n 1)
     fi
 else
-    # シングルコンフィギュレーションジェネレータの場合
+    # For single-configuration generators
     if [[ "$OSTYPE" == darwin* ]]; then
         VST3_OUTPUT=$(find "$BUILD_DIR" -name "*.vst3" -type d | head -n 1)
     else
@@ -232,9 +232,9 @@ else
 fi
 
 if [ -n "$VST3_OUTPUT" ]; then
-    # フルパスを取得
+    # Resolve full path
     VST3_FULLPATH="$(cd "$(dirname "$VST3_OUTPUT")" && pwd)/$(basename "$VST3_OUTPUT")"
-    success "VST3 プラグインが生成されました: $VST3_FULLPATH"
+    success "VST3 plugin generated: $VST3_FULLPATH"
 else
-    error "VST3 プラグインが見つかりません"
+    error "VST3 plugin not found"
 fi

--- a/clap_wrapper_builder/build_wrapper_plugin_static.sh
+++ b/clap_wrapper_builder/build_wrapper_plugin_static.sh
@@ -1,30 +1,30 @@
 #!/bin/bash
-# build_wrapper_plugin_static.sh - 任意のCLAPプラグインの静的リンクライブラリからVST3ラッパーをビルド
+# build_wrapper_plugin_static.sh - Build VST3 wrapper from a CLAP plugin static library
 #
-# 使い方:
-#   ./build_wrapper_plugin_static.sh <静的リンクライブラリファイル名> <出力プラグイン名> [Debug|Release] [Standalone用Plugin ID]
+# Usage:
+#   ./build_wrapper_plugin_static.sh <static library file> <output plugin name> [Debug|Release] [standalone plugin ID]
 #
-# 引数:
-#   CLAPファイル名 - CLAPプラグインの静的リンクライブラリファイル名 (例: "libxdevice_plugin.a")
-#   出力プラグイン名 - VST3/AUで使用する表示名 (例: "Example Plugin NIH")
-#   Debug|Release - ビルド構成（省略時は Debug）
-#   Standalone用Plugin ID - 指定時は standalone もビルドする（省略時は環境変数 CLAP_WRAPPER_STANDALONE_PLUGIN_ID を参照）
+# Arguments:
+#   Library file   - CLAP plugin static library filename (e.g. "libxdevice_plugin.a")
+#   Output name    - Display name used in VST3/AU (e.g. "Example Plugin NIH")
+#   Debug|Release  - Build configuration (default: Debug)
+#   Standalone ID  - When specified, also builds standalone (falls back to CLAP_WRAPPER_STANDALONE_PLUGIN_ID env var)
 #
-# 例:
+# Examples:
 #   ./build_wrapper_plugin.sh example_plugin_nih.clap "Example Plugin NIH" Release
 #   ./build_wrapper_plugin.sh "XDevice Editor.clap" "XDevice Editor" Debug
 
 set -Eeuo pipefail
 
-# カラー出力用の定数
+# Constants for colored output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
-# エラーメッセージ表示関数
+# Error message function
 error() {
-    echo -e "${RED}エラー: $1${NC}" >&2
+    echo -e "${RED}Error: $1${NC}" >&2
     exit 1
 }
 
@@ -32,38 +32,38 @@ on_error() {
     local exit_code="$1"
     local line_no="$2"
     local command="$3"
-    echo -e "${RED}エラー: ${line_no} 行目のコマンドが失敗しました (exit=${exit_code}): ${command}${NC}" >&2
+    echo -e "${RED}Error: command failed at line ${line_no} (exit=${exit_code}): ${command}${NC}" >&2
     exit "$exit_code"
 }
 
 trap 'on_error $? $LINENO "$BASH_COMMAND"' ERR
 
-# 成功メッセージ表示関数
+# Success message function
 success() {
     echo -e "${GREEN}$1${NC}"
 }
 
-# 警告メッセージ表示関数
+# Warning message function
 warning() {
-    echo -e "${YELLOW}警告: $1${NC}"
+    echo -e "${YELLOW}Warning: $1${NC}"
 }
 
-# 現在のディレクトリを保存
+# Save the directory of this script
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-# 使用方法を表示する関数
+# Usage display function
 usage() {
-    echo "使用方法: $0 <CLAPファイル名> <出力プラグイン名> [Debug|Release] [Standalone用Plugin ID]"
-    echo "  引数を指定しない場合、ビルド構成のデフォルトは Debug です"
+    echo "Usage: $0 <library file> <output plugin name> [Debug|Release] [standalone plugin ID]"
+    echo "  If omitted, build configuration defaults to Debug"
     echo ""
-    echo "例:"
+    echo "Examples:"
     echo "  $0 example_plugin_nih.clap \"Example Plugin NIH\" Release"
     echo "  $0 \"XDevice Editor.clap\" \"XDevice Editor\" Debug"
     echo "  $0 libexample_plugin_clack.a \"Example Plugin Clack Static\" Debug com.novo-notes.pulsus-gain-clack"
     exit 1
 }
 
-# 引数の処理
+# Argument parsing
 if [ $# -lt 2 ]; then
     usage
 fi
@@ -88,7 +88,7 @@ if [ $# -ge 3 ]; then
             usage
             ;;
         *)
-            error "無効なビルド構成: $3"
+            error "Invalid build configuration: $3"
             ;;
     esac
 fi
@@ -109,60 +109,60 @@ if [ -z "$BUILD_AUV2" ]; then
     fi
 fi
 
-echo "CLAPライブラリファイル: $CLAP_LIBRARY_FILE"
-echo "出力プラグイン名: $OUTPUT_NAME"
-echo "ビルド構成: $BUILD_CONFIG"
-echo "VST3ビルド: $BUILD_VST3"
-echo "AUビルド: $BUILD_AUV2"
+echo "CLAP library file: $CLAP_LIBRARY_FILE"
+echo "Output plugin name: $OUTPUT_NAME"
+echo "Build configuration: $BUILD_CONFIG"
+echo "VST3 build: $BUILD_VST3"
+echo "AU build: $BUILD_AUV2"
 if [ -n "$STANDALONE_PLUGIN_ID" ]; then
     if [ -z "$STANDALONE_OUTPUT_NAME" ]; then
         STANDALONE_OUTPUT_NAME="${OUTPUT_NAME} Standalone"
     fi
-    echo "Standaloneビルド: 有効"
-    echo "Standalone出力名: $STANDALONE_OUTPUT_NAME"
+    echo "Standalone build: enabled"
+    echo "Standalone output name: $STANDALONE_OUTPUT_NAME"
     echo "Standalone Plugin ID: $STANDALONE_PLUGIN_ID"
 else
-    echo "Standaloneビルド: 無効"
+    echo "Standalone build: disabled"
 fi
 
-# CLAPライブラリファイル名から拡張子を除いた名前を取得し、スペースをアンダースコアに置換
-# パス部分を除去してファイル名のみを取得
+# Strip extension from CLAP library filename and replace spaces with underscores
+# Remove path component, keep filename only
 CLAP_FILE_BASENAME=$(basename "$CLAP_LIBRARY_FILE")
 CLAP_BASE_NAME="${CLAP_FILE_BASENAME%.a}"
 CLAP_BASE_NAME="${CLAP_BASE_NAME%.lib}"
 CLAP_BASE_NAME="${CLAP_BASE_NAME// /_}_static"
 
-# clap-wrapper ディレクトリの確認
+# Check for clap-wrapper directory
 if [ ! -d "$SCRIPT_DIR/clap-wrapper" ]; then
-    error "clap-wrapper ディレクトリが見つかりません。先に git clone https://github.com/free-audio/clap-wrapper.git を実行してください。"
+    error "clap-wrapper directory not found. Run: git clone https://github.com/free-audio/clap-wrapper.git"
 fi
 
-# サブモジュールの clap SDK を使用
+# Use the clap SDK submodule
 CLAP_SDK_ROOT="$SCRIPT_DIR/clap"
 if [ ! -d "$CLAP_SDK_ROOT" ]; then
-    error "clap サブモジュールが見つかりません。git submodule update --init --recursive を実行してください。"
+    error "clap submodule not found. Run: git submodule update --init --recursive"
 fi
-success "CLAP SDK サブモジュールを検出: $CLAP_SDK_ROOT"
+success "CLAP SDK submodule found: $CLAP_SDK_ROOT"
 
-# サブモジュールの VST3 SDK を使用
+# Use the VST3 SDK submodule
 VST3_SDK_ROOT="$SCRIPT_DIR/vst3sdk"
 if [ ! -d "$VST3_SDK_ROOT" ]; then
-    error "vst3sdk サブモジュールが見つかりません。git submodule update --init --recursive を実行してください。"
+    error "vst3sdk submodule not found. Run: git submodule update --init --recursive"
 fi
-success "VST3 SDK サブモジュールを検出: $VST3_SDK_ROOT"
+success "VST3 SDK submodule found: $VST3_SDK_ROOT"
 
-# サブモジュールの AU SDK を使用
+# Use the AU SDK submodule
 if [[ "$OSTYPE" == darwin* ]]; then
     AU_SDK_ROOT="$SCRIPT_DIR/AudioUnitSDK"
     if [[ ! -d "$AU_SDK_ROOT" ]]; then
-        error "AudioUnitSDK サブモジュールが見つかりません。git submodule update --init --recursive を実行してください。"
+        error "AudioUnitSDK submodule not found. Run: git submodule update --init --recursive"
     fi
-    success "AU SDK サブモジュールを検出: $AU_SDK_ROOT"
+    success "AU SDK submodule found: $AU_SDK_ROOT"
 else
     AU_SDK_ROOT=
 fi
 
-# OS の検出とジェネレータの選択
+# OS detection and generator selection
 CMAKE_GENERATOR=""
 
 case "$OSTYPE" in
@@ -170,34 +170,34 @@ case "$OSTYPE" in
         # macOS
         if command -v xcodebuild &> /dev/null; then
             CMAKE_GENERATOR="Xcode"
-            success "macOS を検出: Xcode を使用します"
+            success "Detected macOS: using Xcode"
         else
-            error "Xcode が見つかりません。Xcode または Command Line Tools をインストールしてください。"
+            error "Xcode not found. Install Xcode or Command Line Tools."
         fi
         ;;
     linux*)
         # Linux
         CMAKE_GENERATOR="Unix Makefiles"
-        success "Linux を検出: Unix Makefiles を使用します"
+        success "Detected Linux: using Unix Makefiles"
         ;;
     msys*|cygwin*|mingw*)
         # Windows
-        # CMakeが自動的にVisual Studioを検出する
+        # CMake automatically detects Visual Studio
         CMAKE_GENERATOR="Visual Studio 17 2022"
-        success "Windows を検出: Visual Studio 2022 を使用します"
+        success "Detected Windows: using Visual Studio 2022"
         ;;
     *)
         CMAKE_GENERATOR="Unix Makefiles"
-        warning "不明な OS: Unix Makefiles を使用します"
+        warning "Unknown OS: using Unix Makefiles"
         ;;
 esac
 
-# ビルドディレクトリをclap_wrapper_builderに作成
+# Create build directory inside clap_wrapper_builder
 BUILD_DIR="$SCRIPT_DIR/build_$CLAP_BASE_NAME"
 
-# リポジトリ名変更などで CMakeCache に古いソースパスが残っている場合は作り直す
+# Rebuild if the CMakeCache has a stale source path (e.g. after repo rename)
 if [ -f "$BUILD_DIR/CMakeCache.txt" ] && ! grep -Fq "$SCRIPT_DIR" "$BUILD_DIR/CMakeCache.txt"; then
-    warning "既存の CMake キャッシュが現在のソースディレクトリと一致しないため削除します: $BUILD_DIR"
+    warning "Removing stale CMake cache that does not match current source directory: $BUILD_DIR"
     rm -rf "$BUILD_DIR"
 fi
 
@@ -241,17 +241,17 @@ fi
 
 cmake "${CMAKE_CONFIGURE_ARGS[@]}"
 
-success "CMake の設定が完了しました"
+success "CMake configuration complete"
 
-# ビルドの実行
-echo "ビルド中..."
+# Run the build
+echo "Building..."
 
-# AudioUnitSDK のヘッダーが GNU statement expression を使用しており、
-# clap-wrapper の -Wpedantic -Werror と衝突するため、Xcode ビルド時に抑制する
+# AudioUnitSDK headers use GNU statement expressions which conflict with
+# clap-wrapper's -Wpedantic -Werror; suppress the warning during Xcode builds
 if [[ "$CMAKE_GENERATOR" == "Xcode" ]]; then
     XCODE_FLAGS=('--' 'OTHER_CPLUSPLUSFLAGS=$(inherited) -Wno-gnu-statement-expression-from-macro-expansion -Wno-shorten-64-to-32')
     XCODE_BUILD_ARGS=(--clean-first)
-    # macOS かつ xcbeautify がある場合のみパイプを追加
+    # Pipe through xcbeautify only when on macOS and xcbeautify is available
     if command -v xcbeautify &> /dev/null; then
         cmake --build "$BUILD_DIR" --config "$BUILD_CONFIG" "${XCODE_BUILD_ARGS[@]}" "${XCODE_FLAGS[@]}" 2>&1 | xcbeautify --quiet
     else
@@ -262,19 +262,19 @@ elif [[ "$CMAKE_GENERATOR" == "Visual Studio 17 2022" ]]; then
 else
     cmake --build "$BUILD_DIR"
 fi
-success "ビルドが完了しました"
+success "Build complete"
 
-# ビルド結果の確認
+# Verify build output
 VST3_OUTPUT=""
 if [[ "$CMAKE_GENERATOR" == "Xcode" ]] || [[ "$CMAKE_GENERATOR" == "Visual Studio 17 2022" ]]; then
-    # マルチコンフィギュレーションジェネレータの場合、Configuration サブディレクトリを探す
+    # For multi-configuration generators, look in the Configuration subdirectory
     if [[ "$OSTYPE" == darwin* ]]; then
         VST3_OUTPUT=$(find "$BUILD_DIR/$BUILD_CONFIG" -name "*.vst3" -type d 2>/dev/null | head -n 1)
     else
         VST3_OUTPUT=$(find "$BUILD_DIR/$BUILD_CONFIG" -name "*.vst3" -type f 2>/dev/null | head -n 1)
     fi
 else
-    # シングルコンフィギュレーションジェネレータの場合
+    # For single-configuration generators
     if [[ "$OSTYPE" == darwin* ]]; then
         VST3_OUTPUT=$(find "$BUILD_DIR" -name "*.vst3" -type d | head -n 1)
     else
@@ -284,11 +284,11 @@ fi
 
 if [[ "$BUILD_VST3" != "OFF" ]]; then
     if [ -n "$VST3_OUTPUT" ]; then
-        # フルパスを取得
+        # Resolve full path
         VST3_FULLPATH="$(cd "$(dirname "$VST3_OUTPUT")" && pwd)/$(basename "$VST3_OUTPUT")"
-        success "VST3 プラグインが生成されました: $VST3_FULLPATH"
+        success "VST3 plugin generated: $VST3_FULLPATH"
     else
-        error "VST3 プラグインが見つかりません"
+        error "VST3 plugin not found"
     fi
 fi
 
@@ -310,8 +310,8 @@ if [ -n "$STANDALONE_PLUGIN_ID" ]; then
 
     if [ -n "$STANDALONE_OUTPUT" ]; then
         STANDALONE_FULLPATH="$(cd "$(dirname "$STANDALONE_OUTPUT")" && pwd)/$(basename "$STANDALONE_OUTPUT")"
-        success "Standalone アプリが生成されました: $STANDALONE_FULLPATH"
+        success "Standalone app generated: $STANDALONE_FULLPATH"
     else
-        error "Standalone アプリが見つかりません"
+        error "Standalone app not found"
     fi
 fi

--- a/clap_wrapper_builder/install_wrapper_plugin.sh
+++ b/clap_wrapper_builder/install_wrapper_plugin.sh
@@ -1,28 +1,28 @@
 #!/bin/bash
-# install_wrapper_plugin.sh - 生成されたVST3/AUプラグインをインストール
+# install_wrapper_plugin.sh - Install generated VST3/AU plugins
 #
-# 使い方:
-#   ./install_wrapper_plugin.sh <CLAPファイル名> <出力プラグイン名> [Debug|Release]
+# Usage:
+#   ./install_wrapper_plugin.sh <CLAP file> <output plugin name> [Debug|Release]
 #
-# 引数:
-#   CLAPファイル名 - CLAPプラグインのファイル名 (例: "example_plugin_nih.clap")
-#   出力プラグイン名 - VST3/AUで使用する表示名 (例: "Example Plugin NIH")
-#   Debug|Release - ビルド構成（省略時は Debug）
+# Arguments:
+#   CLAP file    - CLAP plugin filename (e.g. "example_plugin_nih.clap")
+#   Output name  - Display name used in VST3/AU (e.g. "Example Plugin NIH")
+#   Debug|Release - Build configuration (default: Debug)
 #
-# 注意:
-#   - build_wrapper_plugin.sh を先に実行してVST3/AUを生成する必要があります
+# Note:
+#   - Run build_wrapper_plugin.sh first to generate the VST3/AU plugins
 
 set -Eeuo pipefail
 
-# カラー出力用の定数
+# Constants for colored output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
-# エラーメッセージ表示関数
+# Error message function
 error() {
-    echo -e "${RED}エラー: $1${NC}" >&2
+    echo -e "${RED}Error: $1${NC}" >&2
     exit 1
 }
 
@@ -30,37 +30,37 @@ on_error() {
     local exit_code="$1"
     local line_no="$2"
     local command="$3"
-    echo -e "${RED}エラー: ${line_no} 行目のコマンドが失敗しました (exit=${exit_code}): ${command}${NC}" >&2
+    echo -e "${RED}Error: command failed at line ${line_no} (exit=${exit_code}): ${command}${NC}" >&2
     exit "$exit_code"
 }
 
 trap 'on_error $? $LINENO "$BASH_COMMAND"' ERR
 
-# 成功メッセージ表示関数
+# Success message function
 success() {
     echo -e "${GREEN}$1${NC}"
 }
 
-# 警告メッセージ表示関数
+# Warning message function
 warning() {
-    echo -e "${YELLOW}警告: $1${NC}"
+    echo -e "${YELLOW}Warning: $1${NC}"
 }
 
-# 現在のディレクトリを保存
+# Save the directory of this script
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-# 使用方法を表示する関数
+# Usage display function
 usage() {
-    echo "使用方法: $0 <CLAPファイル名> <出力プラグイン名> [Debug|Release]"
-    echo "  引数を指定しない場合、ビルド構成のデフォルトは Debug です"
+    echo "Usage: $0 <CLAP file> <output plugin name> [Debug|Release]"
+    echo "  If omitted, build configuration defaults to Debug"
     echo ""
-    echo "例:"
+    echo "Examples:"
     echo "  $0 example_plugin_nih.clap \"Example Plugin NIH\" Release"
     echo "  $0 \"XDevice Editor.clap\" \"XDevice Editor\" Debug"
     exit 1
 }
 
-# 引数の処理
+# Argument parsing
 if [ $# -lt 2 ]; then
     usage
 fi
@@ -81,65 +81,65 @@ if [ $# -ge 3 ]; then
             usage
             ;;
         *)
-            error "無効なビルド構成: $3"
+            error "Invalid build configuration: $3"
             ;;
     esac
 fi
 
-echo "CLAPファイル: $CLAP_FILE"
-echo "出力プラグイン名: $OUTPUT_NAME"
-echo "ビルド構成: $BUILD_CONFIG"
+echo "CLAP file: $CLAP_FILE"
+echo "Output plugin name: $OUTPUT_NAME"
+echo "Build configuration: $BUILD_CONFIG"
 
-# CLAPファイル名から拡張子を除いた名前を取得し、スペースをアンダースコアに置換
-# パス部分を除去してファイル名のみを取得
+# Strip extension from CLAP filename and replace spaces with underscores
+# Remove path component, keep filename only
 CLAP_FILE_BASENAME=$(basename "$CLAP_FILE")
 CLAP_BASE_NAME="${CLAP_FILE_BASENAME%.clap}"
 CLAP_BASE_NAME="${CLAP_BASE_NAME// /_}"
 
-# OS判定とインストール先ディレクトリの設定
+# OS detection and installation directory setup
 case "$OSTYPE" in
     darwin*)
         # macOS
         OS="macos"
         VST3_INSTALL_DIR="$HOME/Library/Audio/Plug-Ins/VST3"
         AU_INSTALL_DIR="$HOME/Library/Audio/Plug-Ins/Components"
-        success "macOS を検出"
+        success "Detected macOS"
         ;;
     linux*)
         # Linux
         OS="linux"
         VST3_INSTALL_DIR="$HOME/.vst3"
-        success "Linux を検出"
+        success "Detected Linux"
         ;;
     msys*|cygwin*|mingw*)
         # Windows
         OS="windows"
-        # Windows環境変数を使用
+        # Use Windows environment variables
         if [ -n "$COMMONPROGRAMFILES" ]; then
             VST3_INSTALL_DIR="$COMMONPROGRAMFILES/VST3"
         else
             VST3_INSTALL_DIR="$LOCALAPPDATA/Programs/Common/VST3"
         fi
-        success "Windows を検出"
+        success "Detected Windows"
         ;;
     *)
-        error "未対応のOS: $OSTYPE"
+        error "Unsupported OS: $OSTYPE"
         ;;
 esac
 
-# ビルドディレクトリの確認
+# Check build directory
 BUILD_DIR="$SCRIPT_DIR/build_$CLAP_BASE_NAME"
 if [ ! -d "$BUILD_DIR" ]; then
-    error "ビルドディレクトリが見つかりません。先に build_wrapper_plugin.sh を実行してください。"
+    error "Build directory not found. Run build_wrapper_plugin.sh first."
 fi
 
-# VST3プラグインの検索
+# Search for VST3 plugin
 VST3_OUTPUT=""
 VST3_FILENAME="$OUTPUT_NAME.vst3"
 AU_OUTPUT=""
 AU_FILENAME="$OUTPUT_NAME.component"
 
-# マルチコンフィギュレーションジェネレータの場合
+# For multi-configuration generators
 if [ -d "$BUILD_DIR/$BUILD_CONFIG" ]; then
     if [[ "$OS" == "macos" ]]; then
         VST3_OUTPUT=$(find "$BUILD_DIR/$BUILD_CONFIG" -name "$VST3_FILENAME" -type d | head -n 1 || true)
@@ -148,7 +148,7 @@ if [ -d "$BUILD_DIR/$BUILD_CONFIG" ]; then
     fi
 fi
 
-# シングルコンフィギュレーションジェネレータの場合
+# For single-configuration generators
 if [ -z "$VST3_OUTPUT" ]; then
     if [[ "$OS" == "macos" ]]; then
         VST3_OUTPUT=$(find "$BUILD_DIR" -name "$VST3_FILENAME" -type d | head -n 1 || true)
@@ -158,11 +158,11 @@ if [ -z "$VST3_OUTPUT" ]; then
 fi
 
 if [ -z "$VST3_OUTPUT" ]; then
-    error "VST3プラグインが見つかりません。先に build_wrapper_plugin.sh を実行してください。"
+    error "VST3 plugin not found. Run build_wrapper_plugin.sh first."
 fi
 
 VST3_FULLPATH="$(cd "$(dirname "$VST3_OUTPUT")" && pwd)/$(basename "$VST3_OUTPUT")"
-success "VST3プラグインを検出: $VST3_FULLPATH"
+success "VST3 plugin found: $VST3_FULLPATH"
 
 if [[ "$OS" == "macos" ]]; then
     if [ -d "$BUILD_DIR/$BUILD_CONFIG" ]; then
@@ -175,13 +175,13 @@ if [[ "$OS" == "macos" ]]; then
 
     if [ -n "$AU_OUTPUT" ]; then
         AU_FULLPATH="$(cd "$(dirname "$AU_OUTPUT")" && pwd)/$(basename "$AU_OUTPUT")"
-        success "AUプラグインを検出: $AU_FULLPATH"
+        success "AU plugin found: $AU_FULLPATH"
     else
-        warning "AUプラグインが見つかりませんでした。VST3 のみインストールします。"
+        warning "AU plugin not found. Installing VST3 only."
     fi
 fi
 
-# CLAPプラグインの確認（警告のみ）
+# Check CLAP plugin installation (warning only)
 CLAP_INSTALLED=false
 
 if [[ "$OS" == "macos" ]]; then
@@ -200,70 +200,70 @@ elif [[ "$OS" == "windows" ]]; then
     fi
 fi
 
-# CLAP未インストール警告は最後にまとめて表示
+# Defer CLAP-not-installed warning to the end
 
-# VST3インストールディレクトリの作成
-echo "VST3インストールディレクトリを準備しています..."
+# Create VST3 installation directory
+echo "Preparing VST3 installation directory..."
 if [[ "$OS" == "windows" ]]; then
-    # Windowsの場合、管理者権限が必要な可能性がある
+    # On Windows, admin privileges may be required
     mkdir -p "$VST3_INSTALL_DIR" 2>/dev/null || {
-        warning "VST3インストールディレクトリの作成に失敗しました。"
-        warning "管理者権限でスクリプトを実行するか、手動でインストールしてください。"
+        warning "Failed to create VST3 installation directory."
+        warning "Run the script with administrator privileges or install manually."
         echo ""
-        echo "手動インストール方法:"
+        echo "Manual installation:"
         echo "  cp -r \"$VST3_FULLPATH\" \"$VST3_INSTALL_DIR/\""
         exit 1
     }
 else
     mkdir -p "$VST3_INSTALL_DIR" || {
-        error "VST3インストールディレクトリを作成できませんでした: $VST3_INSTALL_DIR"
+        error "Failed to create VST3 installation directory: $VST3_INSTALL_DIR"
     }
 fi
 
-# VST3プラグインのインストール
-echo "VST3プラグインをインストールしています..."
+# Install VST3 plugin
+echo "Installing VST3 plugin..."
 if [[ "$OS" == "macos" ]]; then
-    # macOSではバンドル全体をコピー
+    # On macOS, copy the entire bundle
     rm -rf "$VST3_INSTALL_DIR/$VST3_FILENAME"
     cp -r "$VST3_FULLPATH" "$VST3_INSTALL_DIR/" || {
-        error "VST3プラグインのコピーに失敗しました"
+        error "Failed to copy VST3 plugin"
     }
 else
-    # その他のOSではファイルをコピー
+    # On other OSes, copy the file
     cp "$VST3_FULLPATH" "$VST3_INSTALL_DIR/" || {
-        error "VST3プラグインのコピーに失敗しました"
+        error "Failed to copy VST3 plugin"
     }
 fi
 
-success "インストールが完了しました！"
+success "Installation complete!"
 echo ""
-echo "VST3プラグインは以下の場所にインストールされました:"
+echo "VST3 plugin installed at:"
 echo "  $VST3_INSTALL_DIR/$VST3_FILENAME"
 
 if [[ "$OS" == "macos" && -n "${AU_OUTPUT:-}" ]]; then
-    echo "AUインストールディレクトリを準備しています..."
+    echo "Preparing AU installation directory..."
     mkdir -p "$AU_INSTALL_DIR" || {
-        error "AUインストールディレクトリを作成できませんでした: $AU_INSTALL_DIR"
+        error "Failed to create AU installation directory: $AU_INSTALL_DIR"
     }
 
-    echo "AUプラグインをインストールしています..."
+    echo "Installing AU plugin..."
     rm -rf "$AU_INSTALL_DIR/$AU_FILENAME"
     cp -r "$AU_FULLPATH" "$AU_INSTALL_DIR/" || {
-        error "AUプラグインのコピーに失敗しました"
+        error "Failed to copy AU plugin"
     }
 
-    echo "AUプラグインは以下の場所にインストールされました:"
+    echo "AU plugin installed at:"
     echo "  $AU_INSTALL_DIR/$AU_FILENAME"
 fi
 echo ""
 
 if [ "$CLAP_INSTALLED" = false ]; then
-    warning "注意: VST3を使用するには、$CLAP_FILE がインストールされている必要があります。"
+    warning "Note: $CLAP_FILE must be installed for VST3 to work."
 fi
 
-# DAWのスキャンに関する注意
+# Note about DAW plugin scanning
 echo ""
-echo "次のステップ:"
-echo "1. DAWを起動（または再起動）してください"
-echo "2. DAWのプラグインスキャンを実行してください"
-echo "3. $OUTPUT_NAME がVST3プラグインとして表示されるはずです"
+echo "Next steps:"
+echo "1. Launch (or restart) your DAW"
+echo "2. Run your DAW's plugin scan"
+echo "3. $OUTPUT_NAME should appear as a VST3 plugin"

--- a/script/build.sh
+++ b/script/build.sh
@@ -1,32 +1,32 @@
 #!/bin/bash
-# build.sh - gain_plugin の CLAP ビルド
+# build.sh - CLAP build for gain_plugin
 #
-# このスクリプトは以下の 3 ステップを実行します:
-#   1. GUI フロントエンド（src-gui）の npm ビルド
-#   2. Rust プラグイン（src-plugin）の cargo ビルド
-#   3. ビルド成果物を .clap バンドル形式にパッケージング
+# This script performs the following 3 steps:
+#   1. npm build of the GUI frontend (src-gui)
+#   2. cargo build of the Rust plugin (src-plugin)
+#   3. Package the build artifacts into a .clap bundle format
 #
-# .clap バンドルとは:
-#   CLAP ホスト（DAW）がプラグインとして認識できる形式のファイル/ディレクトリ。
-#   macOS ではバンドル（.app に似たディレクトリ構造）、
-#   Windows/Linux では単一の .dll/.so ファイルになる。
+# What is a .clap bundle:
+#   A file/directory in a format that CLAP hosts (DAWs) can recognize as a plugin.
+#   On macOS it is a bundle (directory structure similar to .app),
+#   on Windows/Linux it is a single .dll/.so file.
 #
-# 使い方:
+# Usage:
 #   ./script/build.sh [Debug|Release]
 #
-# 引数:
-#   Debug|Release - ビルド構成（省略時は Debug）
+# Arguments:
+#   Debug|Release - Build configuration (default: Debug)
 #
-# 出力:
+# Output:
 #   target/bundled/WXP Example Gain.clap
 
-set -e  # エラー発生時にスクリプトを停止
-set -u  # 未定義変数の参照をエラーにする
+set -e  # Stop script on error
+set -u  # Treat unset variables as an error
 
 # ---------------------------------------------------------------------------
-# OS 検出
+# OS detection
 # ---------------------------------------------------------------------------
-# バンドル形式が OS ごとに異なるため、最初に判定しておく。
+# Bundle format differs per OS, so determine it first.
 case "$(uname -s)" in
     Darwin*)
         OS="macos"
@@ -38,15 +38,15 @@ case "$(uname -s)" in
         OS="windows"
         ;;
     *)
-        echo "エラー: 未対応のOS $(uname -s)"
+        echo "Error: Unsupported OS $(uname -s)"
         exit 1
         ;;
 esac
 
-echo "検出されたOS: $OS"
+echo "Detected OS: $OS"
 
 # ---------------------------------------------------------------------------
-# ビルド構成の決定
+# Build configuration
 # ---------------------------------------------------------------------------
 BUILD_CONFIG="Debug"
 CARGO_BUILD_FLAG=""
@@ -60,13 +60,13 @@ if [ $# -eq 1 ]; then
             CARGO_BUILD_FLAG="--release"
             ;;
         *)
-            echo "エラー: 無効なビルド構成: $1"
+            echo "Error: Invalid build configuration: $1"
             exit 1
             ;;
     esac
 fi
 
-echo "ビルド構成: $BUILD_CONFIG"
+echo "Build configuration: $BUILD_CONFIG"
 
 if [ "$BUILD_CONFIG" = "Debug" ]; then
     PROFILE_DIR="debug"
@@ -75,9 +75,9 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# パスの解決
+# Path resolution
 # ---------------------------------------------------------------------------
-# BASH_SOURCE[0] からスクリプト自身の絶対パスを求め、そこから相対的に各ディレクトリを特定する。
+# Derive the absolute path of this script from BASH_SOURCE[0], then locate each directory relative to it.
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 PLUGIN_ROOT="$( cd "$SCRIPT_DIR/.." && pwd )"
 GUI_DIR="$PLUGIN_ROOT/src-gui"
@@ -85,11 +85,11 @@ TARGET_DIR="${CARGO_TARGET_DIR:-$PLUGIN_ROOT/target}"
 BUILD_DIR="$TARGET_DIR/$PROFILE_DIR"
 
 # ---------------------------------------------------------------------------
-# ステップ 1: GUI フロントエンドのビルド
+# Step 1: GUI frontend build
 # ---------------------------------------------------------------------------
-# Vite で TypeScript/CSS をバンドルし、src-gui/dist/ に出力する。
-# リリースビルドでは build.rs がこの dist/ を ZIP 化してバイナリに埋め込む。
-echo "GUI をビルドしています..."
+# Bundle TypeScript/CSS with Vite and output to src-gui/dist/.
+# For release builds, build.rs ZIP-compresses this dist/ and embeds it in the binary.
+echo "Building GUI..."
 (
     cd "$GUI_DIR"
     npm install
@@ -97,13 +97,13 @@ echo "GUI をビルドしています..."
 )
 
 # ---------------------------------------------------------------------------
-# ステップ 2: Rust プラグインのビルド
+# Step 2: Rust plugin build
 # ---------------------------------------------------------------------------
-# cargo が生成する共有ライブラリ:
+# Shared libraries produced by cargo:
 #   macOS:   libwxp_example_gain_plugin.dylib
 #   Windows: wxp_example_gain_plugin.dll
 #   Linux:   libwxp_example_gain_plugin.so
-echo "プラグインをビルドしています..."
+echo "Building plugin..."
 (
     if [ "$OS" = "macos" ]; then
         MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-11.0}" \
@@ -115,26 +115,26 @@ echo "プラグインをビルドしています..."
 )
 
 # ---------------------------------------------------------------------------
-# ステップ 3: .clap バンドルの作成
+# Step 3: Create .clap bundle
 # ---------------------------------------------------------------------------
-# CLAP プラグインの配布形式は OS ごとに異なる:
-#   macOS:   macOS バンドル（ディレクトリ構造 + Info.plist）
-#   Windows: .dll を .clap にリネーム
-#   Linux:   .so を .clap にリネーム
+# The distribution format for CLAP plugins differs per OS:
+#   macOS:   macOS bundle (directory structure + Info.plist)
+#   Windows: rename .dll to .clap
+#   Linux:   rename .so to .clap
 PLUGIN_NAME="WXP Example Gain.clap"
 BUNDLE_DIR="$TARGET_DIR/bundled/$PLUGIN_NAME"
 
-echo "バンドル構造を作成しています..."
+echo "Creating bundle structure..."
 rm -rf "$BUNDLE_DIR"
 
 case "$OS" in
     macos)
-        # macOS の .clap は .app と同様のバンドル構造を持つ。
-        # Contents/MacOS/ に実行可能バイナリ、Contents/Info.plist にメタデータを配置する。
+        # A .clap on macOS has the same bundle structure as .app.
+        # Place the executable binary under Contents/MacOS/ and metadata in Contents/Info.plist.
         mkdir -p "$BUNDLE_DIR/Contents/MacOS"
 
-        # Info.plist: macOS がバンドルを識別するためのメタデータファイル。
-        # CFBundleIdentifier はプラグインの PLUGIN_ID と一致させる。
+        # Info.plist: metadata file that macOS uses to identify the bundle.
+        # CFBundleIdentifier must match the plugin's PLUGIN_ID.
         cat > "$BUNDLE_DIR/Contents/Info.plist" << EOF
 <?xml version="1.0" encoding="UTF-8"?>
 
@@ -167,37 +167,37 @@ case "$OS" in
 </plist>
 EOF
 
-        # PkgInfo: macOS の古い慣習で必要なファイル。
-        # "BNDL" はバンドルタイプ、"????" はクリエータコード（汎用）。
+        # PkgInfo: required by an old macOS convention.
+        # "BNDL" is the bundle type, "????" is the creator code (generic).
         echo -n "BNDL????" > "$BUNDLE_DIR/Contents/PkgInfo"
 
-        # .dylib を拡張子なしのバイナリ名でコピーする。
-        # CLAP ホストは CFBundleExecutable に指定した名前でバイナリを探す。
+        # Copy the .dylib under the binary name without extension.
+        # The CLAP host looks for the binary by the name specified in CFBundleExecutable.
         cp "$BUILD_DIR/libwxp_example_gain_plugin.dylib" \
             "$BUNDLE_DIR/Contents/MacOS/WXP Example Gain"
 
-        # install_name_tool: dylib の LC_ID_DYLIB（ライブラリの自己識別パス）を書き換える。
-        # "@loader_path/..." にすることで、バンドル内の相対パスで自己参照できるようになり、
-        # インストール先のパスに依存しないポータブルなバンドルになる。
+        # install_name_tool: rewrite the LC_ID_DYLIB (the dylib's self-identification path).
+        # Using "@loader_path/..." allows self-referencing via a relative path within the bundle,
+        # making it a portable bundle that does not depend on the installation path.
         install_name_tool -id "@loader_path/WXP Example Gain" \
             "$BUNDLE_DIR/Contents/MacOS/WXP Example Gain"
         ;;
     windows)
-        # Windows では .dll をそのまま .clap として配置するだけでよい。
+        # On Windows, simply place the .dll as-is with the .clap extension.
         mkdir -p "$TARGET_DIR/bundled"
         cp "$BUILD_DIR/wxp_example_gain_plugin.dll" "$BUNDLE_DIR"
         ;;
     linux)
-        # Linux も同様に .so を .clap として配置する。
+        # On Linux, similarly place the .so with the .clap extension.
         mkdir -p "$TARGET_DIR/bundled"
         cp "$BUILD_DIR/libwxp_example_gain_plugin.so" "$BUNDLE_DIR"
         ;;
 esac
 
 if [ ! -e "$BUNDLE_DIR" ]; then
-    echo "エラー: ビルドは成功しましたが、バンドルされたプラグインが見つかりません"
+    echo "Error: Build succeeded but bundled plugin not found"
     exit 1
 fi
 
-echo "ビルドが完了しました！"
-echo "バンドルは以下の場所に作成されました: target/bundled/$PLUGIN_NAME"
+echo "Build complete!"
+echo "Bundle created at: target/bundled/$PLUGIN_NAME"

--- a/script/build_and_install.sh
+++ b/script/build_and_install.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
-# build_and_install.sh - gain_plugin のビルド＆インストール（一括）
+# build_and_install.sh - Build and install gain_plugin (all-in-one)
 #
-# CLAP をビルドしてインストールし、VST3 / AU と standalone も処理する。
+# Builds and installs the CLAP, and also handles VST3 / AU and standalone.
 #
-# 使い方:
+# Usage:
 #   ./script/build_and_install.sh [Debug|Release]
 #
-# 引数:
-#   Debug|Release - ビルド構成（省略時は Debug）
+# Arguments:
+#   Debug|Release - Build configuration (default: Debug)
 
-set -e  # エラー発生時にスクリプトを停止
+set -e  # Stop script on error
 set -u
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -18,12 +18,12 @@ TARGET_DIR="${CARGO_TARGET_DIR:-$PLUGIN_ROOT/target}"
 DEFAULT_WRAPPER_DIR="$( cd "$PLUGIN_ROOT/clap_wrapper_builder" 2>/dev/null && pwd || true )"
 WRAPPER_DIR="${CLAP_WRAPPER_DIR:-$DEFAULT_WRAPPER_DIR}"
 
-# ターミナル出力の色付け用エスケープコード
+# Escape codes for terminal color output
 GREEN='\033[0;32m'
 BLUE='\033[0;34m'
-NC='\033[0m'  # No Color（色のリセット）
+NC='\033[0m'  # No Color (reset)
 
-# 第 1 引数を BUILD_CONFIG に設定。省略時は "Debug"。
+# Set BUILD_CONFIG from the first argument, defaulting to "Debug".
 BUILD_CONFIG="${1:-Debug}"
 
 case "$(uname -s)" in
@@ -37,36 +37,36 @@ case "$(uname -s)" in
         OS="windows"
         ;;
     *)
-        echo "エラー: 未対応のOS $(uname -s)"
+        echo "Error: Unsupported OS $(uname -s)"
         exit 1
         ;;
 esac
 
-echo -e "${BLUE}gain_plugin (CLAP + wrapper) をインストール中...${NC}"
-echo "ビルド構成: $BUILD_CONFIG"
-echo "Wrapper ビルド: ${CLAP_ONLY:+スキップする}(CLAP_ONLY=${CLAP_ONLY:-0})"
+echo -e "${BLUE}Installing gain_plugin (CLAP + wrapper)...${NC}"
+echo "Build configuration: $BUILD_CONFIG"
+echo "Wrapper build: ${CLAP_ONLY:+skip}(CLAP_ONLY=${CLAP_ONLY:-0})"
 echo ""
 
-echo "1. CLAPプラグインをビルドしています..."
+echo "1. Building CLAP plugin..."
 "$SCRIPT_DIR/build.sh" "$BUILD_CONFIG"
 
 echo ""
-echo "2. CLAPプラグインをインストールしています..."
+echo "2. Installing CLAP plugin..."
 "$SCRIPT_DIR/install.sh"
 
 if [[ "$OS" != "linux" && "${CLAP_ONLY:-0}" != "1" ]]; then
     if [[ -z "$WRAPPER_DIR" || ! -d "$WRAPPER_DIR" ]]; then
-        echo "エラー: clap_wrapper_builder が見つかりません"
-        echo "CLAP_WRAPPER_DIR 環境変数で clap_wrapper_builder のパスを指定してください"
+        echo "Error: clap_wrapper_builder not found"
+        echo "Set the CLAP_WRAPPER_DIR environment variable to the path of clap_wrapper_builder"
         exit 1
     fi
 
     echo ""
-    echo "3. VST3 / AU ラッパーをビルドしています..."
+    echo "3. Building VST3 / AU wrapper..."
     SKIP_CLAP_BUILD=1 "$SCRIPT_DIR/build_wrapper.sh" "$BUILD_CONFIG"
 
     echo ""
-    echo "4. VST3 / AU ラッパーをインストールしています..."
+    echo "4. Installing VST3 / AU wrapper..."
     (
         cd "$WRAPPER_DIR"
         ./install_wrapper_plugin.sh "$TARGET_DIR/bundled/WXP Example Gain.clap" "WXP Example Gain" "$BUILD_CONFIG"
@@ -74,31 +74,31 @@ if [[ "$OS" != "linux" && "${CLAP_ONLY:-0}" != "1" ]]; then
 
     if [[ "${BUILD_STANDALONE:-1}" == "1" ]]; then
         echo ""
-        echo "5. standalone アプリをビルドしています..."
+        echo "5. Building standalone app..."
         SKIP_CLAP_BUILD=1 "$SCRIPT_DIR/build_standalone.sh" "$BUILD_CONFIG"
     else
         echo ""
-        echo "5. BUILD_STANDALONE=0 のため standalone アプリのビルドをスキップします"
+        echo "5. BUILD_STANDALONE=0: skipping standalone app build"
     fi
 else
     echo ""
     if [[ "${CLAP_ONLY:-0}" == "1" ]]; then
-        echo "3. CLAP_ONLY=1 のため VST3 / AU / standalone の処理をスキップします"
+        echo "3. CLAP_ONLY=1: skipping VST3 / AU / standalone"
     else
-        echo "3. Linux では VST3 / AU / standalone の処理をスキップします"
+        echo "3. Skipping VST3 / AU / standalone on Linux"
     fi
 fi
 
 echo ""
-echo -e "${GREEN}gain_plugin のインストールが完了しました！${NC}"
-echo "インストールされたプラグイン:"
-echo "  - WXP Example Gain.clap (CLAP形式)"
+echo -e "${GREEN}gain_plugin installation complete!${NC}"
+echo "Installed plugins:"
+echo "  - WXP Example Gain.clap (CLAP)"
 if [[ "$OS" != "linux" && "${CLAP_ONLY:-0}" != "1" ]]; then
-    echo "  - WXP Example Gain.vst3 (VST3形式)"
+    echo "  - WXP Example Gain.vst3 (VST3)"
     if [[ "$OS" == "macos" ]]; then
-        echo "  - WXP Example Gain.component (AU形式)"
+        echo "  - WXP Example Gain.component (AU)"
     fi
     if [[ "${BUILD_STANDALONE:-1}" == "1" ]]; then
-        echo "  - WXP Example Gain Standalone (ビルドのみ)"
+        echo "  - WXP Example Gain Standalone (build only)"
     fi
 fi

--- a/script/build_standalone.sh
+++ b/script/build_standalone.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
-# build_standalone.sh - gain_plugin の standalone アプリをビルド
+# build_standalone.sh - Build standalone app for gain_plugin
 #
-# 使い方:
+# Usage:
 #   ./script/build_standalone.sh [Debug|Release]
 #
-# 環境変数:
-#   SKIP_CLAP_BUILD=1 を指定すると、事前の CLAP ビルドをスキップする。
-#   WXP_EXAMPLE_GAIN_STANDALONE_PLUGIN_ID で standalone 用 Plugin ID を上書きできる。
+# Environment variables:
+#   Set SKIP_CLAP_BUILD=1 to skip the preceding CLAP build.
+#   Override the standalone Plugin ID with WXP_EXAMPLE_GAIN_STANDALONE_PLUGIN_ID.
 
 set -e
 set -u
@@ -22,7 +22,7 @@ case "$(uname -s)" in
         OS="windows"
         ;;
     *)
-        echo "エラー: 未対応のOS $(uname -s)"
+        echo "Error: Unsupported OS $(uname -s)"
         exit 1
         ;;
 esac
@@ -39,7 +39,7 @@ case "$BUILD_CONFIG" in
         PROFILE_DIR="release"
         ;;
     *)
-        echo "エラー: 無効なビルド構成: $BUILD_CONFIG"
+        echo "Error: Invalid build configuration: $BUILD_CONFIG"
         exit 1
         ;;
 esac
@@ -54,18 +54,18 @@ STANDALONE_PLUGIN_ID="${WXP_EXAMPLE_GAIN_STANDALONE_PLUGIN_ID:-com.novo-notes.wx
 STANDALONE_OUTPUT_NAME="${WXP_EXAMPLE_GAIN_STANDALONE_OUTPUT_NAME:-WXP Example Gain Standalone}"
 
 if [[ -z "$WRAPPER_DIR" || ! -d "$WRAPPER_DIR" ]]; then
-    echo "エラー: clap_wrapper_builder が見つかりません"
-    echo "CLAP_WRAPPER_DIR 環境変数で clap_wrapper_builder のパスを指定してください"
+    echo "Error: clap_wrapper_builder not found"
+    echo "Set the CLAP_WRAPPER_DIR environment variable to the path of clap_wrapper_builder"
     exit 1
 fi
 
 if [[ "${SKIP_CLAP_BUILD:-0}" != "1" ]]; then
-    echo "CLAPプラグインを先にビルドします..."
+    echo "Building CLAP plugin first..."
     "$SCRIPT_DIR/build.sh" "$BUILD_CONFIG"
 fi
 
 if [[ "$OS" == "linux" ]]; then
-    echo "Linux では standalone ラッパーのビルドをスキップします"
+    echo "Skipping standalone wrapper build on Linux"
     exit 0
 fi
 
@@ -75,7 +75,7 @@ else
     LIB_FILE_NAME="libwxp_example_gain_plugin.a"
 fi
 
-echo "standalone ラッパーをビルドしています..."
+echo "Building standalone wrapper..."
 (
     cd "$WRAPPER_DIR"
     CLAP_WRAPPER_BUILDER_BUILD_VST3=OFF \
@@ -97,23 +97,23 @@ if [[ "$OS" == "macos" ]]; then
         STANDALONE_SOURCE=$(find "$WRAPPER_BUILD_DIR" -path "*/${STANDALONE_OUTPUT_NAME}.app" -type d 2>/dev/null | head -n 1 || true)
     fi
     if [[ -z "$STANDALONE_SOURCE" ]]; then
-        echo "エラー: standalone アプリが見つかりません"
+        echo "Error: Standalone app not found"
         exit 1
     fi
 
     rm -rf "$STANDALONE_TARGET_DIR/${STANDALONE_OUTPUT_NAME}.app"
     ln -s "$STANDALONE_SOURCE" "$STANDALONE_TARGET_DIR/${STANDALONE_OUTPUT_NAME}.app"
-    echo "standalone アプリへのリンクを作成しました: $STANDALONE_TARGET_DIR/${STANDALONE_OUTPUT_NAME}.app"
+    echo "Created symlink to standalone app: $STANDALONE_TARGET_DIR/${STANDALONE_OUTPUT_NAME}.app"
 elif [[ "$OS" == "windows" ]]; then
     STANDALONE_SOURCE=$(find "$WRAPPER_BUILD_DIR" -path "*/$BUILD_CONFIG/${STANDALONE_OUTPUT_NAME}.exe" -type f 2>/dev/null | head -n 1 || true)
     if [[ -z "$STANDALONE_SOURCE" ]]; then
         STANDALONE_SOURCE=$(find "$WRAPPER_BUILD_DIR" -path "*/${STANDALONE_OUTPUT_NAME}.exe" -type f 2>/dev/null | head -n 1 || true)
     fi
     if [[ -z "$STANDALONE_SOURCE" ]]; then
-        echo "エラー: standalone アプリが見つかりません"
+        echo "Error: Standalone app not found"
         exit 1
     fi
 
     cp "$STANDALONE_SOURCE" "$STANDALONE_TARGET_DIR/${STANDALONE_OUTPUT_NAME}.exe"
-    echo "standalone アプリをコピーしました: $STANDALONE_TARGET_DIR/${STANDALONE_OUTPUT_NAME}.exe"
+    echo "Copied standalone app: $STANDALONE_TARGET_DIR/${STANDALONE_OUTPUT_NAME}.exe"
 fi

--- a/script/build_wrapper.sh
+++ b/script/build_wrapper.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
-# build_wrapper.sh - gain_plugin の VST3 / AU ラッパーをビルド
+# build_wrapper.sh - Build VST3 / AU wrapper for gain_plugin
 #
-# 使い方:
+# Usage:
 #   ./script/build_wrapper.sh [Debug|Release]
 #
-# 環境変数:
-#   SKIP_CLAP_BUILD=1 を指定すると、事前の CLAP ビルドをスキップする。
+# Environment variables:
+#   Set SKIP_CLAP_BUILD=1 to skip the preceding CLAP build.
 
 set -e
 set -u
@@ -21,7 +21,7 @@ case "$(uname -s)" in
         OS="windows"
         ;;
     *)
-        echo "エラー: 未対応のOS $(uname -s)"
+        echo "Error: Unsupported OS $(uname -s)"
         exit 1
         ;;
 esac
@@ -36,7 +36,7 @@ case "$BUILD_CONFIG" in
         BUILD_CONFIG="Release"
         ;;
     *)
-        echo "エラー: 無効なビルド構成: $BUILD_CONFIG"
+        echo "Error: Invalid build configuration: $BUILD_CONFIG"
         exit 1
         ;;
 esac
@@ -48,25 +48,25 @@ DEFAULT_WRAPPER_DIR="$( cd "$PLUGIN_ROOT/clap_wrapper_builder" 2>/dev/null && pw
 WRAPPER_DIR="${CLAP_WRAPPER_DIR:-$DEFAULT_WRAPPER_DIR}"
 
 if [[ -z "$WRAPPER_DIR" || ! -d "$WRAPPER_DIR" ]]; then
-    echo "エラー: clap_wrapper_builder が見つかりません"
-    echo "CLAP_WRAPPER_DIR 環境変数で clap_wrapper_builder のパスを指定してください"
+    echo "Error: clap_wrapper_builder not found"
+    echo "Set the CLAP_WRAPPER_DIR environment variable to the path of clap_wrapper_builder"
     exit 1
 fi
 
 if [[ "${SKIP_CLAP_BUILD:-0}" != "1" ]]; then
-    echo "CLAPプラグインを先にビルドします..."
+    echo "Building CLAP plugin first..."
     "$SCRIPT_DIR/build.sh" "$BUILD_CONFIG"
 fi
 
 if [[ "$OS" == "linux" ]]; then
-    echo "Linux では VST3 / AU ラッパーのビルドをスキップします"
+    echo "Skipping VST3 / AU wrapper build on Linux"
     exit 0
 fi
 
-echo "VST3 / AU ラッパーをビルドしています..."
+echo "Building VST3 / AU wrapper..."
 (
     cd "$WRAPPER_DIR"
     ./build_wrapper_plugin.sh "$TARGET_DIR/bundled/WXP Example Gain.clap" "WXP Example Gain" "$BUILD_CONFIG"
 )
 
-echo "VST3 / AU ラッパーのビルドが完了しました"
+echo "VST3 / AU wrapper build complete"

--- a/script/install.sh
+++ b/script/install.sh
@@ -1,24 +1,24 @@
 #!/bin/bash
-# install.sh - gain_plugin の CLAP インストール
+# install.sh - CLAP installation for gain_plugin
 #
-# build.sh で作成した .clap バンドルを、OS ごとの CLAP プラグインディレクトリにコピーする。
-# DAW はこのディレクトリを自動スキャンしてプラグインを検出する。
+# Copies the .clap bundle created by build.sh to the OS-specific CLAP plugin directory.
+# DAWs automatically scan this directory to detect plugins.
 #
-# インストール先:
+# Installation directories:
 #   macOS:   ~/Library/Audio/Plug-Ins/CLAP/
 #   Windows: %LOCALAPPDATA%/Programs/Common/CLAP/
 #   Linux:   ~/.clap/
 #
-# 使い方:
+# Usage:
 #   ./script/install.sh
 #
-# 注意: 実行前に build.sh でバンドルを作成しておく必要がある。
+# Note: The bundle must be created with build.sh before running this script.
 
-set -e  # エラー発生時にスクリプトを停止
-set -u  # 未定義変数の参照をエラーにする
+set -e  # Stop script on error
+set -u  # Treat unset variables as an error
 
 # ---------------------------------------------------------------------------
-# OS 検出
+# OS detection
 # ---------------------------------------------------------------------------
 case "$(uname -s)" in
     Darwin*)
@@ -31,15 +31,15 @@ case "$(uname -s)" in
         OS="windows"
         ;;
     *)
-        echo "エラー: 未対応のOS $(uname -s)"
+        echo "Error: Unsupported OS $(uname -s)"
         exit 1
         ;;
 esac
 
-echo "検出されたOS: $OS"
+echo "Detected OS: $OS"
 
 # ---------------------------------------------------------------------------
-# パスの解決
+# Path resolution
 # ---------------------------------------------------------------------------
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 PLUGIN_ROOT="$( cd "$SCRIPT_DIR/.." && pwd )"
@@ -49,54 +49,54 @@ BUNDLE_NAME="WXP Example Gain.clap"
 BUNDLE_PATH="$TARGET_DIR/bundled/${BUNDLE_NAME}"
 
 # ---------------------------------------------------------------------------
-# バンドルの存在確認
+# Bundle existence check
 # ---------------------------------------------------------------------------
-# インストール前に build.sh が正常完了しているかを確認する。
+# Verify that build.sh has completed successfully before installing.
 if [ ! -e "$BUNDLE_PATH" ]; then
-    echo "エラー: バンドルが見つかりません: $BUNDLE_PATH"
-    echo "先に build.sh を実行してください"
+    echo "Error: Bundle not found: $BUNDLE_PATH"
+    echo "Please run build.sh first"
     exit 1
 fi
 
 # ---------------------------------------------------------------------------
-# OS 別インストール
+# OS-specific installation
 # ---------------------------------------------------------------------------
 case "$OS" in
     macos)
-        # macOS の CLAP 標準ディレクトリ。
-        # Logic Pro、Ableton Live 等の多くの DAW がここをスキャンする。
-        echo "インストールディレクトリを準備しています..."
+        # Standard CLAP directory on macOS.
+        # Most DAWs including Logic Pro and Ableton Live scan this directory.
+        echo "Preparing installation directory..."
         mkdir -p ~/Library/Audio/Plug-Ins/CLAP || {
-            echo "エラー: CLAPプラグインディレクトリを作成できませんでした"
+            echo "Error: Failed to create CLAP plugin directory"
             exit 1
         }
 
-        # 既存バージョンを削除してから上書きする（macOS バンドルはディレクトリのため）。
+        # Remove existing version before overwriting (macOS bundles are directories).
         if [ -e ~/Library/Audio/Plug-Ins/CLAP/"${BUNDLE_NAME}" ]; then
             rm -rf ~/Library/Audio/Plug-Ins/CLAP/"${BUNDLE_NAME}"
         fi
 
-        echo "プラグインをインストールしています..."
-        # macOS バンドルはディレクトリ構造のため -r（再帰コピー）が必要。
+        echo "Installing plugin..."
+        # macOS bundles are directory structures, so -r (recursive copy) is required.
         cp -r "$BUNDLE_PATH" ~/Library/Audio/Plug-Ins/CLAP/ || {
-            echo "エラー: プラグインのコピーに失敗しました"
+            echo "Error: Failed to copy plugin"
             exit 1
         }
 
-        echo "インストールが完了しました！"
-        echo "プラグインは以下の場所にインストールされました: ~/Library/Audio/Plug-Ins/CLAP/${BUNDLE_NAME}"
+        echo "Installation complete!"
+        echo "Plugin installed at: ~/Library/Audio/Plug-Ins/CLAP/${BUNDLE_NAME}"
         ;;
     windows)
-        # Windows の CLAP 標準ディレクトリ（ユーザーローカル）。
-        # %PROGRAMFILES%/Common Files/CLAP/ もよく使われるが、管理者権限が不要なこちらを使う。
+        # Standard CLAP directory on Windows (user-local).
+        # %PROGRAMFILES%/Common Files/CLAP/ is also common, but this location does not require admin rights.
         CLAP_DIR="$LOCALAPPDATA/Programs/Common/CLAP"
 
-        echo "注意: Program Files へのインストールには管理者権限が必要な場合があります"
-        echo "インストールディレクトリを準備しています..."
+        echo "Note: Installing to Program Files may require administrator privileges"
+        echo "Preparing installation directory..."
 
         mkdir -p "$CLAP_DIR" || {
-            echo "エラー: CLAPプラグインディレクトリを作成できませんでした"
-            echo "手動で以下のコマンドを実行してください:"
+            echo "Error: Failed to create CLAP plugin directory"
+            echo "Please run the following command manually:"
             echo "cp \"$BUNDLE_PATH\" \"$CLAP_DIR/\""
             exit 1
         }
@@ -105,26 +105,26 @@ case "$OS" in
             rm -rf "$CLAP_DIR/${BUNDLE_NAME}"
         fi
 
-        echo "プラグインをインストールしています..."
+        echo "Installing plugin..."
         cp "$BUNDLE_PATH" "$CLAP_DIR/" || {
-            echo "エラー: プラグインのコピーに失敗しました"
-            echo "手動で以下のコマンドを実行してください:"
+            echo "Error: Failed to copy plugin"
+            echo "Please run the following command manually:"
             echo "cp \"$BUNDLE_PATH\" \"$CLAP_DIR/\""
             exit 1
         }
 
-        echo "インストールが完了しました！"
-        echo "プラグインは以下の場所にインストールされました: $CLAP_DIR/${BUNDLE_NAME}"
+        echo "Installation complete!"
+        echo "Plugin installed at: $CLAP_DIR/${BUNDLE_NAME}"
         ;;
     linux)
-        # Linux の CLAP 標準ディレクトリ（ユーザーローカル）。
-        # システム全体にインストールする場合は /usr/lib/clap/ を使うが、
-        # root 権限が不要な ~/.clap/ を使う。
+        # Standard CLAP directory on Linux (user-local).
+        # Use /usr/lib/clap/ for system-wide installation (requires root),
+        # but ~/.clap/ is used here to avoid requiring root privileges.
         CLAP_DIR="$HOME/.clap"
 
-        echo "インストールディレクトリを準備しています..."
+        echo "Preparing installation directory..."
         mkdir -p "$CLAP_DIR" || {
-            echo "エラー: CLAPプラグインディレクトリを作成できませんでした"
+            echo "Error: Failed to create CLAP plugin directory"
             exit 1
         }
 
@@ -132,13 +132,13 @@ case "$OS" in
             rm -rf "$CLAP_DIR/${BUNDLE_NAME}"
         fi
 
-        echo "プラグインをインストールしています..."
+        echo "Installing plugin..."
         cp -r "$BUNDLE_PATH" "$CLAP_DIR/" || {
-            echo "エラー: プラグインのコピーに失敗しました"
+            echo "Error: Failed to copy plugin"
             exit 1
         }
 
-        echo "インストールが完了しました！"
-        echo "プラグインは以下の場所にインストールされました: $CLAP_DIR/${BUNDLE_NAME}"
+        echo "Installation complete!"
+        echo "Plugin installed at: $CLAP_DIR/${BUNDLE_NAME}"
         ;;
 esac


### PR DESCRIPTION
## Summary

- Translated all Japanese comments, `echo` messages, and documentation in `script/` (5 files) and `clap_wrapper_builder/` (5 files) to English
- Intentionally Japanese files (`README_JA.md`, `docs/setup_JA.md`, `docs/architecture_JA.md`) and their cross-reference links are left unchanged
- Third-party SDK files (`clap-wrapper/`, `vst3sdk/`) are not touched

## Files changed

**`script/`**
- `build.sh`
- `build_and_install.sh`
- `build_standalone.sh`
- `build_wrapper.sh`
- `install.sh`

**`clap_wrapper_builder/`**
- `build_wrapper_plugin.sh`
- `build_wrapper_plugin_static.sh`
- `install_wrapper_plugin.sh`
- `CMakeLists.txt`
- `README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)