### PR TITLE
Add CLAP validator to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,20 +88,20 @@ jobs:
         include:
           - os: ubuntu-latest
             targets: clap,vst3
-            validate-targets: vst3
+            validate-targets: clap,vst3
             verify: |
               test -f "target/wrac/plugins/release/WRAC Gain.clap"
               test -d "target/wrac/plugins/release/WRAC Gain.vst3"
           - os: windows-latest
             targets: clap,vst3,standalone
-            validate-targets: vst3
+            validate-targets: clap,vst3
             verify: |
               test -f "target/wrac/plugins/release/WRAC Gain.clap"
               test -d "target/wrac/plugins/release/WRAC Gain.vst3"
               test -f "target/wrac/standalone/release/WRAC Gain Standalone.exe"
           - os: macos-latest
             targets: clap,vst3,au,standalone
-            validate-targets: vst3,au
+            validate-targets: clap,vst3,au
             verify: |
               test -d "target/wrac/plugins/release/WRAC Gain.clap"
               test -d "target/wrac/plugins/release/WRAC Gain.vst3"

--- a/README.md
+++ b/README.md
@@ -44,17 +44,20 @@ cargo xtask install
 ```
 
 `cargo xtask build` builds every target supported by the current OS:
-CLAP/VST3/AU/standalone on macOS, CLAP/VST3/standalone on Windows, and CLAP on
-Linux. Use `build --target` with a comma-separated list of `clap`, `vst3`,
+CLAP/VST3/AU/standalone on macOS, CLAP/VST3/standalone on Windows, and CLAP/VST3
+on Linux. Use `build --target` with a comma-separated list of `clap`, `vst3`,
 `au`, and `standalone` to build a smaller set. `install` and `uninstall` accept
 plugin formats only: `clap`, `vst3`, and `au`. `install --scope` accepts `user`
 or `system`; `uninstall --scope` accepts `user`, `system`, or `all`.
 
 Plugin artifacts are staged under `target/wrac/plugins/<profile>/`, and
 standalone apps are staged under `target/wrac/standalone/<profile>/`. On macOS,
-`cargo xtask validate` runs the VST3 validator and `auval -v aufx WtGn YrCo`.
-AU validation installs the built component under `~/Library/Audio/Plug-Ins/Components/`
-and fails if the same bundle exists under `/Library/Audio/Plug-Ins/Components/`.
+`cargo xtask validate` runs clap-validator, the VST3 validator, and
+`auval -v aufx WtGn YrCo`. On Windows and Linux, validation runs clap-validator
+and the VST3 validator. CLAP validation downloads clap-validator 0.3.2 into
+`target/tools` when needed. AU validation installs the built component under
+`~/Library/Audio/Plug-Ins/Components/` and fails if the same bundle exists under
+`/Library/Audio/Plug-Ins/Components/`.
 
 
 ## Setting Up a New Project

--- a/README_JA.md
+++ b/README_JA.md
@@ -48,12 +48,13 @@ cargo xtask install
 
 | OS | `cargo xtask build` の対象 | `cargo xtask validate` の対象 |
 |----|---------------------------|-------------------------------|
-| macOS | CLAP / VST3 / AU / Standalone | VST3 / AU |
-| Windows | CLAP / VST3 / Standalone | VST3 |
-| Linux | CLAP | なし |
+| macOS | CLAP / VST3 / AU / Standalone | CLAP / VST3 / AU |
+| Windows | CLAP / VST3 / Standalone | CLAP / VST3 |
+| Linux | CLAP / VST3 | CLAP / VST3 |
 
 `build --target` には `clap`、`vst3`、`au`、`standalone` をカンマ区切りで指定できます。
 ただし、OS が対応していないフォーマットを指定した場合はエラーになります。
+CLAP の検証は必要に応じて clap-validator 0.3.2 を `target/tools` にダウンロードして実行します。
 `install --scope` は `user` または `system`、`uninstall --scope` は `user`、`system`、`all` を指定できます。
 
 使い方:

--- a/crates/wrac_clap_adapter/src/abi/ffi.rs
+++ b/crates/wrac_clap_adapter/src/abi/ffi.rs
@@ -14,11 +14,23 @@ pub(super) unsafe fn write_stream(stream: *const clap_ostream, bytes: &[u8]) -> 
         );
         return false;
     };
-    let written = unsafe { write(stream, bytes.as_ptr().cast(), bytes.len() as u64) };
-    let expected = bytes.len() as i64;
-    if written != expected {
-        log::warn!("ffi.write_stream: short write written={written} expected={expected}");
-        return false;
+    let mut offset = 0;
+    while offset < bytes.len() {
+        let written = unsafe {
+            write(
+                stream,
+                bytes[offset..].as_ptr().cast(),
+                (bytes.len() - offset) as u64,
+            )
+        };
+        if written <= 0 {
+            log::warn!(
+                "ffi.write_stream: write failed written={written} offset={offset} byte_len={}",
+                bytes.len()
+            );
+            return false;
+        }
+        offset += written as usize;
     }
     true
 }

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -22,7 +22,7 @@ Examples:
 
 Notes:
   Run `cargo xtask install` after building to install plugin artifacts.
-  Run `cargo xtask validate` after building to validate VST3/AU artifacts.
+  Run `cargo xtask validate` after building to validate CLAP/VST3/AU artifacts.
   VST3/AU wrapper targets require clap-wrapper dependencies.";
 
 const INSTALL_AFTER_HELP: &str = "\
@@ -66,19 +66,21 @@ Notes:
 
 const VALIDATE_AFTER_HELP: &str = "\
 Targets:
-  vst3, au
+  clap, vst3, au
 
 Default targets by platform:
-  macOS:   vst3, au
-  Windows: vst3
-  Linux:   vst3
+  macOS:   clap, vst3, au
+  Windows: clap, vst3
+  Linux:   clap, vst3
 
 Examples:
   cargo xtask validate
   cargo xtask validate --release
+  cargo xtask validate --target=clap
   cargo xtask validate --target=vst3
 
 Notes:
+  CLAP validation downloads clap-validator 0.3.2 into target/tools if needed.
   VST3 validation uses the VST3 validator.
   AU validation is available only on macOS and installs the built AU before running auval.
   AU validation fails if the same AU bundle exists under /Library/Audio/Plug-Ins/Components.";
@@ -112,7 +114,7 @@ pub(crate) enum Commands {
     )]
     Uninstall(UninstallArgs),
     #[command(
-        about = "Validate previously built VST3/AU artifacts.",
+        about = "Validate previously built CLAP/VST3/AU artifacts.",
         after_help = VALIDATE_AFTER_HELP
     )]
     Validate(ValidateArgs),
@@ -214,7 +216,7 @@ pub(crate) struct ValidateArgs {
         value_delimiter = ',',
         num_args = 1..,
         help = "Targets to validate, comma-separated.",
-        long_help = "Targets to validate, comma-separated. Supported values are vst3 and au. Defaults to every validation target supported by the current OS."
+        long_help = "Targets to validate, comma-separated. Supported values are clap, vst3, and au. Defaults to every validation target supported by the current OS."
     )]
     pub(crate) target: Vec<ValidateTarget>,
 }

--- a/xtask/src/commands.rs
+++ b/xtask/src/commands.rs
@@ -19,6 +19,8 @@ use crate::util::{
     remove_if_exists, run,
 };
 
+const CLAP_VALIDATOR_VERSION: &str = "0.3.2";
+
 pub(crate) fn build(ctx: &Context, args: BuildArgs) -> Result<()> {
     let profile = BuildProfile::from_release(args.release);
     let targets = resolve_build_targets(ctx.platform, &args.target)?;
@@ -585,8 +587,19 @@ fn validate_targets(
     targets: &[ValidateTarget],
 ) -> Result<()> {
     if targets.is_empty() {
-        println!("No VST3/AU targets to validate.");
+        println!("No CLAP/VST3/AU targets to validate.");
         return Ok(());
+    }
+
+    if targets.contains(&ValidateTarget::Clap) {
+        let clap = ctx.clap_bundle(profile);
+        ensure_exists(&clap, "CLAP artifact")?;
+        let validator = ensure_clap_validator(ctx)?;
+        run(Command::new(validator)
+            .arg("validate")
+            .arg(&clap)
+            .arg("--only-failed")
+            .current_dir(&ctx.root))?;
     }
 
     if targets.contains(&ValidateTarget::Vst3) {
@@ -618,6 +631,76 @@ fn validate_targets(
     }
 
     Ok(())
+}
+
+fn ensure_clap_validator(ctx: &Context) -> Result<PathBuf> {
+    let validator_dir = ctx
+        .target_dir
+        .join("tools")
+        .join("clap-validator")
+        .join(CLAP_VALIDATOR_VERSION);
+    let validator = clap_validator_executable(ctx.platform, &validator_dir);
+    if validator.exists() {
+        return Ok(validator);
+    }
+
+    fs::create_dir_all(&validator_dir)?;
+    let archive_name = clap_validator_archive_name(ctx.platform);
+    let archive = validator_dir.join(archive_name);
+    if !archive.exists() {
+        let url = format!(
+            "https://github.com/free-audio/clap-validator/releases/download/{CLAP_VALIDATOR_VERSION}/{archive_name}"
+        );
+        run(Command::new("curl")
+            .args(["-L", "--fail", "-o"])
+            .arg(&archive)
+            .arg(url)
+            .current_dir(&ctx.root))?;
+    }
+
+    if archive_name.ends_with(".zip") {
+        run(Command::new("powershell")
+            .args([
+                "-NoProfile",
+                "-Command",
+                "Expand-Archive -Force -LiteralPath $args[0] -DestinationPath $args[1]",
+            ])
+            .arg(&archive)
+            .arg(&validator_dir)
+            .current_dir(&ctx.root))?;
+    } else {
+        run(Command::new("tar")
+            .args(["-xzf"])
+            .arg(&archive)
+            .arg("-C")
+            .arg(&validator_dir)
+            .current_dir(&ctx.root))?;
+    }
+
+    ensure_exists(&validator, "CLAP validator")?;
+    if ctx.platform != Platform::Windows {
+        run(Command::new("chmod")
+            .arg("+x")
+            .arg(&validator)
+            .current_dir(&ctx.root))?;
+    }
+    Ok(validator)
+}
+
+fn clap_validator_archive_name(platform: Platform) -> &'static str {
+    match platform {
+        Platform::Macos => "clap-validator-0.3.2-macos-universal.tar.gz",
+        Platform::Windows => "clap-validator-0.3.2-windows.zip",
+        Platform::Linux => "clap-validator-0.3.2-ubuntu-18.04.tar.gz",
+    }
+}
+
+fn clap_validator_executable(platform: Platform, validator_dir: &Path) -> PathBuf {
+    match platform {
+        Platform::Macos => validator_dir.join("binaries").join("clap-validator"),
+        Platform::Windows => validator_dir.join("clap-validator.exe"),
+        Platform::Linux => validator_dir.join("clap-validator"),
+    }
 }
 
 fn ensure_no_system_au_conflict() -> Result<()> {

--- a/xtask/src/commands.rs
+++ b/xtask/src/commands.rs
@@ -659,13 +659,12 @@ fn ensure_clap_validator(ctx: &Context) -> Result<PathBuf> {
     }
 
     if archive_name.ends_with(".zip") {
-        run(Command::new("powershell")
-            .args([
-                "-NoProfile",
-                "-Command",
-                "Expand-Archive -Force -LiteralPath $args[0] -DestinationPath $args[1]",
-            ])
+        // Windows runners provide bsdtar as `tar`, and it can extract zip files.
+        // Using it here keeps argument passing identical to the tar.gz path.
+        run(Command::new("tar")
+            .arg("-xf")
             .arg(&archive)
+            .arg("-C")
             .arg(&validator_dir)
             .current_dir(&ctx.root))?;
     } else {

--- a/xtask/src/targets.rs
+++ b/xtask/src/targets.rs
@@ -52,6 +52,7 @@ impl PluginTarget {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub(crate) enum ValidateTarget {
+    Clap,
     Vst3,
     Au,
 }
@@ -59,6 +60,7 @@ pub(crate) enum ValidateTarget {
 impl ValidateTarget {
     pub(crate) fn display(self) -> &'static str {
         match self {
+            Self::Clap => "CLAP",
             Self::Vst3 => "VST3",
             Self::Au => "AU",
         }
@@ -66,6 +68,7 @@ impl ValidateTarget {
 
     pub(crate) fn target(self) -> Target {
         match self {
+            Self::Clap => Target::Clap,
             Self::Vst3 => Target::Vst3,
             Self::Au => Target::Au,
         }
@@ -131,12 +134,15 @@ impl Platform {
     }
 
     pub(crate) fn default_validate_targets(self) -> Vec<ValidateTarget> {
-        // validate は既に build 済みの wrapper artifact を確認する command。
-        // CLAP にはここで呼ぶ外部 validator がないため、VST3/AU だけを対象にする。
+        // validate は既に build 済みの plugin artifact を外部 validator で確認する command。
         match self {
-            Self::Macos => vec![ValidateTarget::Vst3, ValidateTarget::Au],
-            Self::Windows => vec![ValidateTarget::Vst3],
-            Self::Linux => vec![ValidateTarget::Vst3],
+            Self::Macos => vec![
+                ValidateTarget::Clap,
+                ValidateTarget::Vst3,
+                ValidateTarget::Au,
+            ],
+            Self::Windows => vec![ValidateTarget::Clap, ValidateTarget::Vst3],
+            Self::Linux => vec![ValidateTarget::Clap, ValidateTarget::Vst3],
         }
     }
 


### PR DESCRIPTION
## Summary
- Add CLAP validation to `cargo xtask validate`
- Download and cache clap-validator 0.3.2 under `target/tools`
- Run CLAP validation in the plugin artifact validation CI job
- Handle partial writes in CLAP state streams

## Verification
- `cargo xtask build --release --target=clap`
- `cargo xtask validate --release --target=clap`
- `cargo fmt --all -- --check`
- `cargo test --locked --workspace`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`

`origin/develop` does not exist, so this PR targets `main`.