### PR TITLE
Remove clean-first from wrapper builds

### DIFF
--- a/clap_wrapper_builder/build_wrapper_plugin.sh
+++ b/clap_wrapper_builder/build_wrapper_plugin.sh
@@ -199,12 +199,11 @@ echo "Building..."
 # clap-wrapper's -Wpedantic -Werror; suppress the warning during Xcode builds
 if [[ "$CMAKE_GENERATOR" == "Xcode" ]]; then
     XCODE_FLAGS=('--' 'OTHER_CPLUSPLUSFLAGS=$(inherited) -Wno-gnu-statement-expression-from-macro-expansion -Wno-shorten-64-to-32')
-    XCODE_BUILD_ARGS=(--clean-first)
     # Pipe through xcbeautify only when on macOS and xcbeautify is available
     if command -v xcbeautify &> /dev/null; then
-        cmake --build "$BUILD_DIR" --config "$BUILD_CONFIG" "${XCODE_BUILD_ARGS[@]}" "${XCODE_FLAGS[@]}" 2>&1 | xcbeautify --quiet
+        cmake --build "$BUILD_DIR" --config "$BUILD_CONFIG" "${XCODE_FLAGS[@]}" 2>&1 | xcbeautify --quiet
     else
-        cmake --build "$BUILD_DIR" --config "$BUILD_CONFIG" "${XCODE_BUILD_ARGS[@]}" "${XCODE_FLAGS[@]}"
+        cmake --build "$BUILD_DIR" --config "$BUILD_CONFIG" "${XCODE_FLAGS[@]}"
     fi
 elif [[ "$CMAKE_GENERATOR" == "Visual Studio 17 2022" ]]; then
     cmake --build "$BUILD_DIR" --config "$BUILD_CONFIG"

--- a/clap_wrapper_builder/build_wrapper_plugin_static.sh
+++ b/clap_wrapper_builder/build_wrapper_plugin_static.sh
@@ -256,12 +256,11 @@ echo "Building..."
 # clap-wrapper's -Wpedantic -Werror; suppress the warning during Xcode builds
 if [[ "$CMAKE_GENERATOR" == "Xcode" ]]; then
     XCODE_FLAGS=('--' 'OTHER_CPLUSPLUSFLAGS=$(inherited) -Wno-gnu-statement-expression-from-macro-expansion -Wno-shorten-64-to-32')
-    XCODE_BUILD_ARGS=(--clean-first)
     # Pipe through xcbeautify only when on macOS and xcbeautify is available
     if command -v xcbeautify &> /dev/null; then
-        cmake --build "$BUILD_DIR" --config "$BUILD_CONFIG" "${XCODE_BUILD_ARGS[@]}" "${XCODE_FLAGS[@]}" 2>&1 | xcbeautify --quiet
+        cmake --build "$BUILD_DIR" --config "$BUILD_CONFIG" "${XCODE_FLAGS[@]}" 2>&1 | xcbeautify --quiet
     else
-        cmake --build "$BUILD_DIR" --config "$BUILD_CONFIG" "${XCODE_BUILD_ARGS[@]}" "${XCODE_FLAGS[@]}"
+        cmake --build "$BUILD_DIR" --config "$BUILD_CONFIG" "${XCODE_FLAGS[@]}"
     fi
 elif [[ "$CMAKE_GENERATOR" == "Visual Studio 17 2022" ]]; then
     cmake --build "$BUILD_DIR" --config "$BUILD_CONFIG"


### PR DESCRIPTION
## Summary
- Remove `--clean-first` from macOS wrapper build scripts.
- Keep Xcode/CMake builds incremental so repeated wrapper builds can reuse existing build outputs.

## Verification
- Confirmed from xdevice-private with `./script/build_and_install_snapklip_plugin.sh Debug`.
- Confirmed from xdevice-private with `cargo check --workspace --all-targets`.