### PR TITLE
Add smoke test workflow

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,0 +1,54 @@
+name: Smoke Test
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  smoke-test:
+    name: Build CLAP plugin
+    runs-on: macos-14
+    env:
+      MACOSX_DEPLOYMENT_TARGET: "11.0"
+      WRY_OBJC_SUFFIX: WxpExampleGainPlugin
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.12.0"
+          cache: npm
+          cache-dependency-path: src-gui/package-lock.json
+
+      - name: Show Rust version
+        run: |
+          rustup show
+          rustc --version
+          cargo --version
+
+      - name: Install GUI dependencies
+        working-directory: src-gui
+        run: npm ci
+
+      - name: Build GUI
+        working-directory: src-gui
+        run: npm run build
+
+      - name: Check Rust plugin
+        run: cargo check --locked --manifest-path src-plugin/Cargo.toml
+
+      - name: Build CLAP bundle
+        run: ./script/build.sh Release
+
+      - name: Verify CLAP bundle
+        run: test -d "target/bundled/WXP Example Gain.clap"


### PR DESCRIPTION
## Summary
- Add a GitHub Actions smoke test for the template
- Build the GUI with npm ci and Vite
- Run cargo check and build the CLAP bundle via the existing script

## Verification
- npm ci
- npm run build
- cargo check --locked --manifest-path ../src-plugin/Cargo.toml
- ./script/build.sh Release