### PR TITLE
Bump wxp dependency for wry AU crash fix

### DIFF
--- a/src-plugin/Cargo.lock
+++ b/src-plugin/Cargo.lock
@@ -1298,7 +1298,7 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 [[package]]
 name = "novonotes_run_loop"
 version = "0.6.0"
-source = "git+https://github.com/novonotes/wxp.git?rev=80987f1727c19a629cad723d4faa9e1d4d627fae#80987f1727c19a629cad723d4faa9e1d4d627fae"
+source = "git+https://github.com/novonotes/wxp.git?rev=27ab6f68c9f14bf94c3e116b723fa06de8b3cc88#27ab6f68c9f14bf94c3e116b723fa06de8b3cc88"
 dependencies = [
  "core-foundation",
  "futures",
@@ -3099,7 +3099,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 [[package]]
 name = "wry"
 version = "0.52.1"
-source = "git+https://github.com/novonotes/wxp.git?rev=80987f1727c19a629cad723d4faa9e1d4d627fae#80987f1727c19a629cad723d4faa9e1d4d627fae"
+source = "git+https://github.com/novonotes/wxp.git?rev=27ab6f68c9f14bf94c3e116b723fa06de8b3cc88#27ab6f68c9f14bf94c3e116b723fa06de8b3cc88"
 dependencies = [
  "base64",
  "block2 0.6.2",
@@ -3142,7 +3142,7 @@ dependencies = [
 [[package]]
 name = "wxp"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/novonotes/wxp.git?rev=80987f1727c19a629cad723d4faa9e1d4d627fae#80987f1727c19a629cad723d4faa9e1d4d627fae"
+source = "git+https://github.com/novonotes/wxp.git?rev=27ab6f68c9f14bf94c3e116b723fa06de8b3cc88#27ab6f68c9f14bf94c3e116b723fa06de8b3cc88"
 dependencies = [
  "async-trait",
  "directories",
@@ -3163,7 +3163,7 @@ dependencies = [
 [[package]]
 name = "wxp_clack"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/novonotes/wxp.git?rev=80987f1727c19a629cad723d4faa9e1d4d627fae#80987f1727c19a629cad723d4faa9e1d4d627fae"
+source = "git+https://github.com/novonotes/wxp.git?rev=27ab6f68c9f14bf94c3e116b723fa06de8b3cc88#27ab6f68c9f14bf94c3e116b723fa06de8b3cc88"
 dependencies = [
  "clack-extensions",
  "wxp",

--- a/src-plugin/Cargo.lock
+++ b/src-plugin/Cargo.lock
@@ -1298,7 +1298,7 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 [[package]]
 name = "novonotes_run_loop"
 version = "0.6.0"
-source = "git+https://github.com/novonotes/wxp.git?rev=27ab6f68c9f14bf94c3e116b723fa06de8b3cc88#27ab6f68c9f14bf94c3e116b723fa06de8b3cc88"
+source = "git+https://github.com/novonotes/wxp.git?rev=4636daec47a4a7d98d433100fdb27607e5e9d4a3#4636daec47a4a7d98d433100fdb27607e5e9d4a3"
 dependencies = [
  "core-foundation",
  "futures",
@@ -3099,7 +3099,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 [[package]]
 name = "wry"
 version = "0.52.1"
-source = "git+https://github.com/novonotes/wxp.git?rev=27ab6f68c9f14bf94c3e116b723fa06de8b3cc88#27ab6f68c9f14bf94c3e116b723fa06de8b3cc88"
+source = "git+https://github.com/novonotes/wxp.git?rev=4636daec47a4a7d98d433100fdb27607e5e9d4a3#4636daec47a4a7d98d433100fdb27607e5e9d4a3"
 dependencies = [
  "base64",
  "block2 0.6.2",
@@ -3142,7 +3142,7 @@ dependencies = [
 [[package]]
 name = "wxp"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/novonotes/wxp.git?rev=27ab6f68c9f14bf94c3e116b723fa06de8b3cc88#27ab6f68c9f14bf94c3e116b723fa06de8b3cc88"
+source = "git+https://github.com/novonotes/wxp.git?rev=4636daec47a4a7d98d433100fdb27607e5e9d4a3#4636daec47a4a7d98d433100fdb27607e5e9d4a3"
 dependencies = [
  "async-trait",
  "directories",
@@ -3163,7 +3163,7 @@ dependencies = [
 [[package]]
 name = "wxp_clack"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/novonotes/wxp.git?rev=27ab6f68c9f14bf94c3e116b723fa06de8b3cc88#27ab6f68c9f14bf94c3e116b723fa06de8b3cc88"
+source = "git+https://github.com/novonotes/wxp.git?rev=4636daec47a4a7d98d433100fdb27607e5e9d4a3#4636daec47a4a7d98d433100fdb27607e5e9d4a3"
 dependencies = [
  "clack-extensions",
  "wxp",

--- a/src-plugin/Cargo.toml
+++ b/src-plugin/Cargo.toml
@@ -14,13 +14,13 @@ atomic_float = "1.1.0"
 clack-extensions = { git = "https://github.com/prokopyl/clack.git", rev = "9f2ccb40", features = ["audio-ports", "params", "clack-plugin", "gui", "state"] }
 clack-plugin = { git = "https://github.com/prokopyl/clack.git", rev = "9f2ccb40" }
 log = "0.4"
-novonotes_run_loop = { git = "https://github.com/novonotes/wxp.git", rev = "80987f1727c19a629cad723d4faa9e1d4d627fae" }
+novonotes_run_loop = { git = "https://github.com/novonotes/wxp.git", rev = "27ab6f68c9f14bf94c3e116b723fa06de8b3cc88" }
 parking_lot = "0.12"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
-wry = { git = "https://github.com/novonotes/wxp.git", rev = "80987f1727c19a629cad723d4faa9e1d4d627fae", features = ["devtools"] }
-wxp = { git = "https://github.com/novonotes/wxp.git", rev = "80987f1727c19a629cad723d4faa9e1d4d627fae" }
-wxp_clack = { git = "https://github.com/novonotes/wxp.git", rev = "80987f1727c19a629cad723d4faa9e1d4d627fae" }
+wry = { git = "https://github.com/novonotes/wxp.git", rev = "27ab6f68c9f14bf94c3e116b723fa06de8b3cc88", features = ["devtools"] }
+wxp = { git = "https://github.com/novonotes/wxp.git", rev = "27ab6f68c9f14bf94c3e116b723fa06de8b3cc88" }
+wxp_clack = { git = "https://github.com/novonotes/wxp.git", rev = "27ab6f68c9f14bf94c3e116b723fa06de8b3cc88" }
 
 [lints.rust]
 unreachable_pub = "deny"

--- a/src-plugin/Cargo.toml
+++ b/src-plugin/Cargo.toml
@@ -14,13 +14,13 @@ atomic_float = "1.1.0"
 clack-extensions = { git = "https://github.com/prokopyl/clack.git", rev = "9f2ccb40", features = ["audio-ports", "params", "clack-plugin", "gui", "state"] }
 clack-plugin = { git = "https://github.com/prokopyl/clack.git", rev = "9f2ccb40" }
 log = "0.4"
-novonotes_run_loop = { git = "https://github.com/novonotes/wxp.git", rev = "27ab6f68c9f14bf94c3e116b723fa06de8b3cc88" }
+novonotes_run_loop = { git = "https://github.com/novonotes/wxp.git", rev = "4636daec47a4a7d98d433100fdb27607e5e9d4a3" }
 parking_lot = "0.12"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
-wry = { git = "https://github.com/novonotes/wxp.git", rev = "27ab6f68c9f14bf94c3e116b723fa06de8b3cc88", features = ["devtools"] }
-wxp = { git = "https://github.com/novonotes/wxp.git", rev = "27ab6f68c9f14bf94c3e116b723fa06de8b3cc88" }
-wxp_clack = { git = "https://github.com/novonotes/wxp.git", rev = "27ab6f68c9f14bf94c3e116b723fa06de8b3cc88" }
+wry = { git = "https://github.com/novonotes/wxp.git", rev = "4636daec47a4a7d98d433100fdb27607e5e9d4a3", features = ["devtools"] }
+wxp = { git = "https://github.com/novonotes/wxp.git", rev = "4636daec47a4a7d98d433100fdb27607e5e9d4a3" }
+wxp_clack = { git = "https://github.com/novonotes/wxp.git", rev = "4636daec47a4a7d98d433100fdb27607e5e9d4a3" }
 
 [lints.rust]
 unreachable_pub = "deny"


### PR DESCRIPTION
## Summary
- update the `wxp` git revision to include the `wry` AU crash fix
- keep compatibility with the current downstream `wxp` API surface
- refresh `Cargo.lock` for the new `wxp` revision

Supersedes #13 for downstream compatibility.
