### PR TITLE
Improve frontend About metadata and modal controls

### DIFF
--- a/src-gui/index.html
+++ b/src-gui/index.html
@@ -16,7 +16,11 @@
       <main class="panel">
         <div class="header">
           <button class="plugin-name" id="plugin-name" type="button"></button>
-          <p class="version" id="build-info"></p>
+          <button
+            class="header-action"
+            id="header-action"
+            type="button"
+          ></button>
         </div>
         <section class="page is-active" id="page-controls">
           <div class="meter">
@@ -41,7 +45,7 @@
           </section>
         </section>
         <section class="page about-page" id="page-about" hidden>
-          <button class="about-title" id="about-title" type="button"></button>
+          <h1 class="about-title" id="about-title"></h1>
           <dl>
             <div>
               <dt>Plugin Name</dt>

--- a/src-gui/index.html
+++ b/src-gui/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>WRAC Gain</title>
+    <title>Plugin</title>
     <!--
       Load the entry point as a Vite module script.
       In debug builds, the Vite dev server serves the .ts file directly.
@@ -15,46 +15,67 @@
     <div id="app">
       <main class="panel">
         <div class="header">
-          <p class="eyebrow">WRAC Gain</p>
+          <button class="plugin-name" id="plugin-name" type="button"></button>
           <p class="version" id="build-info"></p>
         </div>
-        <nav class="tabs" aria-label="Editor pages">
-          <button class="tab is-active" id="tab-controls" type="button" data-page="controls">Controls</button>
-          <button class="tab" id="tab-about" type="button" data-page="about">About</button>
-        </nav>
         <section class="page is-active" id="page-controls">
           <div class="meter">
             <button class="value" id="gain-db" type="button">0.0 dB</button>
-            <input class="value value-input" id="gain-input" type="text" hidden />
+            <input
+              class="value value-input"
+              id="gain-input"
+              type="text"
+              hidden
+            />
           </div>
           <section class="knob-zone">
-            <button class="knob" id="gain-knob" type="button" aria-label="Gain knob">
+            <button
+              class="knob"
+              id="gain-knob"
+              type="button"
+              aria-label="Gain knob"
+            >
               <div class="knob-track"></div>
               <div class="knob-indicator" id="knob-indicator"></div>
             </button>
           </section>
         </section>
         <section class="page about-page" id="page-about" hidden>
-          <h1>WRAC Gain</h1>
+          <button class="about-title" id="about-title" type="button"></button>
           <dl>
             <div>
-              <dt>Vendor</dt>
-              <dd>Your Company</dd>
+              <dt>Plugin Name</dt>
+              <dd id="about-plugin-name"></dd>
             </div>
             <div>
-              <dt>Format</dt>
-              <dd>CLAP wrapped to AU/VST3</dd>
+              <dt>Version</dt>
+              <dd id="about-version"></dd>
             </div>
             <div>
-              <dt>Processing</dt>
-              <dd>Sample-accurate gain with bypass</dd>
+              <dt>Company Name</dt>
+              <dd id="about-company-name"></dd>
+            </div>
+            <div>
+              <dt>Build</dt>
+              <dd id="about-build"></dd>
             </div>
           </dl>
         </section>
       </main>
-      <button class="resize-grip" id="resize-grip" type="button" aria-label="Resize plugin window">
+      <button
+        class="resize-grip"
+        id="resize-grip"
+        type="button"
+        aria-label="Resize plugin window"
+      >
         <svg width="18" height="18" viewBox="0 0 12 12" aria-hidden="true">
-          <path d="M2 10L10 2M5 10L10 5M8 10L10 8" fill="none" stroke="currentColor" stroke-width="1" stroke-linecap="round" />
+          <path
+            d="M2 10L10 2M5 10L10 5M8 10L10 8"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1"
+            stroke-linecap="round"
+          />
         </svg>
       </button>
     </div>

--- a/src-gui/src/main.ts
+++ b/src-gui/src/main.ts
@@ -61,9 +61,10 @@ const MAX_ANGLE = 135;
 // --- DOM element references ---
 const dbLabel = document.querySelector<HTMLButtonElement>("#gain-db");
 const gainInput = document.querySelector<HTMLInputElement>("#gain-input");
-const buildInfo = document.querySelector<HTMLParagraphElement>("#build-info");
+const headerAction =
+  document.querySelector<HTMLButtonElement>("#header-action");
 const pluginName = document.querySelector<HTMLButtonElement>("#plugin-name");
