### PR TITLE
Simplify xtask install handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ cargo xtask install
 CLAP/VST3/AU/standalone on macOS, CLAP/VST3/standalone on Windows, and CLAP on
 Linux. Use `build --target` with a comma-separated list of `clap`, `vst3`,
 `au`, and `standalone` to build a smaller set. `install` and `uninstall` accept
-plugin formats only: `clap`, `vst3`, and `au`.
+plugin formats only: `clap`, `vst3`, and `au`. `install --scope` accepts `user`
+or `system`; `uninstall --scope` accepts `user`, `system`, or `all`.
 
 Plugin artifacts are staged under `target/wrac/plugins/<profile>/`, and
 standalone apps are staged under `target/wrac/standalone/<profile>/`. On macOS,

--- a/README_JA.md
+++ b/README_JA.md
@@ -54,6 +54,7 @@ cargo xtask install
 
 `build --target` には `clap`、`vst3`、`au`、`standalone` をカンマ区切りで指定できます。
 ただし、OS が対応していないフォーマットを指定した場合はエラーになります。
+`install --scope` は `user` または `system`、`uninstall --scope` は `user`、`system`、`all` を指定できます。
 
 使い方:
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -86,7 +86,8 @@ Run the following from the repository root.
 
 ```sh
 cd /path/to/my_plugin
-cargo xtask build --install
+cargo xtask build
+cargo xtask install
 ```
 
 The built plugin will be installed to the following directories:
@@ -100,7 +101,8 @@ The built plugin will be installed to the following directories:
 On Windows, `cargo xtask install` installs to the user-local paths by default.
 Use `cargo xtask install --scope=system` to install to `%COMMONPROGRAMFILES%/CLAP/`
 and `%COMMONPROGRAMFILES%/VST3/` for hosts that only scan system-wide plug-in
-folders. `cargo xtask uninstall` removes both user-local and system-wide copies.
+folders. `cargo xtask uninstall` removes both user-local and system-wide copies by default;
+use `cargo xtask uninstall --scope=user` or `--scope=system` to remove only one scope.
 
 VST3 / AU / standalone are built where supported by the current OS. Standalone
 apps do not have a plugin install destination, so xtask prints their artifact

--- a/docs/setup_JA.md
+++ b/docs/setup_JA.md
@@ -86,7 +86,8 @@ rg --hidden 'repository = "https://github.com/novonotes/wrac-plugin-template"' -
 
 ```sh
 cd /path/to/my_plugin
-cargo xtask build --install
+cargo xtask build
+cargo xtask install
 ```
 
 以下のディレクトリにビルド済みプラグインがインストールされます:
@@ -100,7 +101,8 @@ cargo xtask build --install
 Windows では `cargo xtask install` は既定で user-local のパスにインストールします。
 system-wide のみをスキャンするホスト向けには `cargo xtask install --scope=system`
 を使うと `%COMMONPROGRAMFILES%/CLAP/` および `%COMMONPROGRAMFILES%/VST3/` に
-インストールできます。`cargo xtask uninstall` は user-local と system-wide の両方を削除します。
+インストールできます。`cargo xtask uninstall` は既定で user-local と system-wide の両方を削除し、
+`cargo xtask uninstall --scope=user` または `--scope=system` で片方だけを削除できます。
 
 VST3 / AU / standalone は現在の OS で対応している場合に同時にビルドされます。
 スタンドアローンアプリには plugin install 先がないため、xtask は artifact path を表示します。

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -21,6 +21,7 @@ Examples:
   cargo xtask build --target=au,standalone --release
 
 Notes:
+  Run `cargo xtask install` after building to install plugin artifacts.
   Run `cargo xtask validate` after building to validate VST3/AU artifacts.
   VST3/AU wrapper targets require clap-wrapper dependencies.";
 
@@ -54,11 +55,14 @@ Default targets by platform:
   Linux:   clap, vst3
 
 Examples:
+  cargo xtask uninstall
   cargo xtask uninstall --target=vst3
+  cargo xtask uninstall --scope=user
+  cargo xtask uninstall --scope=system
   cargo xtask uninstall --dry-run
 
 Notes:
-  uninstall removes both user-local and system-wide plugin artifacts.";
+  --scope defaults to all and removes both user-local and system-wide plugin artifacts.";
 
 const VALIDATE_AFTER_HELP: &str = "\
 Targets:
