### PR TITLE
Align GUI lifecycle with wxp visibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.DS_Store
 /.log/
 /target/
+/vendor/
 
 /src-gui/node_modules/
 /src-gui/dist/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3393,7 +3393,7 @@ dependencies = [
 [[package]]
 name = "wxp"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/novonotes/wxp.git?rev=c5cb77a66fe9600bf60bac828721ba26d510ff07#c5cb77a66fe9600bf60bac828721ba26d510ff07"
+source = "git+https://github.com/novonotes/wxp.git?branch=main#4c7b2c97a6fe1d4d55586f3ee1b0b2201bbe4773"
 dependencies = [
  "async-trait",
  "directories",

--- a/crates/wrac_wxp_gui/Cargo.toml
+++ b/crates/wrac_wxp_gui/Cargo.toml
@@ -13,7 +13,7 @@ novonotes_run_loop = { git = "https://github.com/novonotes/run_loop.git", rev = 
 parking_lot = "0.12"
 raw-window-handle = "0.6"
 wrac_clap_adapter = { path = "../wrac_clap_adapter" }
-wxp = { git = "https://github.com/novonotes/wxp.git", rev = "c5cb77a66fe9600bf60bac828721ba26d510ff07" }
+wxp = { git = "https://github.com/novonotes/wxp.git", branch = "main" }
 
 [lints.rust]
 unreachable_pub = "deny"

--- a/crates/wrac_wxp_gui/src/controller.rs
+++ b/crates/wrac_wxp_gui/src/controller.rs
@@ -10,8 +10,7 @@ use wxp::{WebViewRef, dpi::LogicalSize};
 
 use crate::dpi::DpiConverter;
 use crate::runtime::{
-    GuiRuntimeHandle, WxpGuiFactory, create_gui_runtime_handle, is_gui_thread,
-    release_gui_thread_ref,
+    GuiRuntimeHandle, GuiThreadLease, WxpGuiFactory, create_gui_runtime_handle, is_gui_thread,
 };
 use crate::window::StoredParentWindow;
 
@@ -42,9 +41,19 @@ struct HostGuiLayout {
 }
 
 struct GuiRuntimeState {
+    session: Option<GuiSession>,
+}
+
+// CLAP の `create()` は GUI session の開始だが、embedded WebView の native child は
+// parent handle がないと作れない。session と runtime を分けることで、`create()` 後の
+// size/scale query には答えつつ、parent が来るまで native object 作成を遅延できる。
+struct GuiSession {
+    configuration: GuiConfiguration,
     scale: f64,
     parent: Option<StoredParentWindow>,
+    parent_lease: Option<GuiThreadLease>,
     handle: Option<GuiRuntimeHandle>,
+    visible: bool,
 }
 
 #[derive(Clone)]
@@ -62,27 +71,13 @@ impl WxpGuiController {
             factory: Box::new(factory),
             layout: resize_handle.layout.clone(),
             scale: resize_handle.scale.clone(),
-            runtime: Mutex::new(GuiRuntimeState {
-                scale: 1.0,
-                parent: None,
-                handle: None,
-            }),
+            runtime: Mutex::new(GuiRuntimeState { session: None }),
         }
     }
 
-    fn destroy_runtime_and_parent_ref(&self) {
-        let (handle, release_parent_ref) = {
-            let mut state = self.runtime.lock();
-            let handle = state.handle.take();
-            let release_parent_ref = state.parent.take().is_some();
-            (handle, release_parent_ref)
-        };
-        if let Some(handle) = handle {
-            handle.destroy();
-        }
-        if release_parent_ref {
-            release_gui_thread_ref();
-        }
+    fn destroy_gui_session(&self) {
+        let session = { self.runtime.lock().session.take() };
+        drop_session(session);
     }
 
     fn create_runtime(
@@ -243,20 +238,39 @@ impl PluginGui for WxpGuiController {
         if !self.is_api_supported(configuration.api, configuration.is_floating) {
             return Err(PluginError::Message("unsupported GUI configuration"));
         }
+        self.destroy_gui_session();
+        let scale = *self.scale.lock();
+        self.runtime.lock().session = Some(GuiSession {
+            configuration,
+            scale,
+            parent: None,
+            parent_lease: None,
+            handle: None,
+            // 一部 wrapper は embedded view を parent に付けた時点で表示扱いにし、`show()`
+            // を呼ばない。初回 parent attach は表示状態として扱い、明示的な `hide()` を優先する。
+            visible: true,
+        });
         Ok(())
     }
 
     fn destroy(&self) {
-        self.destroy_runtime_and_parent_ref();
+        self.destroy_gui_session();
     }
 
     fn set_scale(&self, scale: f64) -> PluginResult<()> {
-        let handle = { self.runtime.lock().handle.clone() };
+        let handle = {
+            let mut state = self.runtime.lock();
+            if let Some(session) = &mut state.session {
+                session.scale = scale;
+                session.handle.clone()
+            } else {
+                None
+            }
+        };
         if let Some(handle) = handle {
             handle.set_scale(scale)?;
         }
         *self.scale.lock() = scale;
-        self.runtime.lock().scale = scale;
         Ok(())
     }
 
@@ -278,7 +292,13 @@ impl PluginGui for WxpGuiController {
 
     fn set_size(&self, size: GuiSize) -> PluginResult<()> {
         let size = self.layout.clamp_size(size);
-        let handle = { self.runtime.lock().handle.clone() };
+        let handle = {
+            self.runtime
+                .lock()
+                .session
+                .as_ref()
+                .and_then(|session| session.handle.clone())
+        };
         if let Some(handle) = handle {
             handle.set_size(size)?;
         }
@@ -287,45 +307,80 @@ impl PluginGui for WxpGuiController {
     }
 
     fn set_parent(&self, window: ClapWindow) -> PluginResult<()> {
-        // parent window は host UI thread に属する。WebView の生成自体は `show()` まで
-        // 遅らせるが、thread ownership は最初の `set_parent()` で固定しておく。
-        {
+        let parent = StoredParentWindow::from_clap_window(window);
+        let needs_parent_lease = {
             let state = self.runtime.lock();
-            if state.parent.is_some() {
+            let session = state.session.as_ref().ok_or(PluginError::InvalidState)?;
+            if session.parent.is_some() {
                 if !is_gui_thread() {
                     return Err(PluginError::UnsupportedHostGuiThreadingModel);
                 }
+                false
             } else {
-                drop(state);
-                crate::runtime::acquire_gui_thread()?;
+                true
             }
-        }
+        };
 
-        let parent = StoredParentWindow::from_clap_window(window);
+        let parent_lease = needs_parent_lease
+            .then(GuiThreadLease::acquire)
+            .transpose()?;
+
         let old_handle = {
             let mut state = self.runtime.lock();
-            state.parent = Some(parent);
-            state.handle.take()
+            let session = state.session.as_mut().ok_or(PluginError::InvalidState)?;
+            // parent handle が変わると、既存 child WebView を安全に reparent できる保証が
+            // wxp/wry 側にない。古い runtime を先に落として、新しい parent 上に作り直す。
+            session.handle.take()
         };
         if let Some(handle) = old_handle {
             handle.destroy();
         }
 
-        let create = {
+        let (configuration, size, scale, visible) = {
             let state = self.runtime.lock();
-            // CLAP の GUI spec 上は `show()` が表示開始の合図だが、clap-wrapper の AUv2
-            // 経由では Logic Pro が embedded view を parent に付けた時点で表示扱いにし、
-            // `show()` を呼ばない経路がある。WebView 作成を `show()` だけに遅延すると
-            // host の空 container だけが表示されるため、parent が確定した時点で runtime を作る。
-            state
-                .handle
-                .is_none()
-                .then_some((self.layout.accepted_size(), parent, state.scale))
+            let session = state.session.as_ref().ok_or(PluginError::InvalidState)?;
+            (
+                session.configuration,
+                self.layout.accepted_size(),
+                session.scale,
+                session.visible,
+            )
         };
-        if let Some((size, parent, scale)) = create {
-            let handle = self.create_runtime(default_gui_configuration(), size, parent, scale)?;
-            self.runtime.lock().handle = Some(handle);
+        // CLAP の GUI spec 上は `show()` が表示開始の合図だが、clap-wrapper の AUv2
+        // 経由では Logic Pro が embedded view を parent に付けた時点で表示扱いにし、
+        // `show()` を呼ばない経路がある。WebView 作成は parent が必要なのでここで行う。
+        let handle = match self.create_runtime(configuration, size, parent, scale) {
+            Ok(handle) => handle,
+            Err(error) => {
+                if needs_parent_lease {
+                    let mut state = self.runtime.lock();
+                    if let Some(session) = &mut state.session {
+                        session.parent = None;
+                        session.parent_lease = None;
+                    }
+                }
+                // parent attach 失敗後に parent lease だけ残ると、次回 GUI session が別 thread
+                // から来た時に不要に拒否される。失敗した attach は状態を進めない。
+                drop(parent_lease);
+                return Err(error);
+            }
+        };
+        if !visible {
+            if let Err(error) = handle.hide() {
+                // hidden 初期化に失敗した runtime は、session に入れず破棄する。半端な handle を
+                // 残すと以降の `show()`/`destroy()` が失敗済み WebView を操作してしまう。
+                handle.destroy();
+                drop(parent_lease);
+                return Err(error);
+            }
         }
+        let mut state = self.runtime.lock();
+        let session = state.session.as_mut().ok_or(PluginError::InvalidState)?;
+        session.parent = Some(parent);
+        if let Some(parent_lease) = parent_lease {
+            session.parent_lease = Some(parent_lease);
+        }
+        session.handle = Some(handle);
         Ok(())
     }
 
@@ -338,29 +393,40 @@ impl PluginGui for WxpGuiController {
     fn show(&self) -> PluginResult<()> {
         let action = {
             let state = self.runtime.lock();
-            if let Some(handle) = state.handle.clone() {
+            let session = state.session.as_ref().ok_or(PluginError::InvalidState)?;
+            if let Some(handle) = session.handle.clone() {
                 ShowAction::ShowExisting(handle)
             } else {
-                let parent = state.parent.ok_or(PluginError::InvalidState)?;
+                let parent = session.parent.ok_or(PluginError::InvalidState)?;
                 ShowAction::Create {
+                    configuration: session.configuration,
                     size: self.layout.accepted_size(),
                     parent,
-                    scale: state.scale,
+                    scale: session.scale,
                 }
             }
         };
 
         match action {
-            ShowAction::ShowExisting(handle) => handle.show(),
+            ShowAction::ShowExisting(handle) => {
+                handle.show()?;
+                if let Some(session) = &mut self.runtime.lock().session {
+                    session.visible = true;
+                }
+                Ok(())
+            }
             ShowAction::Create {
+                configuration,
                 size,
                 parent,
                 scale,
             } => {
-                let handle =
-                    self.create_runtime(default_gui_configuration(), size, parent, scale)?;
+                let handle = self.create_runtime(configuration, size, parent, scale)?;
                 handle.show()?;
-                self.runtime.lock().handle = Some(handle);
+                let mut state = self.runtime.lock();
+                let session = state.session.as_mut().ok_or(PluginError::InvalidState)?;
+                session.handle = Some(handle);
+                session.visible = true;
                 Ok(())
             }
         }
@@ -368,16 +434,28 @@ impl PluginGui for WxpGuiController {
 
     fn hide(&self) -> PluginResult<()> {
         let handle = {
-            let mut state = self.runtime.lock();
-            state.handle.take()
+            let state = self.runtime.lock();
+            let session = state.session.as_ref().ok_or(PluginError::InvalidState)?;
+            session.handle.clone()
         };
         if let Some(handle) = handle {
-            let _ = handle.hide();
-            // wxp の public handle は visible 切替を直接公開していない。`hide()` では
-            // runtime を破棄して、CLAP の「見えていない」状態を確実に満たす。
-            handle.destroy();
+            handle.hide()?;
+        }
+        if let Some(session) = &mut self.runtime.lock().session {
+            session.visible = false;
         }
         Ok(())
+    }
+}
+
+fn drop_session(session: Option<GuiSession>) {
+    if let Some(mut session) = session {
+        if let Some(handle) = session.handle.take() {
+            handle.destroy();
+        }
+        // runtime drop が終わってから parent lease を解放する。timer stop や WebView teardown が
+        // run loop 上で完了する前に owner thread を解放しないため。
+        drop(session.parent_lease.take());
     }
 }
 
@@ -390,13 +468,14 @@ fn clamp_size_with_limits(size: GuiSize, limits: GuiSizeLimits) -> GuiSize {
 
 impl Drop for WxpGuiController {
     fn drop(&mut self) {
-        self.destroy_runtime_and_parent_ref();
+        self.destroy_gui_session();
     }
 }
 
 enum ShowAction {
     ShowExisting(GuiRuntimeHandle),
     Create {
+        configuration: GuiConfiguration,
         size: GuiSize,
         parent: StoredParentWindow,
         scale: f64,

--- a/crates/wrac_wxp_gui/src/runtime.rs
+++ b/crates/wrac_wxp_gui/src/runtime.rs
@@ -12,7 +12,7 @@ use crate::window::ParentWindowHandle;
 thread_local! {
     // WebView などの native GUI object は、生成 thread 以外へ移動できない実装が多い。
     // `WxpGuiController` は Send/Sync な `PluginCore` の中に置かれるため、実体は TLS に閉じ込める。
-    static GUI_RUNTIMES: RefCell<HashMap<u64, Box<dyn WxpGuiRuntime>>> = RefCell::new(HashMap::new());
+    static GUI_RUNTIMES: RefCell<HashMap<u64, GuiRuntimeEntry>> = RefCell::new(HashMap::new());
 }
 
 static NEXT_GUI_ID: AtomicU64 = AtomicU64::new(1);
@@ -27,6 +27,21 @@ struct GuiThreadState {
     owner: Option<ThreadId>,
     ref_count: usize,
 }
+
+struct GuiRuntimeEntry {
+    runtime: Box<dyn WxpGuiRuntime>,
+    // runtime が TLS から remove されるまで run loop を生かす。handle 側で手動 release
+    // すると、runtime drop 中に timer や WebView teardown が run loop を必要とする場合に
+    // 順序を間違えやすいので、entry の lifetime に lease を結び付ける。
+    _lease: GuiThreadLease,
+}
+
+/// GUI thread の run loop 参照を表す RAII token。
+///
+/// TODO: `novonotes_run_loop` 側に transactional な guard API が入ったら、この型は
+/// その thin wrapper に寄せる。現状の `RunLoop::init()` は失敗時 rollback が API 契約に
+/// なっていないため、ここではローカル state を進めない範囲で防御する。
+pub(crate) struct GuiThreadLease;
 
 /// UI thread が所有する実際の WebView runtime。
 ///
@@ -82,13 +97,12 @@ pub(crate) struct GuiRuntimeHandle {
 pub(crate) fn create_gui_runtime_handle(
     create: impl FnOnce() -> PluginResult<Box<dyn WxpGuiRuntime>>,
 ) -> PluginResult<GuiRuntimeHandle> {
-    acquire_gui_thread()?;
+    let lease = GuiThreadLease::acquire()?;
+    // `create` が失敗した場合、lease はここで drop される。失敗した runtime 作成が
+    // GUI thread ref を残さないことを型の drop 順で保証する。
     match create() {
-        Ok(runtime) => Ok(insert_gui_runtime(runtime)),
-        Err(error) => {
-            release_gui_thread_ref();
-            Err(error)
-        }
+        Ok(runtime) => Ok(insert_gui_runtime(runtime, lease)),
+        Err(error) => Err(error),
     }
 }
 
@@ -96,10 +110,9 @@ impl GuiRuntimeHandle {
     pub(crate) fn destroy(self) {
         let id = self.id;
         self.sender.send_and_wait(move || {
-            let removed = GUI_RUNTIMES.with(|runtimes| runtimes.borrow_mut().remove(&id).is_some());
-            if removed {
-                release_gui_thread_ref();
-            }
+            GUI_RUNTIMES.with(|runtimes| {
+                runtimes.borrow_mut().remove(&id);
+            });
         });
     }
 
@@ -108,8 +121,8 @@ impl GuiRuntimeHandle {
         self.sender.send_and_wait(move || {
             GUI_RUNTIMES.with(|runtimes| {
                 let mut runtimes = runtimes.borrow_mut();
-                let runtime = runtimes.get_mut(&id).ok_or(PluginError::InvalidState)?;
-                runtime.set_scale(scale)
+                let entry = runtimes.get_mut(&id).ok_or(PluginError::InvalidState)?;
+                entry.runtime.set_scale(scale)
             })
         })
     }
@@ -119,8 +132,8 @@ impl GuiRuntimeHandle {
         self.sender.send_and_wait(move || {
             GUI_RUNTIMES.with(|runtimes| {
                 let mut runtimes = runtimes.borrow_mut();
-                let runtime = runtimes.get_mut(&id).ok_or(PluginError::InvalidState)?;
-                runtime.set_size(size)
+                let entry = runtimes.get_mut(&id).ok_or(PluginError::InvalidState)?;
+                entry.runtime.set_size(size)
             })
         })
     }
@@ -130,8 +143,8 @@ impl GuiRuntimeHandle {
         self.sender.send_and_wait(move || {
             GUI_RUNTIMES.with(|runtimes| {
                 let mut runtimes = runtimes.borrow_mut();
-                let runtime = runtimes.get_mut(&id).ok_or(PluginError::InvalidState)?;
-                runtime.show()
+                let entry = runtimes.get_mut(&id).ok_or(PluginError::InvalidState)?;
+                entry.runtime.show()
             })
         })
     }
@@ -141,41 +154,23 @@ impl GuiRuntimeHandle {
         self.sender.send_and_wait(move || {
             GUI_RUNTIMES.with(|runtimes| {
                 let mut runtimes = runtimes.borrow_mut();
-                let runtime = runtimes.get_mut(&id).ok_or(PluginError::InvalidState)?;
-                runtime.hide()
+                let entry = runtimes.get_mut(&id).ok_or(PluginError::InvalidState)?;
+                entry.runtime.hide()
             })
         })
     }
 }
 
-pub(crate) fn acquire_gui_thread() -> PluginResult<()> {
-    let current_thread = std::thread::current().id();
-    let mut gui_thread = GUI_THREAD_STATE.lock();
-    match gui_thread.owner {
-        Some(owner_thread) if owner_thread != current_thread => {
-            return Err(PluginError::UnsupportedHostGuiThreadingModel);
-        }
-        Some(_) => {}
-        None => {
-            gui_thread.owner = Some(current_thread);
-        }
-    }
-
-    if RunLoop::init().is_err() {
-        if gui_thread.ref_count == 0 {
-            gui_thread.owner = None;
-        }
-        return Err(PluginError::UnsupportedHostGuiThreadingModel);
-    }
-
-    gui_thread.ref_count += 1;
-    Ok(())
-}
-
-fn insert_gui_runtime(runtime: Box<dyn WxpGuiRuntime>) -> GuiRuntimeHandle {
+fn insert_gui_runtime(runtime: Box<dyn WxpGuiRuntime>, lease: GuiThreadLease) -> GuiRuntimeHandle {
     let id = NEXT_GUI_ID.fetch_add(1, Ordering::Relaxed);
     GUI_RUNTIMES.with(|runtimes| {
-        runtimes.borrow_mut().insert(id, runtime);
+        runtimes.borrow_mut().insert(
+            id,
+            GuiRuntimeEntry {
+                runtime,
+                _lease: lease,
+            },
+        );
     });
     GuiRuntimeHandle {
         id,
@@ -183,15 +178,40 @@ fn insert_gui_runtime(runtime: Box<dyn WxpGuiRuntime>) -> GuiRuntimeHandle {
     }
 }
 
-pub(crate) fn release_gui_thread_ref() {
-    RunLoop::deinit();
-    let mut gui_thread = GUI_THREAD_STATE.lock();
-    debug_assert!(gui_thread.ref_count > 0);
-    gui_thread.ref_count = gui_thread.ref_count.saturating_sub(1);
-    if gui_thread.ref_count == 0 {
-        // 最後の runtime だけでなく `set_parent()` 由来の thread 固定も解放された時点で、
-        // 次の GUI session が別 host window から来ることを許可する。
-        gui_thread.owner = None;
+impl GuiThreadLease {
+    pub(crate) fn acquire() -> PluginResult<Self> {
+        let current_thread = std::thread::current().id();
+        let mut gui_thread = GUI_THREAD_STATE.lock();
+        match gui_thread.owner {
+            Some(owner_thread) if owner_thread != current_thread => {
+                return Err(PluginError::UnsupportedHostGuiThreadingModel);
+            }
+            Some(_) | None => {}
+        }
+
+        if RunLoop::init().is_err() {
+            return Err(PluginError::UnsupportedHostGuiThreadingModel);
+        }
+
+        // owner は `RunLoop::init()` 成功後にだけ進める。依存 crate の init が失敗時に
+        // 完全 rollback する保証はまだないため、少なくともこちらの SoT は汚さない。
+        gui_thread.owner = Some(current_thread);
+        gui_thread.ref_count += 1;
+        Ok(Self)
+    }
+}
+
+impl Drop for GuiThreadLease {
+    fn drop(&mut self) {
+        RunLoop::deinit();
+        let mut gui_thread = GUI_THREAD_STATE.lock();
+        debug_assert!(gui_thread.ref_count > 0);
+        gui_thread.ref_count = gui_thread.ref_count.saturating_sub(1);
+        if gui_thread.ref_count == 0 {
+            // 最後の runtime だけでなく `set_parent()` 由来の thread 固定も解放された時点で、
+            // 次の GUI session が別 host window から来ることを許可する。
+            gui_thread.owner = None;
+        }
     }
 }
 

--- a/src-plugin/Cargo.toml
+++ b/src-plugin/Cargo.toml
@@ -23,7 +23,7 @@ time = { version = "0.3", features = ["formatting", "local-offset", "macros"] }
 run_loop_timer = { path = "../crates/run_loop_timer" }
 wrac_clap_adapter = { path = "../crates/wrac_clap_adapter" }
 wrac_wxp_gui = { path = "../crates/wrac_wxp_gui" }
-wxp = { git = "https://github.com/novonotes/wxp.git", rev = "c5cb77a66fe9600bf60bac828721ba26d510ff07" }
+wxp = { git = "https://github.com/novonotes/wxp.git", branch = "main" }
 
 [lints.rust]
 unreachable_pub = "deny"

--- a/src-plugin/src/gui.rs
+++ b/src-plugin/src/gui.rs
@@ -397,6 +397,26 @@ impl WxpGuiRuntime for WracGainGuiRuntime {
         }
         Ok(())
     }
+
+    fn show(&mut self) -> PluginResult<()> {
+        if let Some(web_view) = &self.web_view {
+            web_view
+                .set_visible(true)
+                .map_err(|_| PluginError::Message("failed to show webview"))?;
+        }
+        self.gui_update_timer.start();
+        Ok(())
+    }
+
+    fn hide(&mut self) -> PluginResult<()> {
+        self.gui_update_timer.stop();
+        if let Some(web_view) = &self.web_view {
+            web_view
+                .set_visible(false)
+                .map_err(|_| PluginError::Message("failed to hide webview"))?;
+        }
+        Ok(())
+    }
 }
 
 // host が GUI を閉じると runtime が drop される。
@@ -405,6 +425,9 @@ impl WxpGuiRuntime for WracGainGuiRuntime {
 impl Drop for WracGainGuiRuntime {
     fn drop(&mut self) {
         log::debug!("dropping GUI runtime");
+        // timer callback は run loop と GUI subscription に依存する。native WebView を
+        // 落とす前に止めて、破棄途中の GUI state を tick が見る余地をなくす。
+        self.gui_update_timer.stop();
         // GUI が消えるので、shared state からも channel を外しておく。
         self.gui_notifier.clear_subscriptions();
         // WebView → WebContext の順で drop。逆だと wry が context 不在で panic することがある。


### PR DESCRIPTION
## Summary
- Use wxp from `novonotes/wxp` main after the visibility and weak WebView reference changes.
- Treat `PluginGui::create()` as the GUI session boundary while delaying native WebView creation until a parent exists.
- Keep WebView runtime alive across `hide()`/`show()` and manage run loop references with RAII leases.

## Verification
- `cargo check --workspace`
- `git diff --check`