### PR TITLE
Enable Linux VST3 artifact validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
             validate-targets: vst3
             verify: |
               test -f "target/wrac/plugins/release/WRAC Gain.clap"
-              test -f "target/wrac/plugins/release/WRAC Gain.vst3"
+              test -d "target/wrac/plugins/release/WRAC Gain.vst3"
           - os: windows-latest
             targets: clap,vst3,standalone
             validate-targets: vst3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,10 +84,11 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            targets: clap
-            validate-targets: ""
+            targets: clap,vst3
+            validate-targets: vst3
             verify: |
               test -f "target/wrac/plugins/release/WRAC Gain.clap"
+              test -f "target/wrac/plugins/release/WRAC Gain.vst3"
           - os: windows-latest
             targets: clap,vst3,standalone
             validate-targets: vst3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
     name: Rust lint and test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
 
+    # Keep clippy and tests in one per-OS job so both checks share the same
+    # checkout and compiled dependency graph. Splitting them would make the CI
+    # shape look cleaner, but would duplicate setup and much of the Rust build.
     strategy:
       fail-fast: false
       matrix:
@@ -73,7 +76,7 @@ jobs:
         run: cargo test --locked --workspace
 
   plugin-build:
-    name: Build plugin artifacts (${{ matrix.os }})
+    name: Plugin artifact validation (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     needs:
       - rust-format

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtkmm-3.0-dev
 
       - name: Show Rust version
         run: |
@@ -115,7 +115,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtkmm-3.0-dev
 
       - name: Add msbuild to PATH
         if: runner.os == 'Windows'

--- a/clap_wrapper_builder/CMakeLists.txt
+++ b/clap_wrapper_builder/CMakeLists.txt
@@ -76,10 +76,12 @@ endif()
 # Create the static library target
 # Set up the external static library as an imported library
 add_library(${PLUGIN_NAME_SAFE}_impl STATIC IMPORTED)
+set_target_properties(${PLUGIN_NAME_SAFE}_impl PROPERTIES
+    IMPORTED_LOCATION "${CLAP_WRAPPER_BUILDER_TARGET_LIB}"
+)
 
 if(MSVC)
   set_target_properties(${PLUGIN_NAME_SAFE}_impl PROPERTIES
-      IMPORTED_LOCATION "${CLAP_WRAPPER_BUILDER_TARGET_LIB}"
       # Rust staticlibs do not carry native system-library dependencies into
       # the final wrapper link, so keep the common Windows runtime deps explicit.
       INTERFACE_LINK_LIBRARIES "ntdll.lib;ws2_32.lib;userenv.lib;bcrypt.lib;runtimeobject.lib;psapi.lib"
@@ -88,7 +90,6 @@ endif()
 
 if(APPLE)
   set_target_properties(${PLUGIN_NAME_SAFE}_impl PROPERTIES
-      IMPORTED_LOCATION "${CLAP_WRAPPER_BUILDER_TARGET_LIB}"
       INTERFACE_LINK_LIBRARIES "-framework AppKit;-framework Foundation;-framework WebKit"
   )
 endif()
@@ -227,7 +228,8 @@ if(CLAP_WRAPPER_BUILDER_STAGE_DIR)
             )
         else()
             add_custom_command(TARGET ${PLUGIN_NAME_SAFE}_vst3 POST_BUILD
-                COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:${PLUGIN_NAME_SAFE}_vst3>" "${CLAP_WRAPPER_BUILDER_STAGE_DIR}/${PLUGIN_NAME}.vst3"
+                COMMAND ${CMAKE_COMMAND} -E rm -rf "${CLAP_WRAPPER_BUILDER_STAGE_DIR}/${PLUGIN_NAME}.vst3"
+                COMMAND ${CMAKE_COMMAND} -E copy_directory "$<TARGET_FILE_DIR:${PLUGIN_NAME_SAFE}_vst3>/../.." "${CLAP_WRAPPER_BUILDER_STAGE_DIR}/${PLUGIN_NAME}.vst3"
                 VERBATIM
             )
         endif()

--- a/clap_wrapper_builder/CMakeLists.txt
+++ b/clap_wrapper_builder/CMakeLists.txt
@@ -5,6 +5,7 @@ project(clap_wrapper_builder)
 # Require C++23 or later (required by clap-wrapper and AudioUnitSDK)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 if(APPLE AND NOT DEFINED CMAKE_OSX_DEPLOYMENT_TARGET)
     if(DEFINED ENV{MACOSX_DEPLOYMENT_TARGET} AND NOT "$ENV{MACOSX_DEPLOYMENT_TARGET}" STREQUAL "")
         set(CMAKE_OSX_DEPLOYMENT_TARGET "$ENV{MACOSX_DEPLOYMENT_TARGET}")
@@ -91,6 +92,14 @@ endif()
 if(APPLE)
   set_target_properties(${PLUGIN_NAME_SAFE}_impl PROPERTIES
       INTERFACE_LINK_LIBRARIES "-framework AppKit;-framework Foundation;-framework WebKit"
+  )
+endif()
+
+if(UNIX AND NOT APPLE)
+  find_package(PkgConfig REQUIRED)
+  pkg_check_modules(LINUX_PLUGIN_DEPS REQUIRED IMPORTED_TARGET webkit2gtk-4.1 gtk+-3.0 gdk-x11-3.0)
+  set_target_properties(${PLUGIN_NAME_SAFE}_impl PROPERTIES
+      INTERFACE_LINK_LIBRARIES PkgConfig::LINUX_PLUGIN_DEPS
   )
 endif()
 # Generate the source file for the CLAP entry point.

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -12,7 +12,7 @@ Targets:
 Default targets by platform:
   macOS:   clap, vst3, au, standalone
   Windows: clap, vst3, standalone
-  Linux:   clap
+  Linux:   clap, vst3
 
 Examples:
   cargo xtask build
@@ -31,7 +31,7 @@ Targets:
 Default targets by platform:
   macOS:   clap, vst3, au
   Windows: clap, vst3
-  Linux:   clap
+  Linux:   clap, vst3
 
 Examples:
   cargo xtask install
@@ -51,7 +51,7 @@ Targets:
 Default targets by platform:
   macOS:   clap, vst3, au
   Windows: clap, vst3
-  Linux:   clap
+  Linux:   clap, vst3
 
 Examples:
   cargo xtask uninstall --target=vst3
@@ -67,7 +67,7 @@ Targets:
 Default targets by platform:
   macOS:   vst3, au
   Windows: vst3
-  Linux:   none
+  Linux:   vst3
 
 Examples:
   cargo xtask validate

--- a/xtask/src/commands.rs
+++ b/xtask/src/commands.rs
@@ -650,15 +650,15 @@ fn ensure_vst3_validator(ctx: &Context) -> Result<PathBuf> {
     } else {
         "validator"
     };
-    let validator = ctx
-        .target_dir
-        .join("vst3sdk-validator")
-        .join("bin")
-        .join("Debug")
-        .join(executable);
+    let validator_bin_dir = ctx.target_dir.join("vst3sdk-validator").join("bin");
+    let validator = validator_bin_dir.join("Debug").join(executable);
+    let validator_without_config = validator_bin_dir.join(executable);
 
     if validator.exists() {
         return Ok(validator);
+    }
+    if validator_without_config.exists() {
+        return Ok(validator_without_config);
     }
 
     // validator は出荷 artifact ではなく検証用 tool。
@@ -687,8 +687,12 @@ fn ensure_vst3_validator(ctx: &Context) -> Result<PathBuf> {
         .arg("Debug")
         .current_dir(&ctx.root))?;
 
-    ensure_exists(&validator, "VST3 validator")?;
-    Ok(validator)
+    if validator.exists() {
+        Ok(validator)
+    } else {
+        ensure_exists(&validator_without_config, "VST3 validator")?;
+        Ok(validator_without_config)
+    }
 }
 
 pub(crate) fn clean(ctx: &Context) -> Result<()> {

--- a/xtask/src/commands.rs
+++ b/xtask/src/commands.rs
@@ -528,11 +528,15 @@ fn install_dir(ctx: &Context, scope: InstallScope, format: PluginFormat) -> Resu
             return Err("AU is not supported on Windows".into());
         }
         (Platform::Linux, InstallScope::User, PluginFormat::Clap) => home_dir()?.join(".clap"),
