### PR TITLE
Update wxp and harden GUI lifecycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3317,6 +3317,7 @@ version = "0.1.0"
 dependencies = [
  "assert_no_alloc",
  "atomic_float",
+ "directories",
  "log",
  "novonotes_run_loop",
  "parking_lot",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3352,7 +3352,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 [[package]]
 name = "wry"
 version = "0.52.1"
-source = "git+https://github.com/novonotes/wry.git?rev=cfca5aad39c8cad7a0faabf168adb9af4c4c1923#cfca5aad39c8cad7a0faabf168adb9af4c4c1923"
+source = "git+https://github.com/novonotes/wry.git?rev=62f8d4869363ae3e82b4dcbdb19881b356797e03#62f8d4869363ae3e82b4dcbdb19881b356797e03"
 dependencies = [
  "base64",
  "block2 0.6.2",
@@ -3395,7 +3395,7 @@ dependencies = [
 [[package]]
 name = "wxp"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/novonotes/wxp.git?branch=main#4c7b2c97a6fe1d4d55586f3ee1b0b2201bbe4773"
+source = "git+https://github.com/novonotes/wxp.git?branch=main#953a7dbbba1b6734258a99841de45e5ea5b40cbf"
 dependencies = [
  "async-trait",
  "directories",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3334,6 +3334,7 @@ dependencies = [
 name = "wrac_wxp_gui"
 version = "0.1.0"
 dependencies = [
+ "log",
  "novonotes_run_loop",
  "parking_lot",
  "raw-window-handle",

--- a/crates/wrac_wxp_gui/Cargo.toml
+++ b/crates/wrac_wxp_gui/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 publish = false
 
 [dependencies]
+log = "0.4"
 novonotes_run_loop = { git = "https://github.com/novonotes/run_loop.git", rev = "2779a6400cc99a8728052ba4df1c475a492849de" }
 parking_lot = "0.12"
 raw-window-handle = "0.6"

--- a/crates/wrac_wxp_gui/src/controller.rs
+++ b/crates/wrac_wxp_gui/src/controller.rs
@@ -1,6 +1,8 @@
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
 
+use novonotes_run_loop::RunLoop;
 use parking_lot::Mutex;
 use wrac_clap_adapter::{
     ClapWindow, GuiApi, GuiConfiguration, GuiResizeHints, GuiSize, HostGuiResizeRequester,
@@ -26,10 +28,10 @@ pub struct GuiSizeLimits {
 /// [`PluginGui`] handle として GUI lifecycle callback を受ける。現在は host parent に
 /// child view として貼る embedded GUI のみ対応し、floating window は拒否する。
 pub struct WxpGuiController {
-    factory: Box<dyn WxpGuiFactory>,
+    factory: Arc<dyn WxpGuiFactory>,
     layout: Arc<HostGuiLayout>,
     scale: Arc<Mutex<f64>>,
-    runtime: Mutex<GuiRuntimeState>,
+    runtime: Arc<Mutex<GuiRuntimeState>>,
 }
 
 struct HostGuiLayout {
@@ -42,12 +44,33 @@ struct HostGuiLayout {
 
 struct GuiRuntimeState {
     session: Option<GuiSession>,
+    // Hosts may call create/set_parent/show/destroy in quick succession when the user
+    // repeatedly opens and closes the editor. WebView creation is posted to the GUI
+    // run loop, so callbacks can arrive after the original CLAP GUI call returned.
+    // The generation lets those late callbacks detect stale sessions and tear down
+    // the just-created runtime instead of attaching it to a closed editor.
+    generation: u64,
+    last_runtime_destroyed_at: Option<Instant>,
+    // Windows hosts, especially Ableton Live, can recreate the editor while the
+    // previous WebView teardown is still unwinding. Keep creation single-flight and
+    // remember the newest requested generation instead of overlapping native child
+    // WebView creation.
+    is_creating_runtime: bool,
+    creating_generation: Option<u64>,
+    pending_creation_generation: Option<u64>,
+    destroy_requested_while_creating: bool,
 }
+
+// Give the host and WebView backend a short quiescent period after destroying a
+// runtime. Without this, rapidly toggling the editor can request a new child
+// WebView before the previous native teardown has fully settled.
+const WEBVIEW_RECREATE_QUIET_PERIOD: Duration = Duration::from_millis(500);
 
 // CLAP の `create()` は GUI session の開始だが、embedded WebView の native child は
 // parent handle がないと作れない。session と runtime を分けることで、`create()` 後の
 // size/scale query には答えつつ、parent が来るまで native object 作成を遅延できる。
 struct GuiSession {
+    generation: u64,
     configuration: GuiConfiguration,
     scale: f64,
     parent: Option<StoredParentWindow>,
@@ -68,35 +91,414 @@ impl WxpGuiController {
         resize_handle: WxpGuiResizeHandle,
     ) -> Self {
         Self {
-            factory: Box::new(factory),
+            factory: Arc::new(factory),
             layout: resize_handle.layout.clone(),
             scale: resize_handle.scale.clone(),
-            runtime: Mutex::new(GuiRuntimeState { session: None }),
+            runtime: Arc::new(Mutex::new(GuiRuntimeState {
+                session: None,
+                generation: 0,
+                last_runtime_destroyed_at: None,
+                is_creating_runtime: false,
+                creating_generation: None,
+                pending_creation_generation: None,
+                destroy_requested_while_creating: false,
+            })),
         }
     }
 
     fn destroy_gui_session(&self) {
+        log::debug!("wxp controller: destroy_gui_session requested");
+        {
+            let mut state = self.runtime.lock();
+            if state.is_creating_runtime {
+                log::debug!("wxp controller: destroy_gui_session deferred during runtime creation");
+                let session = state.session.take();
+                state.generation = state.generation.wrapping_add(1);
+                state.destroy_requested_while_creating = true;
+                drop(state);
+                if drop_session(session) {
+                    self.note_runtime_destroyed();
+                }
+                return;
+            }
+        }
         let session = { self.runtime.lock().session.take() };
-        drop_session(session);
+        if drop_session(session) {
+            self.note_runtime_destroyed();
+        }
+        log::debug!("wxp controller: destroy_gui_session completed");
     }
 
-    fn create_runtime(
-        &self,
-        configuration: GuiConfiguration,
-        size: GuiSize,
-        parent: StoredParentWindow,
-        scale: f64,
-    ) -> PluginResult<GuiRuntimeHandle> {
-        let parent = parent.to_parent_window_handle()?;
-        let handle = create_gui_runtime_handle(|| {
-            self.factory.create_gui_runtime(configuration, size, parent)
-        })?;
-        if let Err(error) = handle.set_scale(scale) {
-            handle.destroy();
-            return Err(error);
-        }
-        Ok(handle)
+    fn note_runtime_destroyed(&self) {
+        self.runtime.lock().last_runtime_destroyed_at = Some(Instant::now());
     }
+
+    fn schedule_runtime_creation(&self, generation: u64) -> PluginResult<()> {
+        schedule_runtime_creation(
+            self.factory.clone(),
+            self.runtime.clone(),
+            self.layout.clone(),
+            generation,
+        )
+    }
+}
+
+fn schedule_runtime_creation(
+    factory: Arc<dyn WxpGuiFactory>,
+    runtime: Arc<Mutex<GuiRuntimeState>>,
+    layout: Arc<HostGuiLayout>,
+    generation: u64,
+) -> PluginResult<()> {
+    // Creation is intentionally asynchronous from the CLAP GUI callback. Running
+    // WebView creation inline makes host lifecycle reentrancy much more likely;
+    // posting it to the GUI run loop gives us one place to serialize creation,
+    // apply pending visibility/size state, and discard stale generations.
+    let (configuration, parent) = {
+        let mut state = runtime.lock();
+        if state.is_creating_runtime {
+            log::debug!(
+                "wxp controller: runtime creation pending while another creation is in progress: generation={generation}"
+            );
+            state.pending_creation_generation = Some(generation);
+            return Ok(());
+        }
+        let session = state.session.as_ref().ok_or(PluginError::InvalidState)?;
+        if session.generation != generation {
+            return Err(PluginError::InvalidState);
+        }
+        if session.handle.is_some() {
+            log::debug!(
+                "wxp controller: runtime creation skipped; runtime already exists: generation={generation}"
+            );
+            return Ok(());
+        }
+        let parent = session.parent.ok_or(PluginError::InvalidState)?;
+        let configuration = session.configuration;
+        state.is_creating_runtime = true;
+        state.creating_generation = Some(generation);
+        state.pending_creation_generation = None;
+        state.destroy_requested_while_creating = false;
+        (configuration, parent)
+    };
+
+    log::debug!("wxp controller: posting runtime creation: generation={generation}");
+    let factory_for_callback = factory.clone();
+    let runtime_for_callback = runtime.clone();
+    let layout_for_callback = layout.clone();
+    RunLoop::sender().send(move || {
+            log::debug!("wxp controller: posted runtime creation started: generation={generation}");
+            let result = create_runtime_on_gui_thread(
+                factory_for_callback.as_ref(),
+                runtime_for_callback.as_ref(),
+                layout_for_callback.as_ref(),
+                configuration,
+                parent,
+                generation,
+            );
+
+            let handle = match result {
+                Ok(handle) => handle,
+                Err(error) => {
+                    log::warn!(
+                        "wxp controller: posted runtime creation failed: generation={generation}, error={error:?}"
+                    );
+                    schedule_pending_runtime_creation(
+                        factory_for_callback,
+                        runtime_for_callback,
+                        layout_for_callback,
+                    );
+                    return;
+                }
+            };
+
+            let Some((visible, size, scale)) = latest_runtime_state(
+                runtime_for_callback.as_ref(),
+                layout_for_callback.as_ref(),
+                generation,
+            ) else {
+                log::debug!(
+                    "wxp controller: posted runtime creation produced stale runtime: generation={generation}"
+                );
+                handle.destroy();
+                runtime_for_callback.lock().last_runtime_destroyed_at = Some(Instant::now());
+                schedule_pending_runtime_creation(
+                    factory_for_callback,
+                    runtime_for_callback,
+                    layout_for_callback,
+                );
+                return;
+            };
+
+            if let Err(error) = handle.set_size(size) {
+                log::warn!(
+                    "wxp controller: posted runtime creation latest set_size failed: {error:?}"
+                );
+                handle.destroy();
+                runtime_for_callback.lock().last_runtime_destroyed_at = Some(Instant::now());
+                schedule_pending_runtime_creation(
+                    factory_for_callback,
+                    runtime_for_callback,
+                    layout_for_callback,
+                );
+                return;
+            }
+            if let Err(error) = handle.set_scale(scale) {
+                log::warn!(
+                    "wxp controller: posted runtime creation latest set_scale failed: {error:?}"
+                );
+                handle.destroy();
+                runtime_for_callback.lock().last_runtime_destroyed_at = Some(Instant::now());
+                schedule_pending_runtime_creation(
+                    factory_for_callback,
+                    runtime_for_callback,
+                    layout_for_callback,
+                );
+                return;
+            }
+
+            if !visible {
+                log::debug!("wxp controller: posted runtime creation hiding initially hidden runtime");
+                if let Err(error) = handle.hide() {
+                    log::warn!(
+                        "wxp controller: posted runtime creation initial hide failed: {error:?}"
+                    );
+                    handle.destroy();
+                    runtime_for_callback.lock().last_runtime_destroyed_at = Some(Instant::now());
+                    schedule_pending_runtime_creation(
+                        factory_for_callback,
+                        runtime_for_callback,
+                        layout_for_callback,
+                    );
+                    return;
+                }
+            }
+
+            let mut state = runtime_for_callback.lock();
+            let Some(session) = state.session.as_mut() else {
+                drop(state);
+                handle.destroy();
+                runtime_for_callback.lock().last_runtime_destroyed_at = Some(Instant::now());
+                schedule_pending_runtime_creation(
+                    factory_for_callback,
+                    runtime_for_callback,
+                    layout_for_callback,
+                );
+                return;
+            };
+            if session.generation != generation {
+                drop(state);
+                handle.destroy();
+                runtime_for_callback.lock().last_runtime_destroyed_at = Some(Instant::now());
+                schedule_pending_runtime_creation(
+                    factory_for_callback,
+                    runtime_for_callback,
+                    layout_for_callback,
+                );
+                return;
+            }
+            if let Some(old_handle) = session.handle.replace(handle) {
+                log::debug!(
+                    "wxp controller: destroying previous runtime before replacing handle: generation={generation}"
+                );
+                drop(state);
+                old_handle.destroy();
+                runtime_for_callback.lock().last_runtime_destroyed_at = Some(Instant::now());
+                schedule_pending_runtime_creation(
+                    factory_for_callback,
+                    runtime_for_callback,
+                    layout_for_callback,
+                );
+                return;
+            }
+            if state.pending_creation_generation == Some(generation) {
+                log::debug!(
+                    "wxp controller: dropping redundant pending runtime creation: generation={generation}"
+                );
+                state.pending_creation_generation = None;
+            }
+            log::debug!("wxp controller: posted runtime creation completed: generation={generation}");
+            drop(state);
+            schedule_pending_runtime_creation(
+                factory_for_callback,
+                runtime_for_callback,
+                layout_for_callback,
+            );
+        });
+    Ok(())
+}
+
+fn schedule_pending_runtime_creation(
+    factory: Arc<dyn WxpGuiFactory>,
+    runtime: Arc<Mutex<GuiRuntimeState>>,
+    layout: Arc<HostGuiLayout>,
+) {
+    let pending_generation = {
+        let mut state = runtime.lock();
+        let pending = state.pending_creation_generation.take();
+        if let Some(generation) = pending
+            && state
+                .session
+                .as_ref()
+                .is_some_and(|session| session.generation == generation && session.handle.is_some())
+        {
+            log::debug!(
+                "wxp controller: pending runtime creation skipped; runtime already exists: generation={generation}"
+            );
+            None
+        } else {
+            pending
+        }
+    };
+    let Some(generation) = pending_generation else {
+        return;
+    };
+    log::debug!("wxp controller: scheduling pending runtime creation: generation={generation}");
+    if let Err(error) = schedule_runtime_creation(factory, runtime, layout, generation) {
+        log::warn!("wxp controller: pending runtime creation was dropped: {error:?}");
+    }
+}
+
+fn create_runtime_on_gui_thread(
+    factory: &dyn WxpGuiFactory,
+    runtime: &Mutex<GuiRuntimeState>,
+    layout: &HostGuiLayout,
+    configuration: GuiConfiguration,
+    parent: StoredParentWindow,
+    generation: u64,
+) -> PluginResult<GuiRuntimeHandle> {
+    let (size, scale) = latest_runtime_creation_inputs(runtime, layout, generation)
+        .ok_or(PluginError::InvalidState)?;
+    log::debug!(
+        "wxp controller: create_runtime start: generation={}, width={}, height={}, scale={}, configuration={configuration:?}",
+        generation,
+        size.width,
+        size.height,
+        scale
+    );
+    let Some(wait_duration) = runtime
+        .lock()
+        .last_runtime_destroyed_at
+        .and_then(|at| WEBVIEW_RECREATE_QUIET_PERIOD.checked_sub(at.elapsed()))
+    else {
+        return create_runtime_after_wait(
+            factory,
+            runtime,
+            configuration,
+            size,
+            parent,
+            scale,
+            generation,
+        );
+    };
+    log::debug!(
+        "wxp controller: waiting before WebView recreate: {}ms",
+        wait_duration.as_millis()
+    );
+    std::thread::sleep(wait_duration);
+    log::debug!("wxp controller: WebView recreate wait completed");
+    let (size, scale) = latest_runtime_creation_inputs(runtime, layout, generation)
+        .ok_or(PluginError::InvalidState)?;
+    create_runtime_after_wait(
+        factory,
+        runtime,
+        configuration,
+        size,
+        parent,
+        scale,
+        generation,
+    )
+}
+
+fn create_runtime_after_wait(
+    factory: &dyn WxpGuiFactory,
+    runtime: &Mutex<GuiRuntimeState>,
+    configuration: GuiConfiguration,
+    size: GuiSize,
+    parent: StoredParentWindow,
+    scale: f64,
+    generation: u64,
+) -> PluginResult<GuiRuntimeHandle> {
+    let parent = parent.to_parent_window_handle()?;
+    log::debug!("wxp controller: parent handle converted");
+    let handle =
+        match create_gui_runtime_handle(|| factory.create_gui_runtime(configuration, size, parent))
+        {
+            Ok(handle) => handle,
+            Err(error) => {
+                let mut state = runtime.lock();
+                if state.creating_generation == Some(generation) {
+                    state.is_creating_runtime = false;
+                    state.creating_generation = None;
+                    state.pending_creation_generation = None;
+                    state.destroy_requested_while_creating = false;
+                }
+                return Err(error);
+            }
+        };
+    log::debug!("wxp controller: runtime handle created");
+    if finish_runtime_creation_requested_destroy(runtime, generation) {
+        log::debug!(
+            "wxp controller: destroying newly created runtime after stale/deferred destroy"
+        );
+        handle.destroy();
+        runtime.lock().last_runtime_destroyed_at = Some(Instant::now());
+        return Err(PluginError::InvalidState);
+    }
+    if let Err(error) = handle.set_scale(scale) {
+        log::warn!("wxp controller: initial set_scale failed: {error:?}");
+        handle.destroy();
+        return Err(error);
+    }
+    log::debug!("wxp controller: create_runtime completed");
+    Ok(handle)
+}
+
+fn latest_runtime_creation_inputs(
+    runtime: &Mutex<GuiRuntimeState>,
+    layout: &HostGuiLayout,
+    generation: u64,
+) -> Option<(GuiSize, f64)> {
+    let state = runtime.lock();
+    let session = state.session.as_ref()?;
+    if session.generation != generation {
+        return None;
+    }
+    Some((layout.accepted_size(), session.scale))
+}
+
+fn latest_runtime_state(
+    runtime: &Mutex<GuiRuntimeState>,
+    layout: &HostGuiLayout,
+    generation: u64,
+) -> Option<(bool, GuiSize, f64)> {
+    let state = runtime.lock();
+    let session = state.session.as_ref()?;
+    if session.generation != generation {
+        return None;
+    }
+    Some((session.visible, layout.accepted_size(), session.scale))
+}
+
+fn finish_runtime_creation_requested_destroy(
+    runtime: &Mutex<GuiRuntimeState>,
+    generation: u64,
+) -> bool {
+    let mut state = runtime.lock();
+    let session_is_stale = match state.session.as_ref() {
+        Some(session) => session.generation != generation,
+        None => true,
+    };
+    let should_destroy = state.destroy_requested_while_creating || session_is_stale;
+    if state.creating_generation == Some(generation) {
+        state.is_creating_runtime = false;
+        state.creating_generation = None;
+        if should_destroy {
+            state.pending_creation_generation =
+                state.session.as_ref().map(|session| session.generation);
+        }
+        state.destroy_requested_while_creating = false;
+    }
+    should_destroy
 }
 
 impl HostGuiLayout {
@@ -235,29 +637,42 @@ impl PluginGui for WxpGuiController {
     }
 
     fn create(&self, configuration: GuiConfiguration) -> PluginResult<()> {
+        log::debug!("wxp controller: create called: configuration={configuration:?}");
         if !self.is_api_supported(configuration.api, configuration.is_floating) {
+            log::debug!("wxp controller: create rejected unsupported configuration");
             return Err(PluginError::Message("unsupported GUI configuration"));
         }
         self.destroy_gui_session();
         let scale = *self.scale.lock();
-        self.runtime.lock().session = Some(GuiSession {
-            configuration,
-            scale,
-            parent: None,
-            parent_lease: None,
-            handle: None,
-            // 一部 wrapper は embedded view を parent に付けた時点で表示扱いにし、`show()`
-            // を呼ばない。初回 parent attach は表示状態として扱い、明示的な `hide()` を優先する。
-            visible: true,
-        });
+        let generation = {
+            let mut state = self.runtime.lock();
+            state.generation = state.generation.wrapping_add(1);
+            let generation = state.generation;
+            state.session = Some(GuiSession {
+                generation,
+                configuration,
+                scale,
+                parent: None,
+                parent_lease: None,
+                handle: None,
+                // 一部 wrapper は embedded view を parent に付けた時点で表示扱いにし、`show()`
+                // を呼ばない。初回 parent attach は表示状態として扱い、明示的な `hide()` を優先する。
+                visible: true,
+            });
+            generation
+        };
+        log::debug!("wxp controller: create completed: generation={generation}");
         Ok(())
     }
 
     fn destroy(&self) {
+        log::debug!("wxp controller: destroy called");
         self.destroy_gui_session();
+        log::debug!("wxp controller: destroy completed");
     }
 
     fn set_scale(&self, scale: f64) -> PluginResult<()> {
+        log::debug!("wxp controller: set_scale called: scale={scale}");
         let handle = {
             let mut state = self.runtime.lock();
             if let Some(session) = &mut state.session {
@@ -271,11 +686,18 @@ impl PluginGui for WxpGuiController {
             handle.set_scale(scale)?;
         }
         *self.scale.lock() = scale;
+        log::debug!("wxp controller: set_scale completed");
         Ok(())
     }
 
     fn get_size(&self) -> PluginResult<GuiSize> {
-        Ok(self.layout.accepted_size())
+        let size = self.layout.accepted_size();
+        log::debug!(
+            "wxp controller: get_size called: width={}, height={}",
+            size.width,
+            size.height
+        );
+        Ok(size)
     }
 
     fn can_resize(&self) -> bool {
@@ -291,6 +713,11 @@ impl PluginGui for WxpGuiController {
     }
 
     fn set_size(&self, size: GuiSize) -> PluginResult<()> {
+        log::debug!(
+            "wxp controller: set_size called: requested_width={}, requested_height={}",
+            size.width,
+            size.height
+        );
         let size = self.layout.clamp_size(size);
         let handle = {
             self.runtime
@@ -303,84 +730,84 @@ impl PluginGui for WxpGuiController {
             handle.set_size(size)?;
         }
         self.layout.store_accepted_size(size);
+        log::debug!(
+            "wxp controller: set_size completed: applied_width={}, applied_height={}",
+            size.width,
+            size.height
+        );
         Ok(())
     }
 
     fn set_parent(&self, window: ClapWindow) -> PluginResult<()> {
+        log::debug!("wxp controller: set_parent called");
         let parent = StoredParentWindow::from_clap_window(window);
-        let needs_parent_lease = {
+        let (generation, needs_parent_lease) = {
             let state = self.runtime.lock();
             let session = state.session.as_ref().ok_or(PluginError::InvalidState)?;
-            if session.parent.is_some() {
+            let needs_parent_lease = if session.parent.is_some() {
                 if !is_gui_thread() {
+                    log::debug!("wxp controller: set_parent rejected non-GUI thread reparent");
                     return Err(PluginError::UnsupportedHostGuiThreadingModel);
                 }
                 false
             } else {
                 true
-            }
+            };
+            (session.generation, needs_parent_lease)
         };
+        log::debug!(
+            "wxp controller: set_parent needs_parent_lease={needs_parent_lease}, generation={generation}"
+        );
 
         let parent_lease = needs_parent_lease
             .then(GuiThreadLease::acquire)
             .transpose()?;
+        log::debug!("wxp controller: set_parent parent lease acquired");
 
         let old_handle = {
             let mut state = self.runtime.lock();
             let session = state.session.as_mut().ok_or(PluginError::InvalidState)?;
+            if session.generation != generation {
+                drop(parent_lease);
+                return Err(PluginError::InvalidState);
+            }
             // parent handle が変わると、既存 child WebView を安全に reparent できる保証が
             // wxp/wry 側にない。古い runtime を先に落として、新しい parent 上に作り直す。
             session.handle.take()
         };
         if let Some(handle) = old_handle {
+            log::debug!("wxp controller: set_parent destroying old runtime before reparent");
             handle.destroy();
+            self.note_runtime_destroyed();
+            log::debug!("wxp controller: set_parent old runtime destroyed");
         }
 
-        let (configuration, size, scale, visible) = {
+        {
             let state = self.runtime.lock();
             let session = state.session.as_ref().ok_or(PluginError::InvalidState)?;
-            (
-                session.configuration,
-                self.layout.accepted_size(),
-                session.scale,
-                session.visible,
-            )
-        };
-        // CLAP の GUI spec 上は `show()` が表示開始の合図だが、clap-wrapper の AUv2
-        // 経由では Logic Pro が embedded view を parent に付けた時点で表示扱いにし、
-        // `show()` を呼ばない経路がある。WebView 作成は parent が必要なのでここで行う。
-        let handle = match self.create_runtime(configuration, size, parent, scale) {
-            Ok(handle) => handle,
-            Err(error) => {
-                if needs_parent_lease {
-                    let mut state = self.runtime.lock();
-                    if let Some(session) = &mut state.session {
-                        session.parent = None;
-                        session.parent_lease = None;
-                    }
-                }
-                // parent attach 失敗後に parent lease だけ残ると、次回 GUI session が別 thread
-                // から来た時に不要に拒否される。失敗した attach は状態を進めない。
+            if session.generation != generation {
                 drop(parent_lease);
-                return Err(error);
-            }
-        };
-        if !visible {
-            if let Err(error) = handle.hide() {
-                // hidden 初期化に失敗した runtime は、session に入れず破棄する。半端な handle を
-                // 残すと以降の `show()`/`destroy()` が失敗済み WebView を操作してしまう。
-                handle.destroy();
-                drop(parent_lease);
-                return Err(error);
+                return Err(PluginError::InvalidState);
             }
         }
         let mut state = self.runtime.lock();
         let session = state.session.as_mut().ok_or(PluginError::InvalidState)?;
+        if session.generation != generation {
+            drop(state);
+            drop(parent_lease);
+            return Err(PluginError::InvalidState);
+        }
         session.parent = Some(parent);
         if let Some(parent_lease) = parent_lease {
             session.parent_lease = Some(parent_lease);
         }
-        session.handle = Some(handle);
+        drop(state);
+        // This only accepts the parent and schedules native WebView creation. The
+        // actual creation must stay off the host lifecycle callback to avoid
+        // reentrant create/destroy sequences; failures are logged and leave the
+        // session without a runtime so a later show/set_parent can schedule again.
+        self.schedule_runtime_creation(generation)?;
+        log::debug!("wxp controller: set_parent completed");
         Ok(())
     }
 
@@ -391,71 +818,86 @@ impl PluginGui for WxpGuiController {
     fn suggest_title(&self, _title: &str) {}
 
     fn show(&self) -> PluginResult<()> {
+        log::debug!("wxp controller: show called");
         let action = {
             let state = self.runtime.lock();
             let session = state.session.as_ref().ok_or(PluginError::InvalidState)?;
             if let Some(handle) = session.handle.clone() {
-                ShowAction::ShowExisting(handle)
+                ShowAction::ShowExisting {
+                    handle,
+                    generation: session.generation,
+                }
             } else {
                 let parent = session.parent.ok_or(PluginError::InvalidState)?;
+                let _ = parent;
                 ShowAction::Create {
-                    configuration: session.configuration,
-                    size: self.layout.accepted_size(),
-                    parent,
-                    scale: session.scale,
+                    generation: session.generation,
                 }
             }
         };
 
         match action {
-            ShowAction::ShowExisting(handle) => {
+            ShowAction::ShowExisting { handle, generation } => {
+                log::debug!("wxp controller: show existing runtime");
                 handle.show()?;
-                if let Some(session) = &mut self.runtime.lock().session {
+                if let Some(session) = &mut self.runtime.lock().session
+                    && session.generation == generation
+                {
                     session.visible = true;
                 }
+                log::debug!("wxp controller: show completed on existing runtime");
                 Ok(())
             }
-            ShowAction::Create {
-                configuration,
-                size,
-                parent,
-                scale,
-            } => {
-                let handle = self.create_runtime(configuration, size, parent, scale)?;
-                handle.show()?;
-                let mut state = self.runtime.lock();
-                let session = state.session.as_mut().ok_or(PluginError::InvalidState)?;
-                session.handle = Some(handle);
-                session.visible = true;
+            ShowAction::Create { generation } => {
+                log::debug!("wxp controller: show scheduling runtime creation");
+                self.schedule_runtime_creation(generation)?;
+                if let Some(session) = &mut self.runtime.lock().session
+                    && session.generation == generation
+                {
+                    session.visible = true;
+                }
+                log::debug!("wxp controller: show completed by scheduled runtime creation");
                 Ok(())
             }
         }
     }
 
     fn hide(&self) -> PluginResult<()> {
-        let handle = {
+        log::debug!("wxp controller: hide called");
+        let (generation, handle) = {
             let state = self.runtime.lock();
             let session = state.session.as_ref().ok_or(PluginError::InvalidState)?;
-            session.handle.clone()
+            (session.generation, session.handle.clone())
         };
         if let Some(handle) = handle {
             handle.hide()?;
         }
-        if let Some(session) = &mut self.runtime.lock().session {
+        if let Some(session) = &mut self.runtime.lock().session
+            && session.generation == generation
+        {
             session.visible = false;
         }
+        log::debug!("wxp controller: hide completed");
         Ok(())
     }
 }
 
-fn drop_session(session: Option<GuiSession>) {
+fn drop_session(session: Option<GuiSession>) -> bool {
     if let Some(mut session) = session {
+        log::debug!("wxp controller: drop_session start");
+        let mut destroyed_runtime = false;
         if let Some(handle) = session.handle.take() {
             handle.destroy();
+            destroyed_runtime = true;
         }
         // runtime drop が終わってから parent lease を解放する。timer stop や WebView teardown が
         // run loop 上で完了する前に owner thread を解放しないため。
         drop(session.parent_lease.take());
+        log::debug!("wxp controller: drop_session completed");
+        destroyed_runtime
+    } else {
+        log::debug!("wxp controller: drop_session skipped; no active session");
+        false
     }
 }
 
@@ -473,12 +915,12 @@ impl Drop for WxpGuiController {
 }
 
 enum ShowAction {
-    ShowExisting(GuiRuntimeHandle),
+    ShowExisting {
+        handle: GuiRuntimeHandle,
+        generation: u64,
+    },
     Create {
-        configuration: GuiConfiguration,
-        size: GuiSize,
-        parent: StoredParentWindow,
-        scale: f64,
+        generation: u64,
     },
 }
 

--- a/crates/wrac_wxp_gui/src/runtime.rs
+++ b/crates/wrac_wxp_gui/src/runtime.rs
@@ -97,65 +97,92 @@ pub(crate) struct GuiRuntimeHandle {
 pub(crate) fn create_gui_runtime_handle(
     create: impl FnOnce() -> PluginResult<Box<dyn WxpGuiRuntime>>,
 ) -> PluginResult<GuiRuntimeHandle> {
+    log::debug!("wxp runtime: acquiring GUI thread lease");
     let lease = GuiThreadLease::acquire()?;
     // `create` が失敗した場合、lease はここで drop される。失敗した runtime 作成が
     // GUI thread ref を残さないことを型の drop 順で保証する。
     match create() {
-        Ok(runtime) => Ok(insert_gui_runtime(runtime, lease)),
-        Err(error) => Err(error),
+        Ok(runtime) => {
+            log::debug!("wxp runtime: factory returned runtime");
+            Ok(insert_gui_runtime(runtime, lease))
+        }
+        Err(error) => {
+            log::warn!("wxp runtime: factory failed: {error:?}");
+            Err(error)
+        }
     }
 }
 
 impl GuiRuntimeHandle {
     pub(crate) fn destroy(self) {
         let id = self.id;
+        log::debug!("wxp runtime {id}: destroy requested");
         self.sender.send_and_wait(move || {
+            log::debug!("wxp runtime {id}: removing runtime from GUI thread");
             GUI_RUNTIMES.with(|runtimes| {
                 runtimes.borrow_mut().remove(&id);
             });
+            log::debug!("wxp runtime {id}: removed runtime from GUI thread");
         });
+        log::debug!("wxp runtime {id}: destroy completed");
     }
 
     pub(crate) fn set_scale(&self, scale: f64) -> PluginResult<()> {
         let id = self.id;
+        log::debug!("wxp runtime {id}: set_scale requested: scale={scale}");
         self.sender.send_and_wait(move || {
             GUI_RUNTIMES.with(|runtimes| {
                 let mut runtimes = runtimes.borrow_mut();
                 let entry = runtimes.get_mut(&id).ok_or(PluginError::InvalidState)?;
-                entry.runtime.set_scale(scale)
+                let result = entry.runtime.set_scale(scale);
+                log::debug!("wxp runtime {id}: set_scale completed: result={result:?}");
+                result
             })
         })
     }
 
     pub(crate) fn set_size(&self, size: GuiSize) -> PluginResult<()> {
         let id = self.id;
+        log::debug!(
+            "wxp runtime {id}: set_size requested: width={}, height={}",
+            size.width,
+            size.height
+        );
         self.sender.send_and_wait(move || {
             GUI_RUNTIMES.with(|runtimes| {
                 let mut runtimes = runtimes.borrow_mut();
                 let entry = runtimes.get_mut(&id).ok_or(PluginError::InvalidState)?;
-                entry.runtime.set_size(size)
+                let result = entry.runtime.set_size(size);
+                log::debug!("wxp runtime {id}: set_size completed: result={result:?}");
+                result
             })
         })
     }
 
     pub(crate) fn show(&self) -> PluginResult<()> {
         let id = self.id;
+        log::debug!("wxp runtime {id}: show requested");
         self.sender.send_and_wait(move || {
             GUI_RUNTIMES.with(|runtimes| {
                 let mut runtimes = runtimes.borrow_mut();
                 let entry = runtimes.get_mut(&id).ok_or(PluginError::InvalidState)?;
-                entry.runtime.show()
+                let result = entry.runtime.show();
+                log::debug!("wxp runtime {id}: show completed: result={result:?}");
+                result
             })
         })
     }
 
     pub(crate) fn hide(&self) -> PluginResult<()> {
         let id = self.id;
+        log::debug!("wxp runtime {id}: hide requested");
         self.sender.send_and_wait(move || {
             GUI_RUNTIMES.with(|runtimes| {
                 let mut runtimes = runtimes.borrow_mut();
                 let entry = runtimes.get_mut(&id).ok_or(PluginError::InvalidState)?;
-                entry.runtime.hide()
+                let result = entry.runtime.hide();
+                log::debug!("wxp runtime {id}: hide completed: result={result:?}");
+                result
             })
         })
     }
@@ -163,6 +190,7 @@ impl GuiRuntimeHandle {
 
 fn insert_gui_runtime(runtime: Box<dyn WxpGuiRuntime>, lease: GuiThreadLease) -> GuiRuntimeHandle {
     let id = NEXT_GUI_ID.fetch_add(1, Ordering::Relaxed);
+    log::debug!("wxp runtime {id}: inserting runtime on GUI thread");
     GUI_RUNTIMES.with(|runtimes| {
         runtimes.borrow_mut().insert(
             id,
@@ -172,6 +200,7 @@ fn insert_gui_runtime(runtime: Box<dyn WxpGuiRuntime>, lease: GuiThreadLease) ->
             },
         );
     });
+    log::debug!("wxp runtime {id}: inserted runtime on GUI thread");
     GuiRuntimeHandle {
         id,
         sender: RunLoop::sender(),
@@ -181,15 +210,20 @@ fn insert_gui_runtime(runtime: Box<dyn WxpGuiRuntime>, lease: GuiThreadLease) ->
 impl GuiThreadLease {
     pub(crate) fn acquire() -> PluginResult<Self> {
         let current_thread = std::thread::current().id();
+        log::debug!("wxp GUI thread lease: acquire requested on thread {current_thread:?}");
         let mut gui_thread = GUI_THREAD_STATE.lock();
         match gui_thread.owner {
             Some(owner_thread) if owner_thread != current_thread => {
+                log::debug!(
+                    "wxp GUI thread lease: rejecting thread {current_thread:?}; owner is {owner_thread:?}"
+                );
                 return Err(PluginError::UnsupportedHostGuiThreadingModel);
             }
             Some(_) | None => {}
         }
 
         if RunLoop::init().is_err() {
+            log::debug!("wxp GUI thread lease: RunLoop::init failed");
             return Err(PluginError::UnsupportedHostGuiThreadingModel);
         }
 
@@ -197,20 +231,31 @@ impl GuiThreadLease {
         // 完全 rollback する保証はまだないため、少なくともこちらの SoT は汚さない。
         gui_thread.owner = Some(current_thread);
         gui_thread.ref_count += 1;
+        log::debug!(
+            "wxp GUI thread lease: acquired on thread {current_thread:?}; ref_count={}",
+            gui_thread.ref_count
+        );
         Ok(Self)
     }
 }
 
 impl Drop for GuiThreadLease {
     fn drop(&mut self) {
+        let current_thread = std::thread::current().id();
+        log::debug!("wxp GUI thread lease: dropping on thread {current_thread:?}");
         RunLoop::deinit();
         let mut gui_thread = GUI_THREAD_STATE.lock();
         debug_assert!(gui_thread.ref_count > 0);
         gui_thread.ref_count = gui_thread.ref_count.saturating_sub(1);
+        log::debug!(
+            "wxp GUI thread lease: dropped on thread {current_thread:?}; ref_count={}",
+            gui_thread.ref_count
+        );
         if gui_thread.ref_count == 0 {
             // 最後の runtime だけでなく `set_parent()` 由来の thread 固定も解放された時点で、
             // 次の GUI session が別 host window から来ることを許可する。
             gui_thread.owner = None;
+            log::debug!("wxp GUI thread lease: owner cleared");
         }
     }
 }

--- a/src-plugin/Cargo.toml
+++ b/src-plugin/Cargo.toml
@@ -14,6 +14,7 @@ crate-type = ["rlib", "staticlib", "cdylib"]
 [dependencies]
 assert_no_alloc = { git = "https://github.com/Windfisch/rust-assert-no-alloc.git", rev = "d31f2d5f550ce339d1c2f0c1ab7da951224b20df", features = ["backtrace"] }
 atomic_float = "1.1.0"
+directories = "5"
 log = "0.4"
 novonotes_run_loop = { git = "https://github.com/novonotes/run_loop.git", rev = "2779a6400cc99a8728052ba4df1c475a492849de" }
 parking_lot = "0.12"

--- a/src-plugin/src/gui.rs
+++ b/src-plugin/src/gui.rs
@@ -12,11 +12,13 @@
 //!   command、resize/scale の挙動など、製品ごとに変わる部分だけを書く
 
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
+use directories::ProjectDirs;
 use novonotes_run_loop::{RunLoop, RunLoopSender};
 use parking_lot::Mutex;
 use run_loop_timer::Timer;
@@ -34,7 +36,7 @@ use wxp::{
 };
 
 use crate::commands::register_commands;
-use crate::plugin::{PARAM_GAIN_ID, parameter_value_text};
+use crate::plugin::{PARAM_GAIN_ID, PLUGIN_ID, parameter_value_text};
 use crate::state::SharedState;
 
 // GUI window のサイズ範囲 (pixel)。host は initial size でウインドウを開き、
@@ -271,13 +273,15 @@ impl WracGainGuiRuntime {
             return Err(PluginError::Message("unsupported GUI configuration"));
         }
         log::debug!(
-            "creating GUI runtime: width={}, height={}",
+            "creating GUI runtime: width={}, height={}, configuration={configuration:?}",
             initial_size.width,
             initial_size.height
         );
 
         // WebView から呼べる parameter command を登録する。
+        log::debug!("creating GUI runtime: creating command handler");
         let command_handler = Rc::new(WxpCommandHandler::new());
+        log::debug!("creating GUI runtime: registering commands");
         register_commands(
             command_handler.clone(),
             dependencies.shared.clone(),
@@ -286,18 +290,26 @@ impl WracGainGuiRuntime {
             dependencies.host_gui_resize_requester,
             dependencies.resize_handle,
         );
+        log::debug!("creating GUI runtime: commands registered");
 
-        // WebView の cache/cookie などを置く data directory。
-        let data_dir = std::env::temp_dir().join("wrac-gain-plugin");
+        // WebView2 は同じ user data folder を別の Environment options で共有すると作成に
+        // 失敗し得るため、OS 標準のアプリデータ配下に plugin ID 単位で分離する。
+        let data_dir = webview_data_dir(PLUGIN_ID);
         std::fs::create_dir_all(&data_dir)
             .map_err(|_| PluginError::Message("failed to create GUI data directory"))?;
         log::debug!("using GUI data directory: {}", data_dir.display());
 
+        log::debug!("creating GUI runtime: creating WebContext");
         let mut wxp_context = WebContext::new(data_dir);
         // 初期 scale は 1.0 とし、後で host から `set_scale` で書き換えられる。
         let dpi_converter = DpiConverter::new(1.0);
         let gui_size = gui_size_to_logical(initial_size);
         let bounds = dpi_converter.create_webview_bounds(gui_size);
+        log::debug!(
+            "creating GUI runtime: computed logical size: width={}, height={}",
+            gui_size.width,
+            gui_size.height
+        );
 
         // debug build では Vite dev server を見るので、frontend を変更しても
         // native plugin の再 build が不要になり開発体験が良くなる。
@@ -306,6 +318,7 @@ impl WracGainGuiRuntime {
         #[cfg(debug_assertions)]
         let builder = {
             let url = "http://127.0.0.1:5173/";
+            log::debug!("creating GUI runtime: configuring debug WebView builder: url={url}");
             WxpWebViewBuilder::new(&mut wxp_context)
                 .with_command_handler(command_handler.clone())
                 .with_devtools(cfg!(debug_assertions))
@@ -317,6 +330,7 @@ impl WracGainGuiRuntime {
         #[cfg(not(debug_assertions))]
         let builder = {
             let url = "wxp-plugin://localhost/";
+            log::debug!("creating GUI runtime: configuring release WebView builder: url={url}");
             WxpWebViewBuilder::new(&mut wxp_context)
                 .with_command_handler(command_handler.clone())
                 .with_devtools(cfg!(debug_assertions))
@@ -329,9 +343,11 @@ impl WracGainGuiRuntime {
         };
 
         // parent window 上に子として WebView を作る。これで host UI に埋め込まれる。
+        log::debug!("creating GUI runtime: build_as_child start");
         let web_view = builder
             .build_as_child(&parent)
             .map_err(|_| PluginError::Message("failed to build webview"))?;
+        log::debug!("creating GUI runtime: build_as_child completed");
 
         // 33ms ≒ 30Hz で現在値を GUI に流す。サンプルでは値が変わったかの dirty
         // flag を持たず、GUI runtime が shared state を読む形にしておく方が構造を
@@ -348,8 +364,11 @@ impl WracGainGuiRuntime {
                 gui_notifier.notify_parameter(PARAM_GAIN_ID, shared.gain());
             }
         });
+        log::debug!("creating GUI runtime: starting GUI update timer");
         gui_update_timer.start();
+        log::debug!("creating GUI runtime: GUI update timer started");
 
+        log::debug!("creating GUI runtime: completed");
         Ok(Self {
             gui_notifier: dependencies.gui_notifier,
             web_view: Some(web_view),
@@ -399,24 +418,52 @@ impl WxpGuiRuntime for WracGainGuiRuntime {
     }
 
     fn show(&mut self) -> PluginResult<()> {
+        log::debug!("showing GUI runtime");
         if let Some(web_view) = &self.web_view {
             web_view
                 .set_visible(true)
                 .map_err(|_| PluginError::Message("failed to show webview"))?;
         }
         self.gui_update_timer.start();
+        log::debug!("showing GUI runtime completed");
         Ok(())
     }
 
     fn hide(&mut self) -> PluginResult<()> {
+        log::debug!("hiding GUI runtime");
         self.gui_update_timer.stop();
         if let Some(web_view) = &self.web_view {
             web_view
                 .set_visible(false)
                 .map_err(|_| PluginError::Message("failed to hide webview"))?;
         }
+        log::debug!("hiding GUI runtime completed");
         Ok(())
     }
+}
+
+fn webview_data_dir(plugin_id: &str) -> PathBuf {
+    let plugin_dir = sanitize_plugin_data_dir(plugin_id);
+    match ProjectDirs::from("com", "your-company", "wrac-gain") {
+        Some(dirs) => dirs.data_dir().join("webview").join(plugin_dir),
+        None => std::env::temp_dir()
+            .join("wrac-gain-plugin")
+            .join("webview")
+            .join(plugin_dir),
+    }
+}
+
+fn sanitize_plugin_data_dir(plugin_id: &str) -> String {
+    plugin_id
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || matches!(character, '.' | '-') {
+                character
+            } else {
+                '_'
+            }
+        })
+        .collect()
 }
 
 // host が GUI を閉じると runtime が drop される。
@@ -428,11 +475,15 @@ impl Drop for WracGainGuiRuntime {
         // timer callback は run loop と GUI subscription に依存する。native WebView を
         // 落とす前に止めて、破棄途中の GUI state を tick が見る余地をなくす。
         self.gui_update_timer.stop();
+        log::debug!("dropping GUI runtime: timer stopped");
         // GUI が消えるので、shared state からも channel を外しておく。
         self.gui_notifier.clear_subscriptions();
+        log::debug!("dropping GUI runtime: subscriptions cleared");
         // WebView → WebContext の順で drop。逆だと wry が context 不在で panic することがある。
         self.web_view = None;
+        log::debug!("dropping GUI runtime: webview dropped");
         self.wxp_context = None;
+        log::debug!("dropping GUI runtime: web context dropped");
         // `command_handler` と `gui_update_timer` は field drop に任せる。
         // 下記 2 行は「ここまで生かしたい」ことを明示するためのダミー read。
         let _ = Rc::strong_count(&self.command_handler);

--- a/src-plugin/src/lib.rs
+++ b/src-plugin/src/lib.rs
@@ -31,7 +31,6 @@ static ALLOC_DISABLER: AllocDisabler = AllocDisabler;
 mod audio;
 mod commands;
 mod gui;
-#[cfg(debug_assertions)]
 mod logging;
 mod plugin;
 mod state;

--- a/src-plugin/src/logging.rs
+++ b/src-plugin/src/logging.rs
@@ -126,12 +126,7 @@ fn open_log_file(path: &Path) -> Option<File> {
         }
     }
 
-    match OpenOptions::new()
-        .create(true)
-        .write(true)
-        .truncate(true)
-        .open(path)
-    {
+    match OpenOptions::new().create(true).append(true).open(path) {
         Ok(file) => Some(file),
         Err(error) => {
             eprintln!(

--- a/src-plugin/src/plugin.rs
+++ b/src-plugin/src/plugin.rs
@@ -129,7 +129,6 @@ impl WracGainPlugin {
 /// host が新しい plugin instance を必要としたタイミングで adapter が呼び出し、
 /// trait object として [`PluginCore`] を返す。実装の差し替えはここを変えるだけ。
 pub(crate) fn create_plugin_core(context: PluginCoreContext) -> Box<dyn PluginCore> {
-    #[cfg(debug_assertions)]
     crate::logging::init_debug_logging_once(PLUGIN_DESCRIPTOR.name);
 
     log::debug!(


### PR DESCRIPTION
## Summary

- Serialize WRAC GUI runtime creation so rapid editor open/close requests do not overlap native WebView creation and teardown.
- Persist WebView user data under the plugin's application data directory and keep plugin logs appended across sessions.
- Update the locked `wxp` dependency to the latest `main`, which includes the merged `wry` WebView2 creation fix.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`