-const aboutTitle = document.querySelector<HTMLButtonElement>("#about-title");
+const aboutTitle = document.querySelector<HTMLElement>("#about-title");
 const aboutPluginName =
   document.querySelector<HTMLElement>("#about-plugin-name");
 const aboutVersion = document.querySelector<HTMLElement>("#about-version");
@@ -80,7 +81,7 @@ const pageAbout = document.querySelector<HTMLElement>("#page-about");
 if (
   !dbLabel ||
   !gainInput ||
-  !buildInfo ||
+  !headerAction ||
   !pluginName ||
   !aboutTitle ||
   !aboutPluginName ||
@@ -105,7 +106,6 @@ aboutPluginName.textContent = __WRAC_PLUGIN_METADATA__.pluginName;
 aboutVersion.textContent = __WRAC_PLUGIN_METADATA__.version;
 aboutCompanyName.textContent = __WRAC_PLUGIN_METADATA__.companyName;
 aboutBuild.textContent = `${buildType} build`;
-buildInfo.textContent = `v${__WRAC_PLUGIN_METADATA__.version}`;
 document.title = __WRAC_PLUGIN_METADATA__.pluginName;
 
 // --- State ---
@@ -259,6 +259,14 @@ function renderEditorPage(page: EditorPage): void {
   pluginName.setAttribute(
     "aria-label",
     showControls ? "Show about page" : "Show controls",
+  );
+  headerAction.textContent = showControls
+    ? `v${__WRAC_PLUGIN_METADATA__.version}`
+    : "×";
+  headerAction.disabled = showControls;
+  headerAction.setAttribute(
+    "aria-label",
+    showControls ? "Plugin version" : "Close about page",
   );
 }
 
@@ -441,27 +449,27 @@ gainInput.addEventListener("keydown", (event) => {
 gainInput.addEventListener("pointerdown", (event) => event.stopPropagation());
 
 // About は設定画面ではなく plugin identity の詳細表示なので、常設タブではなく
-// plugin 名そのものを入口にする。メイン操作面の余計な segmented control を避けるため。
+// plugin 名そのものを入口/切り替えにする。メイン操作面の余計な segmented control を避けるため。
 pluginName.addEventListener("click", (event) => {
-  setEditorPage("about");
+  setEditorPage(pageAbout.hidden ? "about" : "controls");
   restoreHostFocusIfNeeded(event.target);
 });
 
-aboutTitle.addEventListener("click", (event) => {
+// About は full-screen modal 相当の一時表示なので、右上の明示的な close affordance で戻す。
+// 中央の plugin 名は情報表示に留め、閉じる操作と混同させない。
+headerAction.addEventListener("click", (event) => {
   setEditorPage("controls");
   restoreHostFocusIfNeeded(event.target);
 });
 
 {
-  let dragStart:
-    | {
-        pointerId: number;
-        x: number;
-        y: number;
-        width: number;
-        height: number;
-      }
-    | null = null;
+  let dragStart: {
+    pointerId: number;
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  } | null = null;
   let resizeFrame = 0;
   let inFlight = false;
   let queuedSize: { width: number; height: number } | null = null;

--- a/src-gui/src/main.ts
+++ b/src-gui/src/main.ts
@@ -264,6 +264,7 @@ function renderEditorPage(page: EditorPage): void {
     ? `v${__WRAC_PLUGIN_METADATA__.version}`
     : "×";
   headerAction.disabled = showControls;
+  headerAction.classList.toggle("is-close", !showControls);
   headerAction.setAttribute(
     "aria-label",
     showControls ? "Plugin version" : "Close about page",

--- a/src-gui/src/main.ts
+++ b/src-gui/src/main.ts
@@ -17,7 +17,12 @@
 import { Channel, invoke } from "@novonotes/webview-bridge";
 import "./style.css";
 
-declare const __WRAC_GAIN_VERSION__: string;
+declare const __WRAC_PLUGIN_METADATA__: {
+  pluginId: string;
+  pluginName: string;
+  companyName: string;
+  version: string;
+};
 
 /** Type definition matching the JSON produced by parameter_payload() on the Rust side */
 type ParameterState = {
@@ -57,11 +62,18 @@ const MAX_ANGLE = 135;
 const dbLabel = document.querySelector<HTMLButtonElement>("#gain-db");
 const gainInput = document.querySelector<HTMLInputElement>("#gain-input");
 const buildInfo = document.querySelector<HTMLParagraphElement>("#build-info");
+const pluginName = document.querySelector<HTMLButtonElement>("#plugin-name");
+const aboutTitle = document.querySelector<HTMLButtonElement>("#about-title");
+const aboutPluginName =
+  document.querySelector<HTMLElement>("#about-plugin-name");
+const aboutVersion = document.querySelector<HTMLElement>("#about-version");
+const aboutCompanyName = document.querySelector<HTMLElement>(
+  "#about-company-name",
+);
+const aboutBuild = document.querySelector<HTMLElement>("#about-build");
 const knob = document.querySelector<HTMLButtonElement>("#gain-knob");
 const indicator = document.querySelector<HTMLDivElement>("#knob-indicator");
 const resizeGrip = document.querySelector<HTMLButtonElement>("#resize-grip");
-const tabControls = document.querySelector<HTMLButtonElement>("#tab-controls");
-const tabAbout = document.querySelector<HTMLButtonElement>("#tab-about");
 const pageControls = document.querySelector<HTMLElement>("#page-controls");
 const pageAbout = document.querySelector<HTMLElement>("#page-about");
 
@@ -69,18 +81,32 @@ if (
   !dbLabel ||
   !gainInput ||
   !buildInfo ||
+  !pluginName ||
+  !aboutTitle ||
+  !aboutPluginName ||
+  !aboutVersion ||
+  !aboutCompanyName ||
+  !aboutBuild ||
   !knob ||
   !indicator ||
   !resizeGrip ||
-  !tabControls ||
-  !tabAbout ||
   !pageControls ||
   !pageAbout
 ) {
   throw new Error("required elements not found");
 }
 
-buildInfo.textContent = `v${__WRAC_GAIN_VERSION__} (${import.meta.env.PROD ? "Release" : "Debug"})`;
+const buildType = import.meta.env.PROD ? "Release" : "Debug";
+// About に出す identity は Vite が src-plugin/Cargo.toml から埋め込んだ値だけを使う。
+// テンプレート利用者が plugin を改名した時に、Rust descriptor と GUI 表示が分岐しないようにする。
+pluginName.textContent = __WRAC_PLUGIN_METADATA__.pluginName;
+aboutTitle.textContent = __WRAC_PLUGIN_METADATA__.pluginName;
+aboutPluginName.textContent = __WRAC_PLUGIN_METADATA__.pluginName;
+aboutVersion.textContent = __WRAC_PLUGIN_METADATA__.version;
+aboutCompanyName.textContent = __WRAC_PLUGIN_METADATA__.companyName;
+aboutBuild.textContent = `${buildType} build`;
+buildInfo.textContent = `v${__WRAC_PLUGIN_METADATA__.version}`;
+document.title = __WRAC_PLUGIN_METADATA__.pluginName;
 
 // --- State ---
 let gain = 1;
@@ -109,7 +135,10 @@ function isEditableElement(target: EventTarget | null): boolean {
 }
 
 function restoreHostFocusIfNeeded(target?: EventTarget | null): void {
-  if (isEditableElement(target ?? null) || isEditableElement(document.activeElement)) {
+  if (
+    isEditableElement(target ?? null) ||
+    isEditableElement(document.activeElement)
+  ) {
     return;
   }
   window.setTimeout(() => {
@@ -176,9 +205,12 @@ void (async () => {
   // Register the Channel on the Rust side and remember the returned subscriptionId.
   // Passing that id back on unsubscribe guarantees we tear down only our own
   // subscription, even if a remount created another one in the meantime.
-  const subscription = await invoke<SubscribeParametersResponse>("subscribe_parameters", {
-    channel,
-  });
+  const subscription = await invoke<SubscribeParametersResponse>(
+    "subscribe_parameters",
+    {
+      channel,
+    },
+  );
   parameterSubscriptionId = subscription.subscriptionId;
 
   const initialPage = await invoke<EditorPageState>("get_editor_page");
@@ -190,6 +222,11 @@ void (async () => {
     },
   );
   editorPageSubscriptionId = editorPageSubscription.subscriptionId;
+  // WebView console に頼らず、native log だけで frontend 初期化完了を確認できるようにする。
+  // DAW 上の plugin GUI では devtools を開けない環境があるため、この境界ログを残す。
+  await invoke("write_to_log", {
+    message: "GUI initialization completed",
+  });
 })();
 
 function clamp(value: number): number {
@@ -215,14 +252,14 @@ function render(state: ParameterState): void {
 
 function renderEditorPage(page: EditorPage): void {
   const showControls = page === "controls";
-  tabControls.classList.toggle("is-active", showControls);
-  tabAbout.classList.toggle("is-active", !showControls);
-  tabControls.setAttribute("aria-selected", String(showControls));
-  tabAbout.setAttribute("aria-selected", String(!showControls));
   pageControls.hidden = !showControls;
   pageAbout.hidden = showControls;
   pageControls.classList.toggle("is-active", showControls);
   pageAbout.classList.toggle("is-active", !showControls);
+  pluginName.setAttribute(
+    "aria-label",
+    showControls ? "Show about page" : "Show controls",
+  );
 }
 
 function setEditorPage(page: EditorPage): void {
@@ -403,13 +440,15 @@ gainInput.addEventListener("keydown", (event) => {
 });
 gainInput.addEventListener("pointerdown", (event) => event.stopPropagation());
 
-tabControls.addEventListener("click", (event) => {
-  setEditorPage("controls");
+// About は設定画面ではなく plugin identity の詳細表示なので、常設タブではなく
+// plugin 名そのものを入口にする。メイン操作面の余計な segmented control を避けるため。
+pluginName.addEventListener("click", (event) => {
+  setEditorPage("about");
   restoreHostFocusIfNeeded(event.target);
 });
 
-tabAbout.addEventListener("click", (event) => {
-  setEditorPage("about");
+aboutTitle.addEventListener("click", (event) => {
+  setEditorPage("controls");
   restoreHostFocusIfNeeded(event.target);
 });
 

--- a/src-gui/src/style.css
+++ b/src-gui/src/style.css
@@ -84,12 +84,23 @@ body {
 }
 
 .header-action {
+  display: grid;
+  min-width: 30px;
+  height: 28px;
+  place-items: center;
+  border-radius: 6px;
   font-size: 11px;
   color: rgba(247, 241, 231, 0.46);
 }
 
 .header-action:not(:disabled) {
+  border: 1px solid rgba(217, 185, 133, 0.44);
   color: #d9b985;
+}
+
+.header-action.is-close {
+  font-size: 19px;
+  line-height: 1;
 }
 
 .header-action:disabled {

--- a/src-gui/src/style.css
+++ b/src-gui/src/style.css
@@ -59,28 +59,41 @@ body {
 }
 
 .plugin-name,
-.version {
+.header-action {
   margin: 0;
 }
 
-.plugin-name {
+.plugin-name,
+.header-action {
   padding: 0;
   border: 0;
   background: transparent;
-  font-size: 11px;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
   color: #d9b985;
   cursor: pointer;
 }
 
-.plugin-name:hover {
+.plugin-name {
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.plugin-name:hover,
+.header-action:not(:disabled):hover {
   color: #fff6e5;
 }
 
-.version {
+.header-action {
   font-size: 11px;
   color: rgba(247, 241, 231, 0.46);
+}
+
+.header-action:not(:disabled) {
+  color: #d9b985;
+}
+
+.header-action:disabled {
+  cursor: default;
 }
 
 .page {
@@ -200,18 +213,10 @@ body {
 
 .about-title {
   margin: 0;
-  padding: 0;
-  border: 0;
-  background: transparent;
   color: #f7f1e7;
   font-size: 32px;
   line-height: 1;
   font-weight: 600;
-  cursor: pointer;
-}
-
-.about-title:hover {
-  color: #fff6e5;
 }
 
 .about-page dl {

--- a/src-gui/src/style.css
+++ b/src-gui/src/style.css
@@ -38,7 +38,11 @@ body {
   padding: 22px 22px 20px;
   border-radius: 20px;
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.02)),
+    linear-gradient(
+      180deg,
+      rgba(255, 255, 255, 0.06),
+      rgba(255, 255, 255, 0.02)
+    ),
     rgba(9, 12, 16, 0.72);
   border: 1px solid rgba(255, 255, 255, 0.08);
   box-shadow:
@@ -54,16 +58,24 @@ body {
   gap: 12px;
 }
 
-.eyebrow,
+.plugin-name,
 .version {
   margin: 0;
 }
 
-.eyebrow {
+.plugin-name {
+  padding: 0;
+  border: 0;
+  background: transparent;
   font-size: 11px;
   letter-spacing: 0.16em;
   text-transform: uppercase;
   color: #d9b985;
+  cursor: pointer;
+}
+
+.plugin-name:hover {
+  color: #fff6e5;
 }
 
 .version {
@@ -71,38 +83,12 @@ body {
   color: rgba(247, 241, 231, 0.46);
 }
 
-.tabs {
-  margin-top: 16px;
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 6px;
-  padding: 4px;
-  border-radius: 8px;
-  background: rgba(255, 255, 255, 0.06);
-}
-
-.tab {
-  height: 30px;
-  border: 0;
-  border-radius: 6px;
-  background: transparent;
-  color: rgba(247, 241, 231, 0.62);
-  font: inherit;
-  font-size: 12px;
-  cursor: pointer;
-}
-
-.tab.is-active {
-  background: rgba(255, 184, 92, 0.16);
-  color: #fff6e5;
-}
-
 .page {
   min-height: 278px;
 }
 
 .meter {
-  margin-top: 12px;
+  margin-top: 32px;
   display: grid;
   place-items: center;
 }
@@ -139,7 +125,11 @@ body {
   border: 0;
   border-radius: 50%;
   background:
-    radial-gradient(circle at 35% 30%, rgba(255, 255, 255, 0.22), transparent 24%),
+    radial-gradient(
+      circle at 35% 30%,
+      rgba(255, 255, 255, 0.22),
+      transparent 24%
+    ),
     radial-gradient(circle at 50% 55%, #303a46, #1c242d 66%, #0a0d10 100%);
   box-shadow:
     inset 0 3px 14px rgba(255, 255, 255, 0.08),
@@ -205,14 +195,23 @@ body {
 }
 
 .about-page {
-  padding-top: 22px;
+  padding-top: 34px;
 }
 
-.about-page h1 {
+.about-title {
   margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: #f7f1e7;
   font-size: 32px;
   line-height: 1;
   font-weight: 600;
+  cursor: pointer;
+}
+
+.about-title:hover {
+  color: #fff6e5;
 }
 
 .about-page dl {

--- a/src-gui/vite.config.ts
+++ b/src-gui/vite.config.ts
@@ -2,18 +2,61 @@ import { defineConfig } from "vite";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
-function readCargoVersion(): string {
-  const cargoToml = readFileSync(resolve(__dirname, "../src-plugin/Cargo.toml"), "utf8");
+type PluginMetadata = {
+  pluginId: string;
+  pluginName: string;
+  companyName: string;
+  version: string;
+};
+
+function readCargoMetadata(): PluginMetadata {
+  // テンプレート利用者が plugin 名や company 名を変える場所を 1 箇所に絞るため、
+  // GUI も Rust descriptor と同じ src-plugin/Cargo.toml の metadata を読む。
+  // フロント側に直書きすると、host に見える plugin 名と About 表示がずれやすい。
+  const cargoToml = readFileSync(
+    resolve(__dirname, "../src-plugin/Cargo.toml"),
+    "utf8",
+  );
   const versionMatch = cargoToml.match(/^\s*version\s*=\s*"([^"]+)"\s*$/m);
   if (!versionMatch) {
-    throw new Error("src-plugin/Cargo.toml から version を取得できませんでした");
+    throw new Error(
+      "src-plugin/Cargo.toml から version を取得できませんでした",
+    );
   }
-  return versionMatch[1];
+  return {
+    pluginId: readWracMetadataString(cargoToml, "plugin_id"),
+    pluginName: readWracMetadataString(cargoToml, "plugin_name"),
+    companyName: readWracMetadataString(cargoToml, "company_name"),
+    version: versionMatch[1],
+  };
+}
+
+function readWracMetadataString(cargoToml: string, key: string): string {
+  let inSection = false;
+  for (const rawLine of cargoToml.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (line.startsWith("[") && line.endsWith("]")) {
+      inSection = line === "[package.metadata.wrac]";
+      continue;
+    }
+    if (!inSection) {
+      continue;
+    }
+    const match = line.match(new RegExp(`^${key}\\s*=\\s*"([^"]+)"\\s*$`));
+    if (match) {
+      return match[1];
+    }
+  }
+  throw new Error(
+    `src-plugin/Cargo.toml から package.metadata.wrac.${key} を取得できませんでした`,
+  );
 }
 
 export default defineConfig({
   define: {
-    __WRAC_GAIN_VERSION__: JSON.stringify(readCargoVersion()),
+    // plugin 固有名を定数名に含めると、テンプレートから別 plugin を作るたびに
+    // TypeScript 側の識別子まで変更が必要になる。中身だけ metadata として差し替える。
+    __WRAC_PLUGIN_METADATA__: JSON.stringify(readCargoMetadata()),
   },
   server: {
     // Debug plugin は WebView から 127.0.0.1 を読む。Vite の default `localhost`

--- a/src-plugin/Cargo.toml
+++ b/src-plugin/Cargo.toml
@@ -8,6 +8,13 @@ repository = "https://github.com/novonotes/wrac-plugin-template"
 publish = false
 build = "build.rs"
 
+# Plugin identity lives here so the Rust descriptor and GUI About page are
+# generated from the same values when this template is renamed.
+[package.metadata.wrac]
+plugin_id = "com.your-company.wrac-gain"
+plugin_name = "WRAC Gain"
+company_name = "Your Company"
+
 [lib]
 crate-type = ["rlib", "staticlib", "cdylib"]
 

--- a/src-plugin/build.rs
+++ b/src-plugin/build.rs
@@ -21,12 +21,24 @@ fn main() {
     println!("cargo:rerun-if-changed=../src-gui/vite.config.ts");
     println!("cargo:rerun-if-changed=Cargo.toml");
 
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR"));
+    let manifest_path = manifest_dir.join("Cargo.toml");
+    // Cargo.toml の [package.metadata.wrac] を plugin identity の SoT にする。
+    // Rust の descriptor と GUI の About が別々の値を持つと、テンプレートを改名した時に
+    // 片方だけ古い表示になるため、build.rs から compile-time env として Rust へ渡す。
+    let metadata = read_wrac_metadata(&manifest_path).expect("failed to read WRAC metadata");
+    println!("cargo:rustc-env=WRAC_PLUGIN_ID={}", metadata.plugin_id);
+    println!("cargo:rustc-env=WRAC_PLUGIN_NAME={}", metadata.plugin_name);
+    println!(
+        "cargo:rustc-env=WRAC_COMPANY_NAME={}",
+        metadata.company_name
+    );
+
     // debug build 時は zip を作らない (Vite dev server を使うため)。
     if env::var("PROFILE").ok().as_deref() != Some("release") {
         return;
     }
 
-    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR"));
     let gui_dist_dir = manifest_dir
         .parent()
         .expect("src-plugin must have a parent directory")
@@ -44,6 +56,62 @@ fn main() {
     }
 
     create_zip(&gui_dist_dir, &out_zip).expect("failed to create frontend zip");
+}
+
+struct WracMetadata {
+    plugin_id: String,
+    plugin_name: String,
+    company_name: String,
+}
+
+fn read_wrac_metadata(manifest_path: &Path) -> io::Result<WracMetadata> {
+    let manifest = fs::read_to_string(manifest_path)?;
+    let plugin_id = read_toml_string(&manifest, "package.metadata.wrac", "plugin_id")
+        .ok_or_else(|| missing_metadata("plugin_id"))?;
+    let plugin_name = read_toml_string(&manifest, "package.metadata.wrac", "plugin_name")
+        .ok_or_else(|| missing_metadata("plugin_name"))?;
+    let company_name = read_toml_string(&manifest, "package.metadata.wrac", "company_name")
+        .ok_or_else(|| missing_metadata("company_name"))?;
+    Ok(WracMetadata {
+        plugin_id,
+        plugin_name,
+        company_name,
+    })
+}
+
+fn missing_metadata(key: &str) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidData,
+        format!("missing package.metadata.wrac.{key} in src-plugin/Cargo.toml"),
+    )
+}
+
+fn read_toml_string(manifest: &str, section: &str, key: &str) -> Option<String> {
+    let mut in_section = false;
+    for line in manifest.lines() {
+        let line = line.trim();
+        if line.starts_with('[') && line.ends_with(']') {
+            in_section = line == format!("[{section}]");
+            continue;
+        }
+        if !in_section {
+            continue;
+        }
+        let Some((line_key, value)) = line.split_once('=') else {
+            continue;
+        };
+        if line_key.trim() != key {
+            continue;
+        }
+        return parse_toml_basic_string(value.trim());
+    }
+    None
+}
+
+fn parse_toml_basic_string(value: &str) -> Option<String> {
+    let value = value.strip_prefix('"')?;
+    let value = value.strip_suffix('"')?;
+    Some(value.replace("\\\"", "\"").replace("\\\\", "\\"))
 }
 
 /// `src_dir` 以下を丸ごと deflate 圧縮の zip にまとめて `out_zip` に書き出す。

--- a/src-plugin/src/commands.rs
+++ b/src-plugin/src/commands.rs
@@ -35,6 +35,15 @@ pub(crate) fn register_commands(
     host_gui_resize_requester: Arc<dyn HostGuiResizeRequester>,
     gui_resize_handle: WxpGuiResizeHandle,
 ) {
+    // GUI 初期化のどこまで到達したかを native log から追えるようにする。
+    // WebView console は DAW 環境で見えないことが多いため、frontend 起点の診断ログを
+    // plugin 側 logger に橋渡しする command を用意しておく。
+    command_handler.register_sync("write_to_log", move |ctx| {
+        let message = ctx.arg::<String>("message").map_err(|e| e.to_string())?;
+        log::info!("frontend: {message}");
+        Ok::<_, String>(json!({ "ok": true }))
+    });
+
     // editor page は音に関係しない project state。audio thread が読む SharedState とは
     // 別の store に置き、保存時に parameter snapshot と合成する。
     {

--- a/src-plugin/src/plugin.rs
+++ b/src-plugin/src/plugin.rs
@@ -32,9 +32,12 @@ use crate::state::{
     EditorPage, ParameterStateSnapshot, ProjectState, ProjectStateStore, SharedState,
 };
 
-// plugin を識別する reverse-DNS 形式の ID。DAW が plugin を一意に判別するために
-// 使うので、自分の plugin を作るときはここを必ず変更する。
-pub(crate) const PLUGIN_ID: &str = "com.your-company.wrac-gain";
+// plugin identity は src-plugin/Cargo.toml の [package.metadata.wrac] から来る。
+// GUI 側も同じ metadata を読むことで、host-facing descriptor と About 表示の
+// 改名漏れを防ぐ。
+pub(crate) const PLUGIN_ID: &str = env!("WRAC_PLUGIN_ID");
+pub(crate) const PLUGIN_NAME: &str = env!("WRAC_PLUGIN_NAME");
+pub(crate) const COMPANY_NAME: &str = env!("WRAC_COMPANY_NAME");
 
 // 各 parameter にも host 内で一意の ID を割り当てる必要がある。
 // 新しい parameter を追加するときは、ここに `PARAM_*_ID` を増やし、下の
@@ -52,8 +55,8 @@ pub(crate) const MAX_GAIN: f32 = 2.0;
 // `wrac_clap_adapter` がこれを CLAP / AUv2 の descriptor 構造体へと変換する。
 pub(crate) const PLUGIN_DESCRIPTOR: PluginDescriptor = PluginDescriptor {
     id: PLUGIN_ID,
-    name: "WRAC Gain",
-    vendor: "Your Company",
+    name: PLUGIN_NAME,
+    vendor: COMPANY_NAME,
     url: "",
     manual_url: "",
     support_url: "",
@@ -69,7 +72,7 @@ pub(crate) const PLUGIN_DESCRIPTOR: PluginDescriptor = PluginDescriptor {
     // 同じ会社内で重複しないように決める必要がある。
     auv2: Some(Auv2Descriptor {
         manufacturer_code: *b"YrCo",
-        manufacturer_name: "Your Company",
+        manufacturer_name: COMPANY_NAME,
         plugin_type: *b"aufx", // "aufx" = audio effect
         plugin_subtype: *b"WtGn",
     }),


### PR DESCRIPTION
## Summary
- Add a write_to_log command so the frontend can write diagnostic messages to the native plugin log
- Log frontend initialization completion from the GUI
- Replace the segmented About navigation with plugin-name entry and modal-style close behavior
- Limit About content to plugin name, version, company name, and build type
- Source plugin identity metadata from src-plugin/Cargo.toml for both Rust descriptors and the GUI

## Verification
- npm run build
- cargo check -p wrac_gain_plugin
- git diff --check