### PR TITLE
Decouple host capabilities from core lifecycle lock

### DIFF
--- a/crates/wrac_clap_adapter/src/abi.rs
+++ b/crates/wrac_clap_adapter/src/abi.rs
@@ -45,7 +45,8 @@ use crate::descriptor::{
 use crate::host_gui::HostGuiResizeRequest;
 use crate::params::ParameterEditQueue;
 use crate::{
-    ActivateContext, PluginCore, PluginCoreContext, PluginGui, PluginStateSupport, ProcessContext,
+    ActivateContext, PluginAudioPorts, PluginConfigurableAudioPorts, PluginCore, PluginCoreContext,
+    PluginGui, PluginNotePorts, PluginParameters, PluginStateSupport, ProcessContext,
     ProcessStatus, Processor,
 };
 
@@ -57,18 +58,32 @@ const CLAP_PLUGIN_FACTORY_INFO_AUV2: &CStr = c"clap.plugin-factory-info-as-auv2.
 /// CLAP instance と Rust core の同期境界。
 ///
 /// wrapper format では、Native CLAP なら `[main-thread]` 扱いの query/state callback
-/// が別 thread から呼ばれることがある。そのため `PluginCore` は lock で守り、
-/// audio callback が直接必要とする state は `Processor` / notifier 側へ分離する。
+/// が別 thread から呼ばれることがある。
+///
+/// そのため、この型は「lifecycle を守る lock」と「host-facing callback から直接読める
+/// capability」を明確に分ける。`PluginCore` lock は `activate()` / `deactivate()` のように
+/// processor 所有権を動かす callback だけで使い、parameter / state / port query は instance
+/// 作成時に固定した `Arc` capability を読む。
+///
+/// この分離がないと、たとえば wrapper が `activate()` 中に parameter query や state save を
+/// 再入させたとき、adapter は core lock を取れずに「parameter なし」「state 保存失敗」のような
+/// host-visible な欠落を返すことになる。クラッシュ回避としては安全でも、ユーザーの project
+/// data や host routing には悪い結果になる。
 pub(crate) struct PluginInstance {
     plugin: clap_plugin,
-    // `PluginCore` は lifecycle と mutable extension state の所有者です。wrapper format では
-    // CLAP の thread annotation と違う順序・thread で callback が再入することがあるため、
-    // query / flush は `try_read()`、state / configurable ports は `try_write()` に寄せる。
-    // lock cycle を待つより、その callback だけ失敗値を返して host 依存の deadlock を避ける。
+    // `PluginCore` は processor lifecycle の所有者です。host-facing capability は instance
+    // 作成時に Arc として固定し、query/state callback が lifecycle lock と競合して
+    // host-visible metadata や state を欠落させないようにする。
     core: RwLock<Box<dyn PluginCore>>,
     // `get_extension()` は thread-safe callback なので、ここで `PluginCore` lock を取らない。
     // instance 作成時点の capability に固定し、以後は immutable な function table だけを返す。
+    // capability の有無を runtime state と連動させないことで、host が query した瞬間だけ
+    // extension が消えるような不安定な見え方を避ける。
     capabilities: PluginCapabilities,
+    audio_ports: Option<Arc<dyn PluginAudioPorts>>,
+    configurable_audio_ports: Option<Arc<dyn PluginConfigurableAudioPorts>>,
+    note_ports: Option<Arc<dyn PluginNotePorts>>,
+    parameters: Option<Arc<dyn PluginParameters>>,
     state: Option<Arc<dyn PluginStateSupport>>,
     gui: Option<Arc<dyn PluginGui>>,
     // GUI mutation callback は native UI lifecycle に触れる。wrapper が再入・並行
@@ -110,17 +125,26 @@ impl PluginInstance {
             host_parameter_edit_notifier: parameter_edits.clone(),
             host_gui_resize_requester: Arc::new(HostGuiResizeRequest::new(host)),
         };
-        let mut core = (registration.create)(context);
+        let core = (registration.create)(context);
         // wrapper は軽量 query の途中で `get_extension()` を呼ぶことがある。ここで
         // `PluginCore` の lock を待つと host 側の再入順に依存するため、capability は
         // callback が走り始める前の instance 作成時点で固定する。
+        //
+        // 重要なのは、ここで得た Arc を adapter が SoT にしないことです。adapter は
+        // capability への入口だけを保持し、実際の parameter 値、project state、port layout の
+        // SoT は plugin 実装側の store に残す。製品 plugin はそれぞれの store に対して
+        // realtime-safe / non-realtime-safe の境界を自分で設計できる。
+        let audio_ports = core.audio_ports();
+        let configurable_audio_ports = core.configurable_audio_ports();
+        let note_ports = core.note_ports();
+        let parameters = core.parameters();
         let state = core.state();
         let gui = core.gui();
         let capabilities = PluginCapabilities {
-            audio_ports: core.audio_ports().is_some(),
-            configurable_audio_ports: core.configurable_audio_ports().is_some(),
-            note_ports: core.note_ports().is_some(),
-            parameters: core.parameters().is_some(),
+            audio_ports: audio_ports.is_some(),
+            configurable_audio_ports: configurable_audio_ports.is_some(),
+            note_ports: note_ports.is_some(),
+            parameters: parameters.is_some(),
             state: state.is_some(),
             gui: gui.is_some(),
         };
@@ -143,6 +167,10 @@ impl PluginInstance {
             },
             core: RwLock::new(core),
             capabilities,
+            audio_ports,
+            configurable_audio_ports,
+            note_ports,
+            parameters,
             state,
             gui,
             gui_callback_busy: Mutex::new(()),
@@ -481,10 +509,9 @@ unsafe extern "C" fn plugin_deactivate(plugin: *const clap_plugin) {
             log::warn!("plugin.deactivate: missing plugin instance");
             return;
         };
-        let Some(_guard) = instance.try_enter_lifecycle() else {
-            log::warn!("plugin.deactivate: lifecycle is busy");
-            return;
-        };
+        // deactivate は host へ完了を返す前に Processor を必ず回収したい cleanup callback。
+        // wrapper が lifecycle callback を並行させても、ここでは待って破棄漏れを避ける。
+        let _guard = instance.enter_lifecycle_blocking();
         if let Some(processor) = instance.take_processor_blocking() {
             if let Err(error) = instance.core.write().deactivate(processor) {
                 log::warn!("plugin.deactivate: plugin deactivate failed: {error}");

--- a/crates/wrac_clap_adapter/src/abi.rs
+++ b/crates/wrac_clap_adapter/src/abi.rs
@@ -45,8 +45,8 @@ use crate::descriptor::{
 use crate::host_gui::HostGuiResizeRequest;
 use crate::params::ParameterEditQueue;
 use crate::{
-    ActivateContext, PluginCore, PluginCoreContext, PluginGui, ProcessContext, ProcessStatus,
-    Processor,
+    ActivateContext, PluginCore, PluginCoreContext, PluginGui, PluginStateSupport, ProcessContext,
+    ProcessStatus, Processor,
 };
 
 // clap-wrapper は AUv2 metadata 生成時にこの draft factory を読む。CLAP descriptor とは
@@ -69,6 +69,7 @@ pub(crate) struct PluginInstance {
     // `get_extension()` は thread-safe callback なので、ここで `PluginCore` lock を取らない。
     // instance 作成時点の capability に固定し、以後は immutable な function table だけを返す。
     capabilities: PluginCapabilities,
+    state: Option<Arc<dyn PluginStateSupport>>,
     gui: Option<Arc<dyn PluginGui>>,
     // GUI mutation callback は native UI lifecycle に触れる。wrapper が再入・並行
     // 呼び出ししてきた場合は待たずに失敗させ、host 依存の deadlock を避ける。
@@ -113,13 +114,14 @@ impl PluginInstance {
         // wrapper は軽量 query の途中で `get_extension()` を呼ぶことがある。ここで
         // `PluginCore` の lock を待つと host 側の再入順に依存するため、capability は
         // callback が走り始める前の instance 作成時点で固定する。
+        let state = core.state();
         let gui = core.gui();
         let capabilities = PluginCapabilities {
             audio_ports: core.audio_ports().is_some(),
             configurable_audio_ports: core.configurable_audio_ports().is_some(),
             note_ports: core.note_ports().is_some(),
             parameters: core.parameters().is_some(),
-            state: core.state().is_some(),
+            state: state.is_some(),
             gui: gui.is_some(),
         };
         let storage = registration.storage();
@@ -141,6 +143,7 @@ impl PluginInstance {
             },
             core: RwLock::new(core),
             capabilities,
+            state,
             gui,
             gui_callback_busy: Mutex::new(()),
             parameter_edits,

--- a/crates/wrac_clap_adapter/src/abi/audio_ports.rs
+++ b/crates/wrac_clap_adapter/src/abi/audio_ports.rs
@@ -23,17 +23,7 @@ unsafe extern "C" fn audio_ports_count(plugin: *const clap_plugin, is_input: boo
             log::warn!("audio_ports.count: missing plugin instance is_input={is_input}");
             return 0;
         };
-        // wrapper format では、別の lifecycle callback が core write lock を持つ最中に
-        // port metadata を問い合わせることがある。host 側 query path を plugin deadlock
-        // に巻き込むより、この瞬間だけ「取得不可」と返す方が安全。
-        let Some(core) = instance.core.try_read() else {
-            log::warn!(
-                "audio_ports.count: core try_read failed is_input={is_input} thread={:?}",
-                std::thread::current().id()
-            );
-            return 0;
-        };
-        let Some(audio_ports) = core.audio_ports() else {
+        let Some(audio_ports) = instance.audio_ports.as_ref() else {
             log::warn!("audio_ports.count: plugin has no audio ports is_input={is_input}");
             return 0;
         };
@@ -63,14 +53,7 @@ unsafe extern "C" fn audio_ports_get(
             );
             return false;
         };
-        let Some(core) = instance.core.try_read() else {
-            log::warn!(
-                "audio_ports.get: core try_read failed index={index} is_input={is_input} thread={:?}",
-                std::thread::current().id()
-            );
-            return false;
-        };
-        let Some(audio_ports) = core.audio_ports() else {
+        let Some(audio_ports) = instance.audio_ports.as_ref() else {
             log::warn!(
                 "audio_ports.get: plugin has no audio ports index={index} is_input={is_input}"
             );

--- a/crates/wrac_clap_adapter/src/abi/configurable_audio_ports.rs
+++ b/crates/wrac_clap_adapter/src/abi/configurable_audio_ports.rs
@@ -72,16 +72,6 @@ unsafe extern "C" fn configurable_audio_ports_apply_configuration(
             log::warn!("configurable_audio_ports.apply: missing plugin instance");
             return false;
         };
-        // host が `can_apply` を省略しても、Processor が古い port view を使っている間に
-        // layout を変えないよう `apply` 側でも同じ条件を確認する。ここを二重に守らないと、
-        // `can_apply` 直後に activate された場合や、wrapper が直接 apply してきた場合に、
-        // Processor が持つ layout snapshot と実際の host buffer 契約がずれる。
-        if instance.has_processor_or_busy() || instance.lifecycle_busy.load(Ordering::Acquire) {
-            log::warn!(
-                "configurable_audio_ports.apply: rejected while processor/lifecycle is busy"
-            );
-            return false;
-        }
         let Some(requests) = convert_requests(requests, request_count) else {
             log::warn!(
                 "configurable_audio_ports.apply: invalid request pointer count={request_count}"
@@ -93,6 +83,21 @@ unsafe extern "C" fn configurable_audio_ports_apply_configuration(
             log::debug!("configurable_audio_ports.apply: plugin has no configurable audio ports");
             return false;
         };
+
+        // host が `can_apply` を省略しても、Processor が古い port view を使っている間に
+        // layout を変えないよう `apply` 側でも同じ条件を確認する。確認と実際の apply は
+        // 同じ lifecycle guard の内側で行う。そうしないと、processor 不在確認の直後に
+        // `activate()` が古い layout を snapshot し、その後この callback が layout store を
+        // 書き換える race が残る。
+        let Some(_guard) = instance.try_enter_lifecycle() else {
+            log::warn!("configurable_audio_ports.apply: rejected while lifecycle is busy");
+            return false;
+        };
+        if instance.has_processor_or_busy() {
+            log::warn!("configurable_audio_ports.apply: rejected while processor is busy");
+            return false;
+        }
+
         match configurable_audio_ports.apply_audio_port_configuration(&requests) {
             Ok(()) => {
                 log::debug!(

--- a/crates/wrac_clap_adapter/src/abi/configurable_audio_ports.rs
+++ b/crates/wrac_clap_adapter/src/abi/configurable_audio_ports.rs
@@ -28,8 +28,13 @@ unsafe extern "C" fn configurable_audio_ports_can_apply_configuration(
             log::warn!("configurable_audio_ports.can_apply: missing plugin instance");
             return false;
         };
-        // port layout は Processor の buffer view 契約を変える。別の active flag は持たず、
-        // 実際に Processor が存在するかどうかだけで「今は交渉不可」を判断する。
+        // port layout は Processor の buffer view 契約を変えるため、active 中の変更は拒否する。
+        //
+        // WRAC adapter では `start_processing()` / `stop_processing()` を active 判定の SoT に
+        // しない。wrapper によってはそれらを省略・遅延するため、ここでは実際の Processor の
+        // 有無と lifecycle callback 中かどうかだけを見る。これにより、plugin 実装側は
+        // `activate()` で layout を snapshot して Processor に渡せば、その Processor が生きている
+        // 間に layout store が書き換わらない前提を置ける。
         if instance.has_processor_or_busy() || instance.lifecycle_busy.load(Ordering::Acquire) {
             log::warn!(
                 "configurable_audio_ports.can_apply: rejected while processor/lifecycle is busy"
@@ -43,14 +48,7 @@ unsafe extern "C" fn configurable_audio_ports_can_apply_configuration(
             return false;
         };
 
-        let Some(mut core) = instance.core.try_write() else {
-            log::warn!(
-                "configurable_audio_ports.can_apply: core try_write failed thread={:?}",
-                std::thread::current().id()
-            );
-            return false;
-        };
-        let Some(configurable_audio_ports) = core.configurable_audio_ports() else {
+        let Some(configurable_audio_ports) = instance.configurable_audio_ports.as_ref() else {
             log::debug!(
                 "configurable_audio_ports.can_apply: plugin has no configurable audio ports"
             );
@@ -75,7 +73,9 @@ unsafe extern "C" fn configurable_audio_ports_apply_configuration(
             return false;
         };
         // host が `can_apply` を省略しても、Processor が古い port view を使っている間に
-        // layout を変えないよう `apply` 側でも同じ条件を確認する。
+        // layout を変えないよう `apply` 側でも同じ条件を確認する。ここを二重に守らないと、
+        // `can_apply` 直後に activate された場合や、wrapper が直接 apply してきた場合に、
+        // Processor が持つ layout snapshot と実際の host buffer 契約がずれる。
         if instance.has_processor_or_busy() || instance.lifecycle_busy.load(Ordering::Acquire) {
             log::warn!(
                 "configurable_audio_ports.apply: rejected while processor/lifecycle is busy"
@@ -89,14 +89,7 @@ unsafe extern "C" fn configurable_audio_ports_apply_configuration(
             return false;
         };
 
-        let Some(mut core) = instance.core.try_write() else {
-            log::warn!(
-                "configurable_audio_ports.apply: core try_write failed thread={:?}",
-                std::thread::current().id()
-            );
-            return false;
-        };
-        let Some(configurable_audio_ports) = core.configurable_audio_ports() else {
+        let Some(configurable_audio_ports) = instance.configurable_audio_ports.as_ref() else {
             log::debug!("configurable_audio_ports.apply: plugin has no configurable audio ports");
             return false;
         };

--- a/crates/wrac_clap_adapter/src/abi/note_ports.rs
+++ b/crates/wrac_clap_adapter/src/abi/note_ports.rs
@@ -15,16 +15,7 @@ unsafe extern "C" fn note_ports_count(plugin: *const clap_plugin, is_input: bool
             log::warn!("note_ports.count: missing plugin instance is_input={is_input}");
             return 0;
         };
-        // note port query は軽量 metadata call です。wrapper 経由では lifecycle/state
-        // 作業と競合し得るため、この path では `PluginCore` を待たない。
-        let Some(core) = instance.core.try_read() else {
-            log::warn!(
-                "note_ports.count: core try_read failed is_input={is_input} thread={:?}",
-                std::thread::current().id()
-            );
-            return 0;
-        };
-        let Some(note_ports) = core.note_ports() else {
+        let Some(note_ports) = instance.note_ports.as_ref() else {
             log::debug!("note_ports.count: plugin has no note ports is_input={is_input}");
             return 0;
         };
@@ -52,14 +43,7 @@ unsafe extern "C" fn note_ports_get(
             log::warn!("note_ports.get: missing plugin instance index={index} is_input={is_input}");
             return false;
         };
-        let Some(core) = instance.core.try_read() else {
-            log::warn!(
-                "note_ports.get: core try_read failed index={index} is_input={is_input} thread={:?}",
-                std::thread::current().id()
-            );
-            return false;
-        };
-        let Some(note_ports) = core.note_ports() else {
+        let Some(note_ports) = instance.note_ports.as_ref() else {
             log::debug!(
                 "note_ports.get: plugin has no note ports index={index} is_input={is_input}"
             );

--- a/crates/wrac_clap_adapter/src/abi/params_extension.rs
+++ b/crates/wrac_clap_adapter/src/abi/params_extension.rs
@@ -27,23 +27,15 @@ pub(super) static PARAMS: clap_plugin_params = clap_plugin_params {
 };
 
 // VST3/AU/AAX wrapper では parameter query が CLAP の `[main-thread]` 前提から外れて
-// 呼ばれることがある。ここは read lock と `PluginCore` の `&self` API だけに寄せ、
-// GUI/runtime 所有権や lifecycle mutation に入らない。state restore などの write 側と
-// 競合した場合も待たず、host へ「今は取得不可」を返す。
+// 呼ばれることがある。parameters capability は instance 作成時に固定した Arc を直接読み、
+// GUI/runtime 所有権や lifecycle mutation に入らない。
 unsafe extern "C" fn params_count(plugin: *const clap_plugin) -> u32 {
     ffi_u32(|| {
         let Some(instance) = (unsafe { PluginInstance::from_plugin(plugin) }) else {
             log::warn!("params.count: missing plugin instance");
             return 0;
         };
-        let Some(core) = instance.core.try_read() else {
-            log::warn!(
-                "params.count: core try_read failed on thread {:?}",
-                std::thread::current().id()
-            );
-            return 0;
-        };
-        let Some(parameters) = core.parameters() else {
+        let Some(parameters) = instance.parameters.as_ref() else {
             log::warn!("params.count: plugin has no parameters");
             return 0;
         };
@@ -70,14 +62,7 @@ unsafe extern "C" fn params_get_info(
             log::warn!("params.get_info: missing plugin instance index={param_index}");
             return false;
         };
-        let Some(core) = instance.core.try_read() else {
-            log::warn!(
-                "params.get_info: core try_read failed index={param_index} thread={:?}",
-                std::thread::current().id()
-            );
-            return false;
-        };
-        let Some(parameters) = core.parameters() else {
+        let Some(parameters) = instance.parameters.as_ref() else {
             log::warn!("params.get_info: plugin has no parameters index={param_index}");
             return false;
         };
@@ -121,14 +106,7 @@ unsafe extern "C" fn params_get_value(
             log::warn!("params.get_value: missing plugin instance param_id={param_id}");
             return false;
         };
-        let Some(core) = instance.core.try_read() else {
-            log::warn!(
-                "params.get_value: core try_read failed param_id={param_id} thread={:?}",
-                std::thread::current().id()
-            );
-            return false;
-        };
-        let Some(parameters) = core.parameters() else {
+        let Some(parameters) = instance.parameters.as_ref() else {
             log::warn!("params.get_value: plugin has no parameters param_id={param_id}");
             return false;
         };
@@ -159,14 +137,7 @@ unsafe extern "C" fn params_value_to_text(
             log::warn!("params.value_to_text: missing plugin instance param_id={param_id}");
             return false;
         };
-        let Some(core) = instance.core.try_read() else {
-            log::warn!(
-                "params.value_to_text: core try_read failed param_id={param_id} thread={:?}",
-                std::thread::current().id()
-            );
-            return false;
-        };
-        let Some(parameters) = core.parameters() else {
+        let Some(parameters) = instance.parameters.as_ref() else {
             log::warn!("params.value_to_text: plugin has no parameters param_id={param_id}");
             return false;
         };
@@ -201,14 +172,7 @@ unsafe extern "C" fn params_text_to_value(
             log::warn!("params.text_to_value: invalid utf8 param_id={param_id}");
             return false;
         };
-        let Some(core) = instance.core.try_read() else {
-            log::warn!(
-                "params.text_to_value: core try_read failed param_id={param_id} thread={:?}",
-                std::thread::current().id()
-            );
-            return false;
-        };
-        let Some(parameters) = core.parameters() else {
+        let Some(parameters) = instance.parameters.as_ref() else {
             log::warn!("params.text_to_value: plugin has no parameters param_id={param_id}");
             return false;
         };
@@ -238,21 +202,12 @@ unsafe extern "C" fn params_flush(
         };
         unsafe {
             let mut events = crate::ProcessEvents::from_raw(in_events, out_events);
-            // wrapper 固有の realtime-ish path から `flush()` が来ることがある。ここで
-            // lifecycle/state 側の core write lock を待つと adapter が避けたい host 依存の
-            // deadlock を再導入するため、input event の取りこぼしを待機より優先する。
-            if let Some(core) = instance.core.try_read() {
-                if let Some(parameters) = core.parameters() {
-                    instance
-                        .parameter_edits
-                        .apply_input_parameter_events(parameters, &events.input);
-                }
-                drop(core);
+            if let Some(parameters) = instance.parameters.as_ref() {
+                instance
+                    .parameter_edits
+                    .apply_input_parameter_events(parameters.as_ref(), &events.input);
             } else {
-                log::warn!(
-                    "params.flush: core try_read failed thread={:?}",
-                    std::thread::current().id()
-                );
+                log::warn!("params.flush: plugin has no parameters");
             }
             instance
                 .parameter_edits

--- a/crates/wrac_clap_adapter/src/abi/state_extension.rs
+++ b/crates/wrac_clap_adapter/src/abi/state_extension.rs
@@ -13,9 +13,9 @@ pub(super) static STATE: clap_plugin_state = clap_plugin_state {
 
 const MAX_STATE_BYTES: usize = 64 * 1024 * 1024;
 
-// state callback は host format により active 中にも来るため、adapter は core の
-// `&mut self` 呼び出しとして lifecycle mutation と直列化する。既存 Processor と共有する
-// state を audio-safe に更新する責務は、format 非依存の `PluginCore` 実装側に残す。
+// state callback は host format により active 中にも来る。ここで lifecycle 用の
+// `PluginCore` write lock を待つ/諦めると、project save が欠落し得るため、instance 作成時に
+// 固定した thread-safe state capability だけを呼ぶ。
 unsafe extern "C" fn state_save(plugin: *const clap_plugin, stream: *const clap_ostream) -> bool {
     ffi_bool(|| {
         if stream.is_null() {
@@ -26,17 +26,7 @@ unsafe extern "C" fn state_save(plugin: *const clap_plugin, stream: *const clap_
             log::warn!("state.save: missing plugin instance");
             return false;
         };
-        // wrapper によっては UI/project-load path の中で state callback と metadata query
-        // が再入する。Native CLAP の thread model 外で lock cycle を待つより、この state
-        // 操作だけ失敗させる。
-        let Some(mut core) = instance.core.try_write() else {
-            log::warn!(
-                "state.save: core try_write failed thread={:?}",
-                std::thread::current().id()
-            );
-            return false;
-        };
-        let Some(state_support) = core.state() else {
+        let Some(state_support) = instance.state.as_ref() else {
             log::debug!("state.save: plugin has no state support");
             return false;
         };
@@ -94,14 +84,7 @@ unsafe extern "C" fn state_load(plugin: *const clap_plugin, stream: *const clap_
             return false;
         };
 
-        let Some(mut core) = instance.core.try_write() else {
-            log::warn!(
-                "state.load: core try_write failed thread={:?}",
-                std::thread::current().id()
-            );
-            return false;
-        };
-        let Some(state_support) = core.state() else {
+        let Some(state_support) = instance.state.as_ref() else {
             log::debug!("state.load: plugin has no state support");
             return false;
         };
@@ -109,7 +92,6 @@ unsafe extern "C" fn state_load(plugin: *const clap_plugin, stream: *const clap_
             log::warn!("state.load: plugin restore_state failed: {error}");
             return false;
         }
-        drop(core);
         instance.parameter_edits.rescan_values();
         log::debug!("state.load: restored byte_len={len}");
         true

--- a/crates/wrac_clap_adapter/src/api.rs
+++ b/crates/wrac_clap_adapter/src/api.rs
@@ -260,35 +260,76 @@ impl ClapWindow {
     }
 }
 
-/// CLAP plugin instance の lifecycle。
+/// 1 つの plugin instance の lifecycle と capability discovery。
 ///
-/// extension ごとの API をこの trait に押し込むと、audio effect / instrument / GUI なし
-/// plugin などの差が曖昧になる。[`PluginCore`] は lifecycle と capability discovery
-/// だけを持ち、extension 固有の契約は [`PluginAudioPorts`] などへ分ける。
+/// 実装者はこの trait を「plugin 本体」だと考えがちですが、ここに全 state を集める必要は
+/// ありません。むしろ [`PluginCore`] は processor lifecycle と capability の入口だけを持ち、
+/// parameter、state、port layout、GUI などはそれぞれ専用の thread-safe store / capability に
+/// 分けるのが推奨形です。
+///
+/// 理由は、VST3/AU などの wrapper 経由では CLAP の thread annotation や lifecycle 順序が
+/// そのまま守られないことがあるためです。`activate()` / `deactivate()` のような `&mut self`
+/// lifecycle と、parameter query や state save のような host-facing callback を同じ mutable
+/// state に集めると、片方が動いている間にもう片方へ答えられなくなります。
 pub trait PluginCore: Send + Sync + 'static {
     fn activate(&mut self, context: ActivateContext) -> PluginResult<Box<dyn Processor>>;
     fn deactivate(&mut self, processor: Box<dyn Processor>) -> PluginResult<()>;
 
-    fn audio_ports(&self) -> Option<&dyn PluginAudioPorts> {
+    /// Audio port query を実装する object を返す。
+    ///
+    /// この object は instance 作成時に adapter が保持し、その後の port query では
+    /// [`PluginCore`] を借用しません。実装者は port 情報を `PluginCore` の field から直接
+    /// 読ませるのではなく、軽量に並行 read できる layout/schema store へ置いてください。
+    fn audio_ports(&self) -> Option<Arc<dyn PluginAudioPorts>> {
         None
     }
 
-    fn configurable_audio_ports(&mut self) -> Option<&mut dyn PluginConfigurableAudioPorts> {
+    /// Host からの port layout 変更要求を扱う object を返す。
+    ///
+    /// `apply_audio_port_configuration()` は `&self` API ですが、active 中でも自由に layout を
+    /// 変えてよいという意味ではありません。adapter は processor が存在する間、または lifecycle
+    /// callback が走っている間は `can_apply` / `apply` を拒否します。
+    ///
+    /// 実装者側では、この object は「次に activate する processor の layout」を non-realtime
+    /// store に記録するだけにしてください。audio thread からその store を読ませず、
+    /// `activate()` で snapshot して [`Processor`] に渡すと、processor が生きている間に layout
+    /// 契約が変わらないことをコード上で表現できます。
+    fn configurable_audio_ports(&self) -> Option<Arc<dyn PluginConfigurableAudioPorts>> {
         None
     }
 
-    fn note_ports(&self) -> Option<&dyn PluginNotePorts> {
+    /// Note port query を実装する object を返す。
+    ///
+    /// Note port count や dialect は host の routing 判断に使われます。実装者は、lifecycle の
+    /// 一時的な busy 状態に左右されない schema store から答えられるようにしてください。
+    fn note_ports(&self) -> Option<Arc<dyn PluginNotePorts>> {
         None
     }
 
-    fn parameters(&self) -> Option<&dyn PluginParameters> {
+    /// Parameter schema/value query と flush-time parameter input を扱う object を返す。
+    ///
+    /// Parameter は automation、generic editor、state restore 後の rescan などから並行に
+    /// 触られます。schema は immutable data、現在値は atomic/seqlock などの realtime-safe store
+    /// に置き、GUI runtime や project-only state の lock をここから辿らないようにしてください。
+    fn parameters(&self) -> Option<Arc<dyn PluginParameters>> {
         None
     }
 
+    /// Project state の save/restore を扱う object を返す。
+    ///
+    /// State はユーザーの project data を守る経路です。再生中や automation 中に呼ばれても、
+    /// 実装者側の committed state snapshot を返せるようにしてください。`PluginCore` の
+    /// `&mut self` が取れないと保存できない設計にすると、host が retry しない場合に編集内容を
+    /// 失う可能性があります。
     fn state(&self) -> Option<Arc<dyn PluginStateSupport>> {
         None
     }
 
+    /// GUI を扱う object を返す。
+    ///
+    /// GUI 実装は native window や WebView runtime など thread affinity の強い資源を持ちます。
+    /// 実装者は backend の thread 契約を守りつつ、size query などの軽量 API はなるべく
+    /// runtime mutation に依存せず答えられるようにしてください。
     fn gui(&self) -> Option<Arc<dyn PluginGui>> {
         None
     }
@@ -296,46 +337,53 @@ pub trait PluginCore: Send + Sync + 'static {
 
 /// CLAP audio-ports extension に対応する capability。
 ///
-/// wrapper host では port query が任意 thread から呼ばれ得るため、ここは `&self` だけで
-/// 完結させる。active 中に変わる layout は、別途明示的な再設定 API を足すまで扱わない。
-pub trait PluginAudioPorts {
+/// 実装者は、この trait を任意 thread から並行に呼ばれてもよい読み取り API として扱ってください。
+/// port count / channel count / port name は、host が routing や bus layout を決めるための
+/// metadata です。ここで一時的に失敗したり busy 状態によって値が変わったりすると、host が
+/// plugin を正しく配線できなくなります。
+pub trait PluginAudioPorts: Send + Sync + 'static {
     fn audio_port_count(&self, is_input: bool) -> u32;
     fn audio_port_info(&self, index: u32, is_input: bool) -> Option<AudioPortInfo>;
 }
 
 /// CLAP configurable-audio-ports extension に対応する capability。
 ///
-/// VST3 などの wrapper host は speaker arrangement をあとから交渉する。固定 port 情報だけを
-/// 返すと wrapper 内の process adapter が host の実 buffer channel 数とずれ、audio process
-/// が呼ばれないことがあるため、対応 plugin はこの capability で非 active 時の layout 変更を
-/// 受け入れる。
-pub trait PluginConfigurableAudioPorts {
+/// 実装者は、この trait を「inactive 時に次回 activate 用の layout store を更新する API」として
+/// 実装してください。adapter は active 中の apply を拒否しますが、この trait の中でも file IO、
+/// GUI callback、audio thread が待つ lock などには入らないでください。
+///
+/// VST3/AU wrapper は host-native の speaker arrangement と CLAP audio ports を対応させます。
+/// ここで対応 layout を受け入れないと、wrapper 内の process adapter が host の実 buffer channel
+/// 数と合わず、音声処理が呼ばれないことがあります。
+pub trait PluginConfigurableAudioPorts: Send + Sync + 'static {
     fn can_apply_audio_port_configuration(
         &self,
         requests: &[AudioPortConfigurationRequest],
     ) -> bool;
 
     fn apply_audio_port_configuration(
-        &mut self,
+        &self,
         requests: &[AudioPortConfigurationRequest],
     ) -> PluginResult<()>;
 }
 
 /// CLAP note-ports extension に対応する capability。
 ///
-/// notes は audio callback の event stream に流れるが、port 数と dialect は host query で
-/// 先に公開される。audio-ports と同じく wrapper host では任意 thread から読まれ得るため、
-/// 実装は `&self` だけで完結させる。
-pub trait PluginNotePorts {
+/// Note events 自体は process event stream に流れますが、port 数と dialect は host が先に
+/// query します。実装者は audio ports と同じく、ここを immutable schema か軽量 read-only store
+/// から答える API として扱ってください。
+pub trait PluginNotePorts: Send + Sync + 'static {
     fn note_port_count(&self, is_input: bool) -> u32;
     fn note_port_info(&self, index: u32, is_input: bool) -> Option<NotePortInfo>;
 }
 
 /// CLAP params extension に対応する capability。
 ///
-/// parameter query は host の軽量 API から並行に呼ばれやすい。実装は schema と value を
-/// thread-safe に読める形へ寄せ、GUI/runtime 専用 state へ入り込まないようにする。
-pub trait PluginParameters {
+/// 実装者は parameter schema と current value を、host が任意 thread から読めるものとして
+/// 設計してください。特に `parameter_value()` と `apply_parameter_value()` は automation /
+/// flush / generic editor と audio processing の境界に近いため、audio thread が待つ lock を
+/// 共有しない store に寄せるのが安全です。
+pub trait PluginParameters: Send + Sync + 'static {
     fn parameter_count(&self) -> u32;
     fn parameter_info(&self, index: u32) -> Option<ParameterInfo>;
     /// Returns the parameter's current plain value, corresponding to CLAP `get_value`.
@@ -358,10 +406,17 @@ pub struct ParameterValueEvent {
 
 /// CLAP state extension に対応する capability。
 ///
-/// VST3/AU/AAX host は処理が active な間にも state save/restore し得る。
-/// この capability は lifecycle 用の [`PluginCore`] lock から切り離して呼ばれるため、
-/// 実装側は project state の committed snapshot を任意 thread から安全に保存・復元できる
-/// 内部同期境界を持つ必要がある。audio thread が待つ lock をここへ持ち込んではならない。
+/// 実装者は、この trait を [`PluginCore`] の lifecycle から独立した project state 境界として
+/// 実装してください。VST3/AU/AAX host は処理が active な間にも state save/restore し得ます。
+///
+/// `save_state()` は「今 committed になっている project state」を短時間で snapshot して返す
+/// API です。serialize、file IO、GUI dispatch などを lock 中に行うと、host の project save を
+/// 詰まらせたり deadlock の原因になります。
+///
+/// `restore_state()` は decoded state を SoT に commit する API です。parameter のように audio
+/// thread と共有する値は atomic/seqlock などの realtime-safe store へ、editor-only state は
+/// audio thread から読まない project store へ、というように state の種類で同期境界を分けると
+/// 製品実装が破綻しにくくなります。
 pub trait PluginStateSupport: Send + Sync + 'static {
     fn save_state(&self) -> PluginResult<PluginState>;
     fn restore_state(&self, state: PluginState) -> PluginResult<()>;
@@ -369,11 +424,16 @@ pub trait PluginStateSupport: Send + Sync + 'static {
 
 /// CLAP gui extension に対応する capability。
 ///
-/// adapter は GUI callback を main/UI thread に marshal しない。GUI lifecycle / mutation
-/// callback は adapter 側で待たずに guard し、再入・並行呼び出しは失敗値として返す。
-/// query callback は host layout 中の再入に備え、実装側が host-facing/static state だけで
-/// 待たずに答える必要がある。
-/// native GUI object の thread affinity は実装側が自分の backend に合わせて守る。
+/// 実装者は、GUI backend の thread affinity をこの trait の内側で守ってください。adapter は
+/// callback を UI thread に marshal しません。
+///
+/// `get_size()` / `can_resize()` / `resize_hints()` のような query は、host の layout 計算中に
+/// 再入することがあります。できるだけ cached size や static hints から答え、WebView/native
+/// runtime の重い mutation に入らない設計にしてください。
+///
+/// `create()` / `destroy()` / `set_parent()` のような mutation は adapter 側でも再入 guard しますが、
+/// backend 固有の lifecycle 制約までは隠せません。必要なら GUI controller 内に command queue や
+/// main-thread executor を持たせます。
 pub trait PluginGui: Send + Sync + 'static {
     fn is_api_supported(&self, api: GuiApi, is_floating: bool) -> bool;
     fn preferred_api(&self) -> Option<GuiConfiguration>;
@@ -394,8 +454,13 @@ pub trait PluginGui: Send + Sync + 'static {
 
 /// Audio thread で使う processing object。
 ///
-/// processor を core から分けることで、audio callback は同期済み core の write lock
-/// を取らずに済む。この境界を越える state は、明示的に audio-safe なものだけにする。
+/// 実装者は、[`Processor`] を realtime path の所有物として扱ってください。`PluginCore` から
+/// 分けているのは、audio callback が core の write lock や GUI/project state に入らずに済むように
+/// するためです。
+///
+/// `Processor` に渡す state は、`activate()` 時点で copy した immutable 設定、または atomic /
+/// lock-free queue など audio thread が待たない共有状態に限るのが基本です。`Arc<Mutex<_>>` や
+/// `Arc<RwLock<_>>` を渡す場合でも、process 中に lock しない設計にしてください。
 pub trait Processor: Send {
     fn reset(&mut self) {}
     fn process(&mut self, context: ProcessContext<'_>) -> PluginResult<ProcessStatus>;

--- a/crates/wrac_clap_adapter/src/api.rs
+++ b/crates/wrac_clap_adapter/src/api.rs
@@ -285,7 +285,7 @@ pub trait PluginCore: Send + Sync + 'static {
         None
     }
 
-    fn state(&mut self) -> Option<&mut dyn PluginStateSupport> {
+    fn state(&self) -> Option<Arc<dyn PluginStateSupport>> {
         None
     }
 
@@ -358,12 +358,13 @@ pub struct ParameterValueEvent {
 
 /// CLAP state extension に対応する capability。
 ///
-/// VST3/AU/AAX host は処理が active な間にも state restore し得る。adapter はこの
-/// capability を `&mut self` として lifecycle mutation と直列化するが、既に作成済みの
-/// [`Processor`] は並行して処理を続ける可能性がある。
-pub trait PluginStateSupport {
-    fn save_state(&mut self) -> PluginResult<PluginState>;
-    fn restore_state(&mut self, state: PluginState) -> PluginResult<()>;
+/// VST3/AU/AAX host は処理が active な間にも state save/restore し得る。
+/// この capability は lifecycle 用の [`PluginCore`] lock から切り離して呼ばれるため、
+/// 実装側は project state の committed snapshot を任意 thread から安全に保存・復元できる
+/// 内部同期境界を持つ必要がある。audio thread が待つ lock をここへ持ち込んではならない。
+pub trait PluginStateSupport: Send + Sync + 'static {
+    fn save_state(&self) -> PluginResult<PluginState>;
+    fn restore_state(&self, state: PluginState) -> PluginResult<()>;
 }
 
 /// CLAP gui extension に対応する capability。

--- a/crates/wrac_clap_adapter/src/params.rs
+++ b/crates/wrac_clap_adapter/src/params.rs
@@ -34,7 +34,13 @@ impl ParameterEditQueue {
         events: &InputEvents<'_>,
     ) {
         for event in events.parameter_values() {
-            let _ = parameters.apply_parameter_value(event);
+            if let Err(error) = parameters.apply_parameter_value(event) {
+                log::warn!(
+                    "parameter_edits.apply_input: parameter apply failed parameter_id={} value={} error={error}",
+                    event.parameter_id,
+                    event.value
+                );
+            }
         }
     }
 
@@ -42,7 +48,7 @@ impl ParameterEditQueue {
         // audio callback 上で UI thread と待ち合わないため、queue が一瞬 busy なら次回
         // flush/process へ回す。host への request_flush は edit 追加時点で発行済み。
         let Some(mut pending) = self.pending.try_lock() else {
-            log::warn!("parameter_edits.drain: pending queue try_lock failed; retrying later");
+            log::debug!("parameter_edits.drain: pending queue try_lock failed; retrying later");
             return;
         };
 

--- a/src-gui/index.html
+++ b/src-gui/index.html
@@ -18,15 +18,38 @@
           <p class="eyebrow">WRAC Gain</p>
           <p class="version" id="build-info"></p>
         </div>
-        <div class="meter">
-          <button class="value" id="gain-db" type="button">0.0 dB</button>
-          <input class="value value-input" id="gain-input" type="text" hidden />
-        </div>
-        <section class="knob-zone">
-          <button class="knob" id="gain-knob" type="button" aria-label="Gain knob">
-            <div class="knob-track"></div>
-            <div class="knob-indicator" id="knob-indicator"></div>
-          </button>
+        <nav class="tabs" aria-label="Editor pages">
+          <button class="tab is-active" id="tab-controls" type="button" data-page="controls">Controls</button>
+          <button class="tab" id="tab-about" type="button" data-page="about">About</button>
+        </nav>
+        <section class="page is-active" id="page-controls">
+          <div class="meter">
+            <button class="value" id="gain-db" type="button">0.0 dB</button>
+            <input class="value value-input" id="gain-input" type="text" hidden />
+          </div>
+          <section class="knob-zone">
+            <button class="knob" id="gain-knob" type="button" aria-label="Gain knob">
+              <div class="knob-track"></div>
+              <div class="knob-indicator" id="knob-indicator"></div>
+            </button>
+          </section>
+        </section>
+        <section class="page about-page" id="page-about" hidden>
+          <h1>WRAC Gain</h1>
+          <dl>
+            <div>
+              <dt>Vendor</dt>
+              <dd>Your Company</dd>
+            </div>
+            <div>
+              <dt>Format</dt>
+              <dd>CLAP wrapped to AU/VST3</dd>
+            </div>
+            <div>
+              <dt>Processing</dt>
+              <dd>Sample-accurate gain with bypass</dd>
+            </div>
+          </dl>
         </section>
       </main>
       <button class="resize-grip" id="resize-grip" type="button" aria-label="Resize plugin window">

--- a/src-gui/src/main.ts
+++ b/src-gui/src/main.ts
@@ -30,6 +30,13 @@ type ParameterState = {
   text: string;
 };
 
+type EditorPage = "controls" | "about";
+
+type EditorPageState = {
+  type: "editor-page";
+  page: EditorPage;
+};
+
 type SubscribeParametersResponse = {
   ok?: boolean;
   subscriptionId: number;
@@ -53,8 +60,23 @@ const buildInfo = document.querySelector<HTMLParagraphElement>("#build-info");
 const knob = document.querySelector<HTMLButtonElement>("#gain-knob");
 const indicator = document.querySelector<HTMLDivElement>("#knob-indicator");
 const resizeGrip = document.querySelector<HTMLButtonElement>("#resize-grip");
+const tabControls = document.querySelector<HTMLButtonElement>("#tab-controls");
+const tabAbout = document.querySelector<HTMLButtonElement>("#tab-about");
+const pageControls = document.querySelector<HTMLElement>("#page-controls");
+const pageAbout = document.querySelector<HTMLElement>("#page-about");
 
-if (!dbLabel || !gainInput || !buildInfo || !knob || !indicator || !resizeGrip) {
+if (
+  !dbLabel ||
+  !gainInput ||
+  !buildInfo ||
+  !knob ||
+  !indicator ||
+  !resizeGrip ||
+  !tabControls ||
+  !tabAbout ||
+  !pageControls ||
+  !pageAbout
+) {
   throw new Error("required elements not found");
 }
 
@@ -69,6 +91,7 @@ let dragStartGain = gain;
 /** Whether a gesture (drag interaction) is in progress. Prevents double-sending. */
 let gestureActive = false;
 let parameterSubscriptionId: number | undefined;
+let editorPageSubscriptionId: number | undefined;
 
 type ResizeResponse = {
   ok?: boolean;
@@ -137,6 +160,12 @@ const channel = new Channel<ParameterState>((message) => {
   }
 });
 
+const editorPageChannel = new Channel<EditorPageState>((message) => {
+  if (message && message.type === "editor-page") {
+    renderEditorPage(message.page);
+  }
+});
+
 // Initialization: fetch the current gain state, render the UI, and subscribe to changes.
 void (async () => {
   // Call the Rust "get_parameter_state" command via invoke().
@@ -151,6 +180,16 @@ void (async () => {
     channel,
   });
   parameterSubscriptionId = subscription.subscriptionId;
+
+  const initialPage = await invoke<EditorPageState>("get_editor_page");
+  renderEditorPage(initialPage.page);
+  const editorPageSubscription = await invoke<SubscribeParametersResponse>(
+    "subscribe_editor_page",
+    {
+      channel: editorPageChannel,
+    },
+  );
+  editorPageSubscriptionId = editorPageSubscription.subscriptionId;
 })();
 
 function clamp(value: number): number {
@@ -172,6 +211,25 @@ function render(state: ParameterState): void {
   dbLabel.textContent = state.text;
   const angle = gainToAngle(gain);
   indicator.style.transform = `rotate(${angle}deg)`;
+}
+
+function renderEditorPage(page: EditorPage): void {
+  const showControls = page === "controls";
+  tabControls.classList.toggle("is-active", showControls);
+  tabAbout.classList.toggle("is-active", !showControls);
+  tabControls.setAttribute("aria-selected", String(showControls));
+  tabAbout.setAttribute("aria-selected", String(!showControls));
+  pageControls.hidden = !showControls;
+  pageAbout.hidden = showControls;
+  pageControls.classList.toggle("is-active", showControls);
+  pageAbout.classList.toggle("is-active", !showControls);
+}
+
+function setEditorPage(page: EditorPage): void {
+  renderEditorPage(page);
+  void invoke<EditorPageState>("set_editor_page", { page })
+    .then((state) => renderEditorPage(state.page))
+    .catch(() => undefined);
 }
 
 // -----------------------------------------------------------------------
@@ -345,6 +403,16 @@ gainInput.addEventListener("keydown", (event) => {
 });
 gainInput.addEventListener("pointerdown", (event) => event.stopPropagation());
 
+tabControls.addEventListener("click", (event) => {
+  setEditorPage("controls");
+  restoreHostFocusIfNeeded(event.target);
+});
+
+tabAbout.addEventListener("click", (event) => {
+  setEditorPage("about");
+  restoreHostFocusIfNeeded(event.target);
+});
+
 {
   let dragStart:
     | {
@@ -436,8 +504,13 @@ gainInput.addEventListener("pointerdown", (event) => event.stopPropagation());
 window.addEventListener("beforeunload", () => {
   endGesture();
   if (parameterSubscriptionId !== undefined) {
-    void invoke("unsubscribe_parameters", {
+    void invoke("unsubscribe_gui_subscription", {
       subscriptionId: parameterSubscriptionId,
+    });
+  }
+  if (editorPageSubscriptionId !== undefined) {
+    void invoke("unsubscribe_gui_subscription", {
+      subscriptionId: editorPageSubscriptionId,
     });
   }
 });

--- a/src-gui/src/style.css
+++ b/src-gui/src/style.css
@@ -71,6 +71,36 @@ body {
   color: rgba(247, 241, 231, 0.46);
 }
 
+.tabs {
+  margin-top: 16px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+  padding: 4px;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.tab {
+  height: 30px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: rgba(247, 241, 231, 0.62);
+  font: inherit;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.tab.is-active {
+  background: rgba(255, 184, 92, 0.16);
+  color: #fff6e5;
+}
+
+.page {
+  min-height: 278px;
+}
+
 .meter {
   margin-top: 12px;
   display: grid;
@@ -172,4 +202,46 @@ body {
 
 .resize-grip svg {
   pointer-events: none;
+}
+
+.about-page {
+  padding-top: 22px;
+}
+
+.about-page h1 {
+  margin: 0;
+  font-size: 32px;
+  line-height: 1;
+  font-weight: 600;
+}
+
+.about-page dl {
+  margin: 26px 0 0;
+  display: grid;
+  gap: 16px;
+}
+
+.about-page div {
+  display: grid;
+  gap: 5px;
+  padding-bottom: 13px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.about-page dt,
+.about-page dd {
+  margin: 0;
+}
+
+.about-page dt {
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #d9b985;
+}
+
+.about-page dd {
+  color: rgba(247, 241, 231, 0.78);
+  font-size: 13px;
+  line-height: 1.35;
 }

--- a/src-plugin/src/audio.rs
+++ b/src-plugin/src/audio.rs
@@ -21,16 +21,35 @@ use crate::state::SharedState;
 
 /// [`wrac_clap_adapter::PluginCore::activate`] で生成され、host の audio thread に所有される DSP 実体。
 ///
-/// 中身は共有 state への [`Arc`] だけ。[`Processor`] instance は host が
-/// [`wrac_clap_adapter::PluginCore::deactivate`] するまで生き続け、その間に何度も
-/// [`Processor::process`] が呼ばれる。
+/// [`Processor`] instance は host が [`wrac_clap_adapter::PluginCore::deactivate`] するまで
+/// 生き続け、その間に何度も [`Processor::process`] が呼ばれる。
+///
+/// この型に入れる field は「audio thread が待たずに読めるもの」だけにします。
+/// `shared` は atomic parameter store なので process 中に読めます。一方で
+/// `audio_channel_count` は [`PluginCore::activate`](wrac_clap_adapter::PluginCore::activate)
+/// 時点で non-realtime layout store から copy した snapshot です。
+///
+/// この snapshot が適切なのは、adapter が Processor の存在中に configurable-audio-ports の
+/// layout apply を拒否するからです。つまり、layout store は次回 activate 用には更新されますが、
+/// すでに走っている Processor の契約は途中で書き換わりません。
+///
+/// 製品 plugin で layout に応じて DSP graph や channel mapping を変える場合も、ここに
+/// `Arc<RwLock<Layout>>` を渡すのではなく、activate 時に必要な設定へ変換して processor に
+/// 持たせるのが安全です。
 pub(crate) struct WracGainAudioProcessor {
     shared: Arc<SharedState>,
+    // Gain の DSP 自体は channel count を必要としないが、template として
+    // 「layout は activate 時に snapshot して Processor field にする」形を示すために保持する。
+    // debug build では host から来た実 buffer がこの snapshot と合っているかを検査する。
+    audio_channel_count: u32,
 }
 
 impl WracGainAudioProcessor {
-    pub(crate) fn new(shared: Arc<SharedState>) -> Self {
-        Self { shared }
+    pub(crate) fn new(shared: Arc<SharedState>, audio_channel_count: u32) -> Self {
+        Self {
+            shared,
+            audio_channel_count,
+        }
     }
 }
 
@@ -62,6 +81,12 @@ impl Processor for WracGainAudioProcessor {
 
 impl WracGainAudioProcessor {
     fn process_no_alloc(&mut self, mut context: ProcessContext<'_>) -> PluginResult<ProcessStatus> {
+        #[cfg(debug_assertions)]
+        assert_audio_layout_matches_processor_snapshot(
+            &mut context.audio,
+            self.audio_channel_count,
+        );
+
         // ブロック開始時点の gain。event が来るたびに更新される。
         let mut gain = self.shared.gain();
         let mut bypass = self.shared.bypass();
@@ -115,6 +140,36 @@ impl WracGainAudioProcessor {
         // 入力が無音でなければ次のブロックも処理を続けてほしい、という宣言。
         // `Quiet` を返すと host が optimization の判断材料に使う。
         Ok(ProcessStatus::ContinueIfNotQuiet)
+    }
+}
+
+#[cfg(debug_assertions)]
+fn assert_audio_layout_matches_processor_snapshot(
+    audio: &mut AudioProcessBuffer<'_>,
+    expected_channel_count: u32,
+) {
+    // Port layout は `activate()` 時に non-RT store から snapshot して Processor へ渡す。
+    // audio thread では store の lock を読まず、この snapshot と実 buffer の整合だけを見る。
+    //
+    // これは adapter の buffer validation を補うものではなく、activate 時に取得した layout
+    // snapshot を Processor 側でどう使うかを示すデモです。実際の製品 DSP が channel count を
+    // 必要としないなら、この assertion 自体は削って構いません。host/wrapper 由来の不正 buffer
+    // から memory safety を守る責務は adapter 側にあります。
+    debug_assert_eq!(
+        audio.port_pair_count(),
+        1,
+        "WRAC Gain expects exactly one main audio port pair"
+    );
+
+    for port_index in 0..audio.port_pair_count() {
+        let Some(port_pair) = audio.port_pair(port_index) else {
+            continue;
+        };
+        debug_assert_eq!(
+            port_pair.channel_pair_count(),
+            expected_channel_count as usize,
+            "audio buffer channel count must match the layout captured at activate()"
+        );
     }
 }
 

--- a/src-plugin/src/commands.rs
+++ b/src-plugin/src/commands.rs
@@ -12,9 +12,9 @@ use wrac_clap_adapter::{HostGuiResizeRequester, HostParameterEditNotifier};
 use wrac_wxp_gui::WxpGuiResizeHandle;
 use wxp::{Channel, WxpCommandHandler};
 
-use crate::gui::{GuiStateNotifier, GuiSubscriptionId, parameter_payload};
+use crate::gui::{GuiStateNotifier, GuiSubscriptionId, editor_page_payload, parameter_payload};
 use crate::plugin::{parameter_default_value, parameter_host_value, parameter_text_value};
-use crate::state::SharedState;
+use crate::state::{EditorPage, ProjectStateStore, SharedState};
 
 #[derive(Debug, Deserialize)]
 struct RequestGuiResizeRequest {
@@ -28,12 +28,35 @@ struct RequestGuiResizeRequest {
 /// { parameterId, value })` のような形でこれらの command を呼び出す。
 pub(crate) fn register_commands(
     command_handler: Rc<WxpCommandHandler>,
+    project_state: Arc<ProjectStateStore>,
     shared: Arc<SharedState>,
     gui_notifier: Arc<GuiStateNotifier>,
     host_parameter_edit_notifier: Arc<dyn HostParameterEditNotifier>,
     host_gui_resize_requester: Arc<dyn HostGuiResizeRequester>,
     gui_resize_handle: WxpGuiResizeHandle,
 ) {
+    // editor page は音に関係しない project state。audio thread が読む SharedState とは
+    // 別の store に置き、保存時に parameter snapshot と合成する。
+    {
+        let project_state = project_state.clone();
+        command_handler.register_sync("get_editor_page", move |_| {
+            Ok::<_, String>(editor_page_payload(project_state.editor_page()))
+        });
+    }
+
+    {
+        let project_state = project_state.clone();
+        let gui_notifier = gui_notifier.clone();
+        command_handler.register_sync("set_editor_page", move |ctx| {
+            let page = ctx.arg::<String>("page").map_err(|e| e.to_string())?;
+            let editor_page =
+                EditorPage::from_str(&page).ok_or_else(|| "invalid editor page".to_string())?;
+            project_state.set_editor_page(editor_page);
+            gui_notifier.notify_editor_page(editor_page);
+            Ok::<_, String>(editor_page_payload(editor_page))
+        });
+    }
+
     // 現在の parameter 値を取得する。GUI 起動直後の初期表示などに使う。
     {
         let shared = shared.clone();
@@ -150,12 +173,24 @@ pub(crate) fn register_commands(
         });
     }
 
+    {
+        let gui_notifier = gui_notifier.clone();
+        command_handler.register_sync("subscribe_editor_page", move |ctx| {
+            let channel = ctx.arg::<Channel>("channel").map_err(|e| e.to_string())?;
+            let subscription_id = gui_notifier.subscribe_editor_page(channel);
+            Ok::<_, String>(json!({
+                "ok": true,
+                "subscriptionId": subscription_id.get(),
+            }))
+        });
+    }
+
     // subscription を解除する。指定の id が登録されていなければ no-op。
     // id 指定にすることで、遅れて届いた古い cleanup が、後から始まった別の購読を
     // 誤って解除してしまう事故を防げる。
     {
         let gui_notifier = gui_notifier.clone();
-        command_handler.register_sync("unsubscribe_parameters", move |ctx| {
+        command_handler.register_sync("unsubscribe_gui_subscription", move |ctx| {
             let subscription_id = ctx
                 .arg::<u64>("subscriptionId")
                 .map_err(|e| e.to_string())?;

--- a/src-plugin/src/gui.rs
+++ b/src-plugin/src/gui.rs
@@ -37,7 +37,7 @@ use wxp::{
 
 use crate::commands::register_commands;
 use crate::plugin::{PARAM_GAIN_ID, PLUGIN_ID, parameter_value_text};
-use crate::state::SharedState;
+use crate::state::{EditorPage, ProjectStateStore, SharedState};
 
 // GUI window のサイズ範囲 (pixel)。host は initial size でウインドウを開き、
 // ユーザーがリサイズしたときは min..=max の範囲にクランプされる。
@@ -70,6 +70,7 @@ pub(crate) struct GuiIntegration {
 
 #[derive(Clone)]
 struct GuiRuntimeDependencies {
+    project_state: Arc<ProjectStateStore>,
     shared: Arc<SharedState>,
     gui_notifier: Arc<GuiStateNotifier>,
     host_parameter_edit_notifier: Arc<dyn HostParameterEditNotifier>,
@@ -82,6 +83,7 @@ struct GuiRuntimeDependencies {
 /// `plugin.rs` 側には GUI window のサイズ制約や WebView runtime の詳細を置かず、
 /// host-facing な core 実装から GUI 固有の組み立てを切り離す。
 pub(crate) fn create_gui_integration(
+    project_state: Arc<ProjectStateStore>,
     shared: Arc<SharedState>,
     host_parameter_edit_notifier: Arc<dyn HostParameterEditNotifier>,
     host_gui_resize_requester: Arc<dyn HostGuiResizeRequester>,
@@ -95,6 +97,7 @@ pub(crate) fn create_gui_integration(
         },
     );
     let runtime_dependencies = GuiRuntimeDependencies {
+        project_state,
         shared,
         gui_notifier: notifier.clone(),
         host_parameter_edit_notifier,
@@ -164,6 +167,7 @@ impl GuiSubscriptionId {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum GuiSubscriptionKind {
     Parameters,
+    EditorPage,
 }
 
 impl GuiStateNotifier {
@@ -175,13 +179,21 @@ impl GuiStateNotifier {
     }
 
     pub(crate) fn subscribe_parameters(&self, channel: Channel) -> GuiSubscriptionId {
+        self.subscribe(GuiSubscriptionKind::Parameters, channel)
+    }
+
+    pub(crate) fn subscribe_editor_page(&self, channel: Channel) -> GuiSubscriptionId {
+        self.subscribe(GuiSubscriptionKind::EditorPage, channel)
+    }
+
+    fn subscribe(&self, kind: GuiSubscriptionKind, channel: Channel) -> GuiSubscriptionId {
         // id は Rust 側で採番する。wxp の Channel id とは独立させることで、
         // transport (Channel) と購読 lifecycle を別々に管理できる。
         let id = GuiSubscriptionId(self.next_subscription_id.fetch_add(1, Ordering::Relaxed));
         self.subscriptions.lock().insert(
             id,
             GuiSubscription {
-                kind: GuiSubscriptionKind::Parameters,
+                kind,
                 sender: RunLoop::sender(),
                 channel,
             },
@@ -198,13 +210,27 @@ impl GuiStateNotifier {
     }
 
     pub(crate) fn notify_parameter(&self, parameter_id: u32, value: f32) {
+        self.notify(
+            GuiSubscriptionKind::Parameters,
+            parameter_payload(parameter_id, value),
+        );
+    }
+
+    pub(crate) fn notify_editor_page(&self, editor_page: EditorPage) {
+        self.notify(
+            GuiSubscriptionKind::EditorPage,
+            editor_page_payload(editor_page),
+        );
+    }
+
+    fn notify(&self, kind: GuiSubscriptionKind, payload: serde_json::Value) {
         // lock を握ったまま送信しない。送り先の処理が再び notifier を触りに来ても
         // deadlock しないように、配信対象を先に clone してから lock を離す。
         let subscriptions: Vec<_> = self
             .subscriptions
             .lock()
             .values()
-            .filter(|subscription| subscription.kind == GuiSubscriptionKind::Parameters)
+            .filter(|subscription| subscription.kind == kind)
             .cloned()
             .collect();
         if subscriptions.is_empty() {
@@ -212,7 +238,6 @@ impl GuiStateNotifier {
             return;
         }
 
-        let payload = parameter_payload(parameter_id, value);
         for subscription in subscriptions {
             let payload = payload.clone();
             // WebView channel は GUI runtime と同じ UI thread 上で扱う必要がある。
@@ -235,6 +260,13 @@ pub(crate) fn parameter_payload(parameter_id: u32, value: f32) -> serde_json::Va
         "parameterId": parameter_id,
         "value": value,
         "text": parameter_value_text(parameter_id, value as f64).unwrap_or_else(|_| value.to_string()),
+    })
+}
+
+pub(crate) fn editor_page_payload(editor_page: EditorPage) -> serde_json::Value {
+    json!({
+        "type": "editor-page",
+        "page": editor_page.as_str(),
     })
 }
 
@@ -286,6 +318,7 @@ impl WracGainGuiRuntime {
         log::debug!("creating GUI runtime: registering commands");
         register_commands(
             command_handler.clone(),
+            dependencies.project_state.clone(),
             dependencies.shared.clone(),
             dependencies.gui_notifier.clone(),
             dependencies.host_parameter_edit_notifier,

--- a/src-plugin/src/plugin.rs
+++ b/src-plugin/src/plugin.rs
@@ -88,7 +88,12 @@ pub(crate) struct WracGainPlugin {
     // WebView による GUI を CLAP の GUI extension として扱うための helper。
     // `Arc` にしているのは host が `plugin_gui` を複数回問い合わせるため。
     gui: Arc<WxpGuiController>,
-    // GUI が開いているとき、state restore など host-facing 経路から即時反映するための通知口。
+    // Project state は lifecycle 用の PluginCore lock から切り離して保存・復元する。
+    state_support: Arc<WracGainStateSupport>,
+}
+
+struct WracGainStateSupport {
+    shared: Arc<SharedState>,
     gui_notifier: Arc<GuiStateNotifier>,
 }
 
@@ -113,13 +118,17 @@ impl WracGainPlugin {
             context.host_parameter_edit_notifier,
             context.host_gui_resize_requester,
         );
+        let state_support = Arc::new(WracGainStateSupport {
+            shared: shared.clone(),
+            gui_notifier: gui.notifier.clone(),
+        });
 
         Self {
             shared,
             // template の default は stereo。host が configure してくれば書き換わる。
             audio_channel_count: 2,
             gui: gui.controller,
-            gui_notifier: gui.notifier,
+            state_support,
         }
     }
 }
@@ -193,8 +202,8 @@ impl PluginCore for WracGainPlugin {
         Some(self)
     }
 
-    fn state(&mut self) -> Option<&mut dyn PluginStateSupport> {
-        Some(self)
+    fn state(&self) -> Option<Arc<dyn PluginStateSupport>> {
+        Some(self.state_support.clone())
     }
 
     fn gui(&self) -> Option<Arc<dyn PluginGui>> {
@@ -372,8 +381,8 @@ impl PluginParameters for WracGainPlugin {
 // DAW がプロジェクトを保存するときに `save_state` が、開くときに `restore_state` が
 // 呼ばれる。bytes フォーマットは plugin 側で自由に決められるので、ここでは
 // JSON にしておく (人が読めるとデバッグが楽)。
-impl PluginStateSupport for WracGainPlugin {
-    fn save_state(&mut self) -> PluginResult<PluginState> {
+impl PluginStateSupport for WracGainStateSupport {
+    fn save_state(&self) -> PluginResult<PluginState> {
         log::debug!(
             "saving plugin state: gain={}, bypass={}",
             self.shared.gain(),
@@ -387,7 +396,7 @@ impl PluginStateSupport for WracGainPlugin {
         Ok(PluginState { bytes })
     }
 
-    fn restore_state(&mut self, state: PluginState) -> PluginResult<()> {
+    fn restore_state(&self, state: PluginState) -> PluginResult<()> {
         log::debug!("restoring plugin state: byte_count={}", state.bytes.len());
         let state: SavedPluginState =
             serde_json::from_slice(&state.bytes).map_err(|_| PluginError::InvalidState)?;

--- a/src-plugin/src/plugin.rs
+++ b/src-plugin/src/plugin.rs
@@ -381,9 +381,7 @@ impl PluginConfigurableAudioPorts for WracGainConfigurableAudioPorts {
                 PluginError::InvalidState
             })?;
         log::debug!(
-            "applying audio port configuration: previous_channel_count={}, channel_count={}",
-            previous_channel_count,
-            channel_count
+            "applying audio port configuration: previous_channel_count={previous_channel_count}, channel_count={channel_count}"
         );
         self.layout.set_channel_count(channel_count);
         Ok(())

--- a/src-plugin/src/plugin.rs
+++ b/src-plugin/src/plugin.rs
@@ -15,6 +15,7 @@
 
 use std::sync::Arc;
 
+use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use wrac_clap_adapter::{
     ActivateContext, AudioPortConfigurationRequest, AudioPortFlags, AudioPortInfo, AudioPortType,
@@ -83,14 +84,28 @@ pub(crate) struct WracGainPlugin {
     // audio thread / GUI / host から共有して触る状態。
     // 詳細は `SharedState` の doc を参照。
     shared: Arc<SharedState>,
-    // 現在の audio channel 数 (mono なら 1、stereo なら 2)。
-    // configurable audio ports は adapter 側で inactive 時だけ受け付けるので、
-    // audio thread と共有する atomic state にはしない。
-    audio_channel_count: u32,
+    // Port layout は activate 前後の host query / configurable ports で使う非 RT 状態。
+    //
+    // 製品 plugin では channel count や speaker layout を DSP が参照することがよくありますが、
+    // audio thread からこの store を直接読ませないのが重要です。layout 変更は host との交渉で
+    // 決まる non-realtime な出来事で、処理中に RwLock を読みに行くと priority inversion や
+    // callback 再入時の停止要因になります。
+    //
+    // そのため、この store は「次に activate する processor 用の設定」として扱い、`activate()`
+    // で値を snapshot して [`WracGainAudioProcessor`] へ渡します。
+    audio_layout: Arc<AudioLayoutStore>,
+    // Host-facing capability は `PluginCore` の borrow と切り離して Arc で持つ。
+    // wrapper が lifecycle callback 中に query を再入させても、adapter は core lock を取らずに
+    // ここへ到達できる。
+    audio_ports: Arc<WracGainAudioPorts>,
+    configurable_audio_ports: Arc<WracGainConfigurableAudioPorts>,
+    parameters: Arc<WracGainParameters>,
     // WebView による GUI を CLAP の GUI extension として扱うための helper。
     // `Arc` にしているのは host が `plugin_gui` を複数回問い合わせるため。
     gui: Arc<WxpGuiController>,
     // Project state は lifecycle 用の PluginCore lock から切り離して保存・復元する。
+    // project save はユーザーデータ保護の経路なので、active 中や wrapper 再入中でも
+    // committed snapshot を返せる専用 capability にしている。
     state_support: Arc<WracGainStateSupport>,
 }
 
@@ -98,6 +113,57 @@ struct WracGainStateSupport {
     project_state: Arc<ProjectStateStore>,
     shared: Arc<SharedState>,
     gui_notifier: Arc<GuiStateNotifier>,
+}
+
+/// Host と交渉した audio layout の SoT。
+///
+/// この store は non-realtime 専用です。`audio_ports.get()` のような host query と
+/// `configurable_audio_ports.apply()` はここを読み書きしますが、`Processor::process()` は
+/// 読みません。
+///
+/// 製品 plugin で stereo/mono 以外の layout、sidechain、ambisonics などを扱う場合も、
+/// まずはこのような layout store に「次の processor をどう作るか」を記録し、`activate()`
+/// で DSP 用の immutable/snapshot state に変換するのが基本です。
+struct AudioLayoutStore {
+    channel_count: RwLock<u32>,
+}
+
+impl AudioLayoutStore {
+    fn new(channel_count: u32) -> Self {
+        Self {
+            channel_count: RwLock::new(channel_count),
+        }
+    }
+
+    fn channel_count(&self) -> u32 {
+        *self.channel_count.read()
+    }
+
+    fn set_channel_count(&self, channel_count: u32) {
+        *self.channel_count.write() = channel_count;
+    }
+}
+
+struct WracGainAudioPorts {
+    layout: Arc<AudioLayoutStore>,
+}
+
+/// Host からの layout 変更要求を `AudioLayoutStore` に反映する capability。
+///
+/// この型が `&self` で更新できるようにしているのは、adapter が capability を `Arc` で固定し、
+/// `PluginCore` の `&mut self` lifecycle lock を通らずに呼ぶためです。active 中に変更してよい
+/// という意味ではなく、adapter 側が Processor の有無を見て inactive 時だけ呼びます。
+struct WracGainConfigurableAudioPorts {
+    layout: Arc<AudioLayoutStore>,
+}
+
+/// Host-facing parameter API。
+///
+/// Parameter schema/value は DAW の generic editor、automation、state restore 後の rescan から
+/// 並行に読まれます。ここは `SharedState` の atomic parameter SoT だけを触り、GUI runtime や
+/// project-only state には入らないようにしておくと、host query が lifecycle に巻き込まれません。
+struct WracGainParameters {
+    shared: Arc<SharedState>,
 }
 
 /// DAW project に保存される plugin state の serialize 形式。
@@ -117,6 +183,16 @@ pub(crate) struct SavedPluginState {
 impl WracGainPlugin {
     pub(crate) fn new(context: PluginCoreContext) -> Self {
         let shared = Arc::new(SharedState::new());
+        let audio_layout = Arc::new(AudioLayoutStore::new(2));
+        let audio_ports = Arc::new(WracGainAudioPorts {
+            layout: audio_layout.clone(),
+        });
+        let configurable_audio_ports = Arc::new(WracGainConfigurableAudioPorts {
+            layout: audio_layout.clone(),
+        });
+        let parameters = Arc::new(WracGainParameters {
+            shared: shared.clone(),
+        });
         let project_state = Arc::new(ProjectStateStore::new());
         let gui = create_gui_integration(
             project_state.clone(),
@@ -132,8 +208,10 @@ impl WracGainPlugin {
 
         Self {
             shared,
-            // template の default は stereo。host が configure してくれば書き換わる。
-            audio_channel_count: 2,
+            audio_layout,
+            audio_ports,
+            configurable_audio_ports,
+            parameters,
             gui: gui.controller,
             state_support,
         }
@@ -177,14 +255,28 @@ impl PluginCore for WracGainPlugin {
     /// host が audio 処理を開始する直前に呼ばれる。
     /// ここで返した `Processor` が以降 audio thread 上で `process()` される。
     fn activate(&mut self, context: ActivateContext) -> PluginResult<Box<dyn Processor>> {
+        // ここが non-RT layout store と RT processor の境界です。
+        //
+        // adapter は Processor が存在する active 期間中の configurable-audio-ports apply を
+        // 拒否します。そのため、このタイミングで snapshot した channel count は、この
+        // Processor が deactivate されるまで変わらない layout 契約として扱えます。
+        //
+        // Processor に Arc<AudioLayoutStore> を渡すと、将来の DSP 実装者が process() 中に
+        // うっかり lock を読む余地が残ります。activate() で必要な値だけを copy して渡せば、
+        // audio thread 側は immutable な設定として扱えるため、realtime safety の責務が
+        // コード構造として見えます。
+        let audio_channel_count = self.audio_layout.channel_count();
         log::debug!(
             "activating audio processor: sample_rate={}, min_frames_count={}, max_frames_count={}, audio_channel_count={}",
             context.sample_rate,
             context.min_frames_count,
             context.max_frames_count,
-            self.audio_channel_count
+            audio_channel_count
         );
-        Ok(Box::new(WracGainAudioProcessor::new(self.shared.clone())))
+        Ok(Box::new(WracGainAudioProcessor::new(
+            self.shared.clone(),
+            audio_channel_count,
+        )))
     }
 
     /// host が audio 処理を停止したときに呼ばれる。
@@ -197,16 +289,16 @@ impl PluginCore for WracGainPlugin {
     // 以下は CLAP の各 extension の宣言。Some を返すと「この extension を実装している」、
     // None を返すと「未対応」になる。実装本体は別 impl ブロックに書く。
 
-    fn audio_ports(&self) -> Option<&dyn PluginAudioPorts> {
-        Some(self)
+    fn audio_ports(&self) -> Option<Arc<dyn PluginAudioPorts>> {
+        Some(self.audio_ports.clone())
     }
 
-    fn configurable_audio_ports(&mut self) -> Option<&mut dyn PluginConfigurableAudioPorts> {
-        Some(self)
+    fn configurable_audio_ports(&self) -> Option<Arc<dyn PluginConfigurableAudioPorts>> {
+        Some(self.configurable_audio_ports.clone())
     }
 
-    fn parameters(&self) -> Option<&dyn PluginParameters> {
-        Some(self)
+    fn parameters(&self) -> Option<Arc<dyn PluginParameters>> {
+        Some(self.parameters.clone())
     }
 
     fn state(&self) -> Option<Arc<dyn PluginStateSupport>> {
@@ -223,13 +315,13 @@ impl PluginCore for WracGainPlugin {
 // ---------------------------------------------------------------------------
 // gain plugin なので「main in 1 つ」「main out 1 つ」のシンプルな構成。
 // channel 数は configurable audio ports 経由で host が変更できる。
-impl PluginAudioPorts for WracGainPlugin {
+impl PluginAudioPorts for WracGainAudioPorts {
     fn audio_port_count(&self, _is_input: bool) -> u32 {
         1
     }
 
     fn audio_port_info(&self, index: u32, is_input: bool) -> Option<AudioPortInfo> {
-        let channel_count = self.audio_channel_count;
+        let channel_count = self.layout.channel_count();
         (index == 0).then_some(if is_input {
             AudioPortInfo {
                 id: 1,
@@ -263,36 +355,37 @@ impl PluginAudioPorts for WracGainPlugin {
 // ---------------------------------------------------------------------------
 // 例えば host が「stereo から mono に切り替えたい」と提案してきたとき、
 // plugin はそれを受理できるかを `can_apply_*` で答え、`apply_*` で実際に反映する。
-impl PluginConfigurableAudioPorts for WracGainPlugin {
+impl PluginConfigurableAudioPorts for WracGainConfigurableAudioPorts {
     fn can_apply_audio_port_configuration(
         &self,
         requests: &[AudioPortConfigurationRequest],
     ) -> bool {
-        let accepted = resolve_audio_channel_count(self.audio_channel_count, requests);
+        let accepted = resolve_audio_channel_count(self.layout.channel_count(), requests);
         accepted.is_some()
     }
 
     fn apply_audio_port_configuration(
-        &mut self,
+        &self,
         requests: &[AudioPortConfigurationRequest],
     ) -> PluginResult<()> {
-        // adapter 側が Processor の存在中は configuration apply を拒否するので、
-        // core の通常 field を更新すれば後続の port 問い合わせと次回 activate に反映される。
+        // adapter 側が Processor の存在中は configuration apply を拒否する。ここは非 RT
+        // query 専用 store だけを更新し、audio thread は activate 時の snapshot を使う。
+        let previous_channel_count = self.layout.channel_count();
         let channel_count =
-            resolve_audio_channel_count(self.audio_channel_count, requests).ok_or_else(|| {
+            resolve_audio_channel_count(previous_channel_count, requests).ok_or_else(|| {
                 log::warn!(
                     "rejecting unsupported audio port configuration: request_count={}, current_channel_count={}",
                     requests.len(),
-                    self.audio_channel_count
+                    previous_channel_count
                 );
                 PluginError::InvalidState
             })?;
         log::debug!(
             "applying audio port configuration: previous_channel_count={}, channel_count={}",
-            self.audio_channel_count,
+            previous_channel_count,
             channel_count
         );
-        self.audio_channel_count = channel_count;
+        self.layout.set_channel_count(channel_count);
         Ok(())
     }
 }
@@ -302,7 +395,7 @@ impl PluginConfigurableAudioPorts for WracGainPlugin {
 // ---------------------------------------------------------------------------
 // host から見える parameter API。template 利用時に parameter を増やす場合は、
 // ここが host に公開する schema と文字列表現の追加ポイントになる。
-impl PluginParameters for WracGainPlugin {
+impl PluginParameters for WracGainParameters {
     fn parameter_count(&self) -> u32 {
         // 新しい parameter を追加するときは、この数と `parameter_info()` の match を
         // 一緒に更新する。

--- a/src-plugin/src/plugin.rs
+++ b/src-plugin/src/plugin.rs
@@ -27,7 +27,9 @@ use wrac_wxp_gui::WxpGuiController;
 
 use crate::audio::WracGainAudioProcessor;
 use crate::gui::{GuiStateNotifier, create_gui_integration};
-use crate::state::SharedState;
+use crate::state::{
+    EditorPage, ParameterStateSnapshot, ProjectState, ProjectStateStore, SharedState,
+};
 
 // plugin を識別する reverse-DNS 形式の ID。DAW が plugin を一意に判別するために
 // 使うので、自分の plugin を作るときはここを必ず変更する。
@@ -93,32 +95,37 @@ pub(crate) struct WracGainPlugin {
 }
 
 struct WracGainStateSupport {
+    project_state: Arc<ProjectStateStore>,
     shared: Arc<SharedState>,
     gui_notifier: Arc<GuiStateNotifier>,
 }
 
 /// DAW project に保存される plugin state の serialize 形式。
 ///
-/// `serde_json` で JSON にして bytes として host に渡し、復元時は逆に読み戻す。
-/// gain の値だけを persist する単純な構造だが、新しい parameter を追加する際は
-/// この struct を拡張して `restore_state` で欠落 field を default 値に埋めると
-/// 古い project ファイルとの互換性を保ちやすい。
+/// `serde_json` で JSON にして bytes として host に渡し、復元時は逆に読み戻す。realtime な
+/// parameter は [`SharedState`] から、editor-only state は [`ProjectStateStore`] から snapshot
+/// して、この保存形式へ合成する。
 #[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct SavedPluginState {
     pub(crate) gain: f32,
     #[serde(default)]
     pub(crate) bypass: bool,
+    #[serde(default)]
+    pub(crate) editor_page: EditorPage,
 }
 
 impl WracGainPlugin {
     pub(crate) fn new(context: PluginCoreContext) -> Self {
         let shared = Arc::new(SharedState::new());
+        let project_state = Arc::new(ProjectStateStore::new());
         let gui = create_gui_integration(
+            project_state.clone(),
             shared.clone(),
             context.host_parameter_edit_notifier,
             context.host_gui_resize_requester,
         );
         let state_support = Arc::new(WracGainStateSupport {
+            project_state: project_state.clone(),
             shared: shared.clone(),
             gui_notifier: gui.notifier.clone(),
         });
@@ -383,14 +390,18 @@ impl PluginParameters for WracGainPlugin {
 // JSON にしておく (人が読めるとデバッグが楽)。
 impl PluginStateSupport for WracGainStateSupport {
     fn save_state(&self) -> PluginResult<PluginState> {
+        let project = self.project_state.snapshot();
+        let params = self.shared.snapshot_parameters();
         log::debug!(
-            "saving plugin state: gain={}, bypass={}",
-            self.shared.gain(),
-            self.shared.bypass()
+            "saving plugin state: gain={}, bypass={}, editor_page={}",
+            params.gain,
+            params.bypass,
+            project.editor_page.as_str()
         );
         let bytes = serde_json::to_vec(&SavedPluginState {
-            gain: self.shared.gain(),
-            bypass: self.shared.bypass(),
+            gain: params.gain,
+            bypass: params.bypass,
+            editor_page: project.editor_page,
         })
         .map_err(|_| PluginError::InvalidState)?;
         Ok(PluginState { bytes })
@@ -400,14 +411,19 @@ impl PluginStateSupport for WracGainStateSupport {
         log::debug!("restoring plugin state: byte_count={}", state.bytes.len());
         let state: SavedPluginState =
             serde_json::from_slice(&state.bytes).map_err(|_| PluginError::InvalidState)?;
-        let gain = self
-            .shared
-            .set_parameter_value(PARAM_GAIN_ID, state.gain as f64)
-            .ok_or(PluginError::InvalidParameter)?;
-        self.shared
-            .set_parameter_value(PARAM_BYPASS_ID, f64::from(state.bypass))
-            .ok_or(PluginError::InvalidParameter)?;
-        self.gui_notifier.notify_parameter(PARAM_GAIN_ID, gain);
+        let project = ProjectState {
+            editor_page: state.editor_page,
+        };
+        self.project_state.commit(project);
+        self.shared.restore_parameters(ParameterStateSnapshot {
+            gain: state.gain,
+            bypass: state.bypass,
+        });
+        self.gui_notifier
+            .notify_parameter(PARAM_GAIN_ID, self.shared.gain());
+        self.gui_notifier
+            .notify_parameter(PARAM_BYPASS_ID, f32::from(self.shared.bypass()));
+        self.gui_notifier.notify_editor_page(project.editor_page);
         Ok(())
     }
 }

--- a/src-plugin/src/state.rs
+++ b/src-plugin/src/state.rs
@@ -6,8 +6,91 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use atomic_float::AtomicF32;
+use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
 
 use crate::plugin::{DEFAULT_GAIN, PARAM_BYPASS_ID, PARAM_GAIN_ID, clamp_gain};
+
+/// DAW project に保存するが、audio thread からは読まない editor state。
+///
+/// window size のような host 管理の state ではなく、plugin UI 内の表示ページを例にしている。
+/// 製品 plugin では IR path、track color、editor-only preference などもこの系統に入る。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum EditorPage {
+    Controls,
+    About,
+}
+
+impl Default for EditorPage {
+    fn default() -> Self {
+        Self::Controls
+    }
+}
+
+impl EditorPage {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Controls => "controls",
+            Self::About => "about",
+        }
+    }
+
+    pub(crate) fn from_str(value: &str) -> Option<Self> {
+        match value {
+            "controls" => Some(Self::Controls),
+            "about" => Some(Self::About),
+            _ => None,
+        }
+    }
+}
+
+/// DAW project に保存する non-realtime state。
+///
+/// audio thread はこの型も [`ProjectStateStore`] の lock も触らない。保存時は短く clone し、
+/// 復元時は decode/validate 済みの snapshot を短く commit するだけにしておく。
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct ProjectState {
+    pub(crate) editor_page: EditorPage,
+}
+
+/// ProjectState の SoT。
+///
+/// `RwLock` は non-realtime state の snapshot/commit だけに使う。lock 中で serialize、
+/// host callback、GUI 同期 dispatch、file IO などを行わないことが重要。
+pub(crate) struct ProjectStateStore {
+    state: RwLock<ProjectState>,
+}
+
+impl ProjectStateStore {
+    pub(crate) fn new() -> Self {
+        Self {
+            state: RwLock::new(ProjectState::default()),
+        }
+    }
+
+    pub(crate) fn snapshot(&self) -> ProjectState {
+        *self.state.read()
+    }
+
+    pub(crate) fn commit(&self, state: ProjectState) {
+        *self.state.write() = state;
+    }
+
+    pub(crate) fn editor_page(&self) -> EditorPage {
+        self.snapshot().editor_page
+    }
+
+    pub(crate) fn set_editor_page(&self, editor_page: EditorPage) {
+        self.state.write().editor_page = editor_page;
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ParameterStateSnapshot {
+    pub(crate) gain: f32,
+    pub(crate) bypass: bool,
+}
 
 /// audio processor / GUI / host からの問い合わせ が共有する thread-safe な state。
 ///
@@ -16,9 +99,11 @@ use crate::plugin::{DEFAULT_GAIN, PARAM_BYPASS_ID, PARAM_GAIN_ID, clamp_gain};
 /// - GUI thread   : ユーザーが slider を動かして gain を書き換える
 /// - host thread  : [`wrac_clap_adapter::PluginParameters::parameter_value`] などで host が値を尋ねてくる
 ///
-/// そのため値の "Single Source of Truth (SoT)" を [`crate::plugin::WracGainPlugin`] の私有
-/// field に置くのではなく、[`std::sync::Arc`]<[`SharedState`]> として共有する。lock 不要な
-/// [`AtomicF32`] を使うことで audio thread を待たせない実装になっている。
+/// そのため realtime/current parameter values は [`std::sync::Arc`]<[`SharedState`]> として
+/// 共有する。lock 不要な [`AtomicF32`] を使うことで audio thread を待たせない。
+///
+/// DAW project に保存する non-realtime state は [`ProjectStateStore`] に分ける。`save_state()`
+/// は `SharedState` の parameter snapshot と `ProjectStateStore` の project snapshot を合成する。
 pub(crate) struct SharedState {
     // gain の現在値 (線形 amplitude)。lock-free に読み書きする。
     gain: AtomicF32,
@@ -40,6 +125,22 @@ impl SharedState {
 
     pub(crate) fn bypass(&self) -> bool {
         self.bypass.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn snapshot_parameters(&self) -> ParameterStateSnapshot {
+        // Gain では parameter 同士に強い transaction 境界がないため、単純な atomic load で十分。
+        // 複数 field の完全一貫 snapshot が必要な製品では、この関数の中に seqlock 風の
+        // generation check を閉じ込める。
+        ParameterStateSnapshot {
+            gain: self.gain(),
+            bypass: self.bypass(),
+        }
+    }
+
+    pub(crate) fn restore_parameters(&self, snapshot: ParameterStateSnapshot) {
+        self.gain
+            .store(clamp_gain(snapshot.gain), Ordering::Release);
+        self.bypass.store(snapshot.bypass, Ordering::Release);
     }
 
     /// 指定された parameter の現在値を返す。
@@ -78,12 +179,17 @@ impl SharedState {
 
 #[cfg(test)]
 mod tests {
-    use super::SharedState;
+    use super::{ProjectStateStore, SharedState};
 
     const fn assert_send_sync<T: Send + Sync>() {}
 
     #[test]
     fn shared_state_is_send_sync() {
         assert_send_sync::<SharedState>();
+    }
+
+    #[test]
+    fn project_state_store_is_send_sync() {
+        assert_send_sync::<ProjectStateStore>();
     }
 }


### PR DESCRIPTION
## Summary
- Store host-facing capability objects on PluginInstance so query/state callbacks do not depend on the PluginCore lifecycle lock.
- Move the gain template ports/params/state examples to dedicated thread-safe stores and snapshot audio layout at activate.
- Document implementation-side thread/lifecycle expectations for plugin authors.

## Verification
- cargo fmt --all --check
- cargo check --workspace
- cargo test -p wrac_clap_adapter -p wrac_gain_plugin
- npm run build
- cargo xtask build --target=au,vst3
- pluginval strictness 10: VST3 SUCCESS
- pluginval strictness 10: AU aborted with known flaky `Abort trap: 6`; no new WRAC WARN/ERROR entries in the latest log session