@@ -133,9 +137,6 @@ pub(crate) struct BuildArgs {
         long_help = "Targets to build, comma-separated. Supported values are clap, vst3, au, and standalone. Defaults to every target supported by the current OS."
     )]
     pub(crate) target: Vec<Target>,
-
-    #[arg(long, help = "Install plugin artifacts after a successful build.")]
-    pub(crate) install: bool,
 }
 
 #[derive(Debug, Args)]
@@ -168,8 +169,23 @@ pub(crate) enum InstallScope {
     System,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub(crate) enum UninstallScope {
+    All,
+    User,
+    System,
+}
+
 #[derive(Debug, Args)]
 pub(crate) struct UninstallArgs {
+    #[arg(
+        long,
+        value_enum,
+        default_value_t = UninstallScope::All,
+        help = "Uninstall location scope."
+    )]
+    pub(crate) scope: UninstallScope,
+
     #[arg(
         long,
         value_enum,

--- a/xtask/src/commands.rs
+++ b/xtask/src/commands.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use crate::Result;
-use crate::cli::{BuildArgs, InstallScope};
+use crate::cli::{BuildArgs, InstallScope, UninstallScope};
 use crate::constants::{
     AU_BUNDLE_NAME, AU_MANUFACTURER, AU_MANUFACTURER_NAME, AU_SUBTYPE, AU_TYPE, CLAP_BUNDLE_NAME,
     CRATE_NAME, PLUGIN_ID, PLUGIN_NAME, STANDALONE_NAME, VST3_BUNDLE_NAME,
@@ -64,10 +64,6 @@ pub(crate) fn build(ctx: &Context, args: BuildArgs) -> Result<()> {
     if targets.contains(&Target::Standalone) {
         build_rust_plugin(ctx, profile, RustPluginBuild::Standalone)?;
         build_wrapper_set(ctx, profile, WrapperBuild::Standalone)?;
-    }
-
-    if args.install {
-        install_built_targets(ctx, profile, &targets)?;
     }
 
     print_outputs(ctx, profile, &targets);
@@ -401,20 +397,6 @@ pub(crate) fn install(
     install_plugin_targets(ctx, profile, scope, &targets)
 }
 
-fn install_built_targets(ctx: &Context, profile: BuildProfile, targets: &[Target]) -> Result<()> {
-    // build target には standalone も含まれるが、install 先を持つのは plugin format だけ。
-    // CLI の --install は build の便利オプションなので、standalone を黙って除外する。
-    let targets: Vec<_> = targets
-        .iter()
-        .filter_map(|target| target.plugin_target())
-        .collect();
-    if targets.is_empty() {
-        println!("No plugin targets to install.");
-        return Ok(());
-    }
-    install_plugin_targets(ctx, profile, InstallScope::User, &targets)
-}
-
 fn install_plugin_targets(
     ctx: &Context,
     profile: BuildProfile,
@@ -440,13 +422,18 @@ fn install_plugin_targets(
     Ok(())
 }
 
-pub(crate) fn uninstall(ctx: &Context, requested: &[PluginTarget], dry_run: bool) -> Result<()> {
+pub(crate) fn uninstall(
+    ctx: &Context,
+    scope: UninstallScope,
+    requested: &[PluginTarget],
+    dry_run: bool,
+) -> Result<()> {
     let targets = resolve_plugin_targets(ctx.platform, requested)?;
 
     let mut removed = 0usize;
     let mut missing = 0usize;
     for target in targets {
-        for path in installed_artifacts(ctx, target)? {
+        for path in installed_artifacts(ctx, scope, target)? {
             if !path.exists() {
                 println!("Not found: {}", path.display());
                 missing += 1;
@@ -546,7 +533,11 @@ fn install_artifact(artifact: &Path, destination_dir: &Path) -> Result<()> {
     Ok(())
 }
 
-fn installed_artifacts(ctx: &Context, target: PluginTarget) -> Result<Vec<PathBuf>> {
+fn installed_artifacts(
+    ctx: &Context,
+    scope: UninstallScope,
+    target: PluginTarget,
+) -> Result<Vec<PathBuf>> {
     let format = match target {
         PluginTarget::Clap => PluginFormat::Clap,
         PluginTarget::Vst3 => PluginFormat::Vst3,
@@ -557,10 +548,21 @@ fn installed_artifacts(ctx: &Context, target: PluginTarget) -> Result<Vec<PathBu
         PluginTarget::Vst3 => VST3_BUNDLE_NAME,
         PluginTarget::Au => AU_BUNDLE_NAME,
     };
-    [InstallScope::User, InstallScope::System]
-        .into_iter()
-        .map(|scope| install_dir(ctx, scope, format).map(|dir| dir.join(bundle_name)))
+    uninstall_scopes(scope)
+        .iter()
+        .copied()
+        .map(|install_scope| {
+            install_dir(ctx, install_scope, format).map(|dir| dir.join(bundle_name))
+        })
         .collect::<Result<Vec<_>>>()
+}
+
+fn uninstall_scopes(scope: UninstallScope) -> &'static [InstallScope] {
+    match scope {
+        UninstallScope::All => &[InstallScope::User, InstallScope::System],
+        UninstallScope::User => &[InstallScope::User],
+        UninstallScope::System => &[InstallScope::System],
+    }
 }
 
 pub(crate) fn validate(

--- a/xtask/src/commands.rs
+++ b/xtask/src/commands.rs
@@ -133,15 +133,6 @@ impl RustPluginBuild {
             .join(profile.cargo_dir())
             .join(ctx.platform.static_library_name())
     }
-
-    fn objc_suffix(self) -> &'static str {
-        match self {
-            Self::Default => "WracGainPlugin",
-            Self::Vst3 => "WracGainPluginVst3",
-            Self::Au => "WracGainPluginAu",
-            Self::Standalone => "WracGainPluginStandalone",
-        }
-    }
 }
 
 fn build_rust_plugin(ctx: &Context, profile: BuildProfile, build: RustPluginBuild) -> Result<()> {
@@ -157,14 +148,11 @@ fn build_rust_plugin(ctx: &Context, profile: BuildProfile, build: RustPluginBuil
         command.arg(flag);
     }
     if ctx.platform == Platform::Macos {
-        // macOS の webview/Objective-C runtime は deployment target と class 名衝突に敏感。
         // CI や利用者環境の env を尊重しつつ、未指定時だけ template の安全な既定値を入れる。
-        command
-            .env(
-                "MACOSX_DEPLOYMENT_TARGET",
-                env_value_or("MACOSX_DEPLOYMENT_TARGET", "11.0"),
-            )
-            .env("WRY_OBJC_SUFFIX", build.objc_suffix());
+        command.env(
+            "MACOSX_DEPLOYMENT_TARGET",
+            env_value_or("MACOSX_DEPLOYMENT_TARGET", "11.0"),
+        );
     }
     run(command.current_dir(&ctx.root))?;
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -29,7 +29,7 @@ fn main() -> Result<()> {
             args.scope,
             &args.target,
         )?,
-        Commands::Uninstall(args) => uninstall(&ctx, &args.target, args.dry_run)?,
+        Commands::Uninstall(args) => uninstall(&ctx, args.scope, &args.target, args.dry_run)?,
         Commands::Validate(args) => {
             validate(&ctx, BuildProfile::from_release(args.release), &args.target)?
         }

--- a/xtask/src/targets.rs
+++ b/xtask/src/targets.rs
@@ -23,15 +23,6 @@ impl Target {
     pub(crate) fn is_wrapper(self) -> bool {
         matches!(self, Self::Vst3 | Self::Au)
     }
-
-    pub(crate) fn plugin_target(self) -> Option<PluginTarget> {
-        match self {
-            Self::Clap => Some(PluginTarget::Clap),
-            Self::Vst3 => Some(PluginTarget::Vst3),
-            Self::Au => Some(PluginTarget::Au),
-            Self::Standalone => None,
-        }
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]


### PR DESCRIPTION
## Summary
- remove obsolete WRY_OBJC_SUFFIX setup from macOS plugin builds
- add uninstall --scope with all/user/system choices, defaulting to all
- remove build --install and document running build and install as separate commands
- remove leftover build --install helper code

## Verification
- cargo check -p xtask
- cargo xtask build --target=clap
- cargo xtask build --help
- cargo xtask uninstall --help
- cargo xtask uninstall --scope=user --dry-run --target=clap
- confirmed no --install / args.install / install_built_targets references remain outside build outputs