+        (Platform::Linux, InstallScope::User, PluginFormat::Vst3) => home_dir()?.join(".vst3"),
         (Platform::Linux, InstallScope::System, PluginFormat::Clap) => {
             PathBuf::from("/usr/lib/clap")
         }
-        (Platform::Linux, _, PluginFormat::Vst3 | PluginFormat::Au) => {
-            return Err("VST3/AU install is not supported on Linux".into());
+        (Platform::Linux, InstallScope::System, PluginFormat::Vst3) => {
+            PathBuf::from("/usr/lib/vst3")
+        }
+        (Platform::Linux, _, PluginFormat::Au) => {
+            return Err("AU is not supported on Linux".into());
         }
     };
     Ok(dir)

--- a/xtask/src/targets.rs
+++ b/xtask/src/targets.rs
@@ -101,10 +101,12 @@ impl Platform {
         }
     }
 
+    pub(crate) fn supports_vst3(self) -> bool {
+        matches!(self, Self::Macos | Self::Windows | Self::Linux)
+    }
+
     pub(crate) fn supports_wrappers(self) -> bool {
-        // Linux は現状 CLAP のみを配布対象にしている。
-        // clap-wrapper 自体の可能性ではなく、この template が保証する build surface を返す。
-        matches!(self, Self::Macos | Self::Windows)
+        self.supports_vst3() || self.supports_au()
     }
 
     pub(crate) fn supports_au(self) -> bool {
@@ -114,7 +116,7 @@ impl Platform {
     pub(crate) fn supports_target(self, target: Target) -> bool {
         match target {
             Target::Clap => true,
-            Target::Vst3 => self.supports_wrappers(),
+            Target::Vst3 => self.supports_vst3(),
             Target::Au => self.supports_au(),
             Target::Standalone => matches!(self, Self::Macos | Self::Windows),
         }
@@ -122,11 +124,10 @@ impl Platform {
 
     pub(crate) fn default_build_targets(self) -> Vec<Target> {
         // 無指定 build は「その OS で開発者が期待する全部」を作る。
-        // Linux で wrapper を既定に含めないのは、未対応 target の長い CMake 失敗を避けるため。
         match self {
             Self::Macos => vec![Target::Clap, Target::Vst3, Target::Au, Target::Standalone],
             Self::Windows => vec![Target::Clap, Target::Vst3, Target::Standalone],
-            Self::Linux => vec![Target::Clap],
+            Self::Linux => vec![Target::Clap, Target::Vst3],
         }
     }
 
@@ -134,7 +135,7 @@ impl Platform {
         match self {
             Self::Macos => vec![PluginTarget::Clap, PluginTarget::Vst3, PluginTarget::Au],
             Self::Windows => vec![PluginTarget::Clap, PluginTarget::Vst3],
-            Self::Linux => vec![PluginTarget::Clap],
+            Self::Linux => vec![PluginTarget::Clap, PluginTarget::Vst3],
         }
     }
 
@@ -144,7 +145,7 @@ impl Platform {
         match self {
             Self::Macos => vec![ValidateTarget::Vst3, ValidateTarget::Au],
             Self::Windows => vec![ValidateTarget::Vst3],
-            Self::Linux => Vec::new(),
+            Self::Linux => vec![ValidateTarget::Vst3],
         }
     }
 

--- a/xtask/src/util.rs
+++ b/xtask/src/util.rs
@@ -41,6 +41,8 @@ pub(crate) fn ensure_exists(path: &Path, description: &str) -> Result<()> {
 pub(crate) fn run(command: &mut Command) -> Result<()> {
     // xtask は build orchestration なので、失敗時に実際の外部 command が見えることが重要。
     // shell を経由せず Command で実行しつつ、人間が再実行しやすい形だけを表示する。
+    println!();
+    println!("========== Running command ==========");
     println!("$ {}", format_command(command));
     let status = command.status()?;
     if !status.success() {


### PR DESCRIPTION
## Summary
- Add Linux VST3 support to xtask build, install, and validation target resolution.
- Build and validate Linux VST3 artifacts in CI instead of skipping plugin validation on Ubuntu.
- Fix Linux wrapper staging, native link dependencies, validator dependencies, and validator binary discovery.
- Rename the artifact job to emphasize plugin validation and add shared command separators to xtask logs.

## Verification
- cargo fmt --all -- --check
- cargo check --locked -p xtask
- GitHub Actions CI passed on PR run 25891555792.