### PR TITLE
Update wxp WebView dispatch integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3183,7 +3183,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 [[package]]
 name = "wry"
 version = "0.55.1"
-source = "git+https://github.com/novonotes/wxp.git?rev=518cf7ad0332c02900b85e5ba23e14ec0cb484d7#518cf7ad0332c02900b85e5ba23e14ec0cb484d7"
+source = "git+https://github.com/novonotes/wxp.git?rev=eb86da648936dccd3486e6f3f6140be451daeaef#eb86da648936dccd3486e6f3f6140be451daeaef"
 dependencies = [
  "base64",
  "block2 0.6.2",
@@ -3226,7 +3226,7 @@ dependencies = [
 [[package]]
 name = "wxp"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/novonotes/wxp.git?rev=518cf7ad0332c02900b85e5ba23e14ec0cb484d7#518cf7ad0332c02900b85e5ba23e14ec0cb484d7"
+source = "git+https://github.com/novonotes/wxp.git?rev=eb86da648936dccd3486e6f3f6140be451daeaef#eb86da648936dccd3486e6f3f6140be451daeaef"
 dependencies = [
  "async-trait",
  "directories",

--- a/crates/run_loop_timer/src/lib.rs
+++ b/crates/run_loop_timer/src/lib.rs
@@ -251,8 +251,10 @@ mod tests {
                 wait_until_true(&task_started).await;
             }
 
-            RunLoop::current().delay(Duration::from_millis(300)).await;
-            assert!(task_completed.load(Ordering::SeqCst));
+            // Dropping the timer must not cancel a task that has already been spawned, but the
+            // completion delay is still driven by the platform run loop. Wait for the observable
+            // condition instead of assuming CI delivers the 200ms delay within a fixed margin.
+            wait_until_true(&task_completed).await;
         });
     }
 

--- a/crates/wrac_wxp_gui/Cargo.toml
+++ b/crates/wrac_wxp_gui/Cargo.toml
@@ -14,7 +14,7 @@ novonotes_run_loop = { git = "https://github.com/novonotes/run_loop.git", rev = 
 parking_lot = "0.12"
 raw-window-handle = "0.6"
 wrac_clap_adapter = { path = "../wrac_clap_adapter" }
-wxp = { git = "https://github.com/novonotes/wxp.git", rev = "518cf7ad0332c02900b85e5ba23e14ec0cb484d7" }
+wxp = { git = "https://github.com/novonotes/wxp.git", rev = "eb86da648936dccd3486e6f3f6140be451daeaef" }
 
 [lints.rust]
 unreachable_pub = "deny"

--- a/crates/wrac_wxp_gui/README.md
+++ b/crates/wrac_wxp_gui/README.md
@@ -12,5 +12,12 @@
 - floating window はこの helper では扱わない
 - 汎用的なフレームワークではなく実装例を兼ねた出発点を意図しています。今後の変更に伴う、API の後方互換性やマイグレーションサポートは提供しません。
 
+## wxp runtime の扱い
+
+`WxpWebView` は native WebView の寿命を所有する token なので、GUI runtime の中だけで保持します。
+command handler など editor の寿命を延ばしたくない経路では、wxp の `WebViewDispatch` を使って
+WebView 操作を post します。これにより、host が editor を閉じた後に遅れて届いた command や resize
+request が native WebView を直接触らず、閉じた WebView には `WebViewClosed` として失敗できます。
+
 ## 参考
 wxp クレートの使い方は [wxp の README](https://github.com/novonotes/wxp/tree/main/crates/wxp) に記載しています。

--- a/crates/wrac_wxp_gui/src/controller.rs
+++ b/crates/wrac_wxp_gui/src/controller.rs
@@ -8,7 +8,7 @@ use wrac_clap_adapter::{
     ClapWindow, GuiApi, GuiConfiguration, GuiResizeHints, GuiSize, HostGuiResizeRequester,
     PluginError, PluginGui, PluginResult,
 };
-use wxp::{WebViewRef, dpi::LogicalSize};
+use wxp::{WebViewDispatch, dpi::LogicalSize};
 
 use crate::dpi::DpiConverter;
 use crate::runtime::{
@@ -558,7 +558,7 @@ impl WxpGuiResizeHandle {
     pub fn request_resize(
         &self,
         requested: LogicalSize<f64>,
-        web_view: &WebViewRef,
+        web_view: &WebViewDispatch,
         host_gui_resize_requester: &dyn HostGuiResizeRequester,
     ) -> PluginResult<GuiSize> {
         let logical_size = self.layout.clamp_logical_size(requested);
@@ -570,8 +570,10 @@ impl WxpGuiResizeHandle {
 
         self.layout.store_accepted_size(gui_size);
         let scale = *self.scale.lock();
+        // Commands receive `WebViewDispatch`, not the native WebView owner. That keeps resize
+        // requests usable from command handlers without extending a closing editor's lifetime.
         web_view
-            .set_bounds(DpiConverter::new(scale).create_webview_bounds(logical_size))
+            .post_set_bounds(DpiConverter::new(scale).create_webview_bounds(logical_size))
             .map_err(|_| PluginError::Message("failed to resize webview"))?;
         Ok(gui_size)
     }

--- a/src-plugin/Cargo.toml
+++ b/src-plugin/Cargo.toml
@@ -24,7 +24,7 @@ time = { version = "0.3", features = ["formatting", "local-offset", "macros"] }
 run_loop_timer = { path = "../crates/run_loop_timer" }
 wrac_clap_adapter = { path = "../crates/wrac_clap_adapter" }
 wrac_wxp_gui = { path = "../crates/wrac_wxp_gui" }
-wxp = { git = "https://github.com/novonotes/wxp.git", rev = "518cf7ad0332c02900b85e5ba23e14ec0cb484d7" }
+wxp = { git = "https://github.com/novonotes/wxp.git", rev = "eb86da648936dccd3486e6f3f6140be451daeaef" }
 
 [lints.rust]
 unreachable_pub = "deny"

--- a/src-plugin/src/commands.rs
+++ b/src-plugin/src/commands.rs
@@ -166,7 +166,7 @@ pub(crate) fn register_commands(
 
     command_handler.register_sync("focus_host_window", move |ctx| {
         ctx.webview()
-            .focus_parent()
+            .post_focus_parent()
             .map_err(|e| format!("focus_parent failed: {e}"))?;
         Ok::<_, String>(json!({ "ok": true }))
     });
@@ -178,7 +178,7 @@ pub(crate) fn register_commands(
         let size = gui_resize_handle
             .request_resize(
                 wxp::dpi::LogicalSize::new(request.width, request.height),
-                &ctx.webview(),
+                ctx.webview(),
                 host_gui_resize_requester.as_ref(),
             )
             .map_err(|e| e.to_string())?;

--- a/src-plugin/src/gui.rs
+++ b/src-plugin/src/gui.rs
@@ -32,7 +32,7 @@ use wrac_wxp_gui::{
     WxpGuiRuntime, gui_size_to_logical,
 };
 use wxp::{
-    Channel, WebContext, WebViewRef, WxpCommandHandler, WxpWebViewBuilder, dpi::LogicalSize,
+    Channel, WebContext, WxpCommandHandler, WxpWebView, WxpWebViewBuilder, dpi::LogicalSize,
 };
 
 use crate::commands::register_commands;
@@ -243,8 +243,10 @@ pub(crate) fn parameter_payload(parameter_id: u32, value: f32) -> serde_json::Va
 pub(crate) struct WracGainGuiRuntime {
     // WebView 側 subscription への通知口。
     gui_notifier: Arc<GuiStateNotifier>,
-    // 表示中の WebView。Option にしてあるのは Drop の順序を制御するため。
-    web_view: Option<WebViewRef>,
+    // `WxpWebView` は native WebView の寿命を所有する !Send + !Sync token。host からの操作は
+    // runtime が載っている GUI thread で受け、必要なときだけ dispatch handle に変換して post する。
+    // Option にしてあるのは Drop の順序を制御するため。
+    web_view: Option<WxpWebView>,
     // wxp の WebContext。WebView より長く生かしておく必要があるので保持する。
     wxp_context: Option<WebContext>,
     // frontend からの command を受け取って Rust 側関数を呼ぶ dispatcher。
@@ -410,8 +412,11 @@ impl WxpGuiRuntime for WracGainGuiRuntime {
         );
 
         if let Some(web_view) = &self.web_view {
+            // wxp は native WebView の直接操作を owner から分離している。ここは GUI thread 上だが、
+            // stale-close checks と post/enqueue semantics を同じ経路に揃えるため dispatch 経由にする。
             web_view
-                .set_bounds(self.dpi_converter.create_webview_bounds(self.gui_size))
+                .dispatch()
+                .post_set_bounds(self.dpi_converter.create_webview_bounds(self.gui_size))
                 .map_err(|_| PluginError::Message("failed to resize webview"))?;
         }
         Ok(())
@@ -420,8 +425,11 @@ impl WxpGuiRuntime for WracGainGuiRuntime {
     fn show(&mut self) -> PluginResult<()> {
         log::debug!("showing GUI runtime");
         if let Some(web_view) = &self.web_view {
+            // show/hide は host lifecycle と競合しやすいので、owner を直接触らず wxp 側の
+            // close-aware dispatch path に寄せる。
             web_view
-                .set_visible(true)
+                .dispatch()
+                .post_set_visible(true)
                 .map_err(|_| PluginError::Message("failed to show webview"))?;
         }
         self.gui_update_timer.start();
@@ -433,8 +441,11 @@ impl WxpGuiRuntime for WracGainGuiRuntime {
         log::debug!("hiding GUI runtime");
         self.gui_update_timer.stop();
         if let Some(web_view) = &self.web_view {
+            // hide は destroy 直前に呼ばれることがある。dispatch は WebView が閉じていれば
+            // WebViewClosed を返し、native object の寿命を延ばさない。
             web_view
-                .set_visible(false)
+                .dispatch()
+                .post_set_visible(false)
                 .map_err(|_| PluginError::Message("failed to hide webview"))?;
         }
         log::debug!("hiding GUI runtime completed");


### PR DESCRIPTION
## Summary
- update wxp to the merged WebViewDispatch revision
- migrate wrac WebView usage from WebViewRef/direct calls to WxpWebView/WebViewDispatch post APIs
- document the owner/dispatch lifetime split in wrac_wxp_gui

## Verification
- cargo fmt
- cargo check --workspace --all-targets
- cargo test --workspace