### PR TITLE
Fix GUI resize drag stability

### DIFF
--- a/crates/wrac_wxp_gui/src/controller.rs
+++ b/crates/wrac_wxp_gui/src/controller.rs
@@ -752,12 +752,9 @@ impl PluginGui for WxpGuiController {
     }
 
     fn set_size(&self, size: GuiSize) -> PluginResult<()> {
-        log::debug!(
-            "wxp controller: set_size called: requested_width={}, requested_height={}",
-            size.width,
-            size.height
-        );
         let size = self.layout.clamp_size(size);
+        let previous_size = self.layout.accepted_size();
+        let size_changed = previous_size.width != size.width || previous_size.height != size.height;
         let handle = {
             self.runtime
                 .lock()
@@ -765,15 +762,18 @@ impl PluginGui for WxpGuiController {
                 .as_ref()
                 .and_then(|session| session.handle.clone())
         };
+
+        // Several hosts resend the same accepted size while their outer editor
+        // window is settling. Reapplying identical WebView bounds does not change the
+        // contract, but it can make resize drags feel behind the pointer because the
+        // child view keeps receiving redundant geometry work. Still record the size
+        // below so reentrant `request_resize()` detection observes the host callback.
         if let Some(handle) = handle {
-            handle.set_size(size)?;
+            if size_changed {
+                handle.set_size(size)?;
+            }
         }
         self.layout.store_accepted_size(size);
-        log::debug!(
-            "wxp controller: set_size completed: applied_width={}, applied_height={}",
-            size.width,
-            size.height
-        );
         Ok(())
     }
 

--- a/crates/wrac_wxp_gui/src/controller.rs
+++ b/crates/wrac_wxp_gui/src/controller.rs
@@ -38,6 +38,11 @@ struct HostGuiLayout {
     // CLAP layout queries read this without entering the GUI runtime.
     // The accepted size is the controller's host contract, not copied runtime state.
     accepted_size: AtomicGuiSize,
+    // Some wrappers call `set_size()` reentrantly from inside `request_resize()` even
+    // when the resize request returns false. The revision lets the request path detect
+    // that host-confirmed size without taking the GUI runtime lock or guessing from
+    // the boolean return value.
+    accepted_size_revision: AtomicU64,
     limits: GuiSizeLimits,
     resize_policy: GuiResizePolicy,
 }
@@ -506,6 +511,7 @@ impl HostGuiLayout {
         let size = clamp_size_with_limits(size, limits);
         Self {
             accepted_size: AtomicGuiSize::new(size),
+            accepted_size_revision: AtomicU64::new(0),
             limits,
             resize_policy,
         }
@@ -532,6 +538,11 @@ impl HostGuiLayout {
 
     fn store_accepted_size(&self, size: GuiSize) {
         self.accepted_size.store(size);
+        self.accepted_size_revision.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn accepted_size_revision(&self) -> u64 {
+        self.accepted_size_revision.load(Ordering::Relaxed)
     }
 
     fn can_resize(&self) -> bool {
@@ -566,16 +577,42 @@ impl WxpGuiResizeHandle {
             width: logical_size.width as u32,
             height: logical_size.height as u32,
         };
-        host_gui_resize_requester.request_resize(gui_size)?;
 
-        self.layout.store_accepted_size(gui_size);
-        let scale = *self.scale.lock();
-        // Commands receive `WebViewDispatch`, not the native WebView owner. That keeps resize
-        // requests usable from command handlers without extending a closing editor's lifetime.
-        web_view
-            .post_set_bounds(DpiConverter::new(scale).create_webview_bounds(logical_size))
-            .map_err(|_| PluginError::Message("failed to resize webview"))?;
-        Ok(gui_size)
+        let previous_revision = self.layout.accepted_size_revision();
+        let resize_result = host_gui_resize_requester.request_resize(gui_size);
+        let current_revision = self.layout.accepted_size_revision();
+
+        // Logic's AUv2 wrapper currently applies the NSView frame and calls back into
+        // `set_size()` during `request_resize()`, then reports `false` to the CLAP
+        // request. Treat the reentrant `set_size()` as the source of truth: posting an
+        // extra optimistic WebView resize here makes the WebView and host fight over
+        // geometry and can produce visible bouncing while dragging the resize grip.
+        if current_revision != previous_revision {
+            return Ok(self.layout.accepted_size());
+        }
+
+        match resize_result {
+            Ok(()) => {
+                // Some hosts accept the request but do not immediately call `set_size()`.
+                // In that case the plugin owns the WebView update so the editor can
+                // resize without waiting for an optional host callback.
+                // Commands receive `WebViewDispatch`, not the native WebView owner.
+                // That keeps resize requests usable from command handlers without
+                // extending a closing editor's lifetime.
+                let scale = *self.scale.lock();
+                web_view
+                    .post_set_bounds(DpiConverter::new(scale).create_webview_bounds(logical_size))
+                    .map_err(|_| PluginError::Message("failed to resize webview"))?;
+                self.layout.store_accepted_size(gui_size);
+                Ok(gui_size)
+            }
+            Err(error) => {
+                // A real rejection is different from the AUv2 reentrant-set_size case
+                // above. Keep the last host-confirmed size instead of speculatively
+                // moving the child WebView and later snapping it back.
+                Err(error)
+            }
+        }
     }
 }
 

--- a/src-gui/src/main.ts
+++ b/src-gui/src/main.ts
@@ -425,6 +425,7 @@ tabAbout.addEventListener("click", (event) => {
       }
     | null = null;
   let inFlight = false;
+  let drainResizeQueue: Promise<void> | null = null;
   let resizeDragSeq = 0;
   let queuedSize:
     | {
@@ -436,10 +437,10 @@ tabAbout.addEventListener("click", (event) => {
 
   const flushResize = () => {
     if (inFlight) {
-      return;
+      return drainResizeQueue ?? Promise.resolve();
     }
     inFlight = true;
-    void (async () => {
+    drainResizeQueue = (async () => {
       try {
         while (queuedSize) {
           const size = queuedSize;
@@ -452,9 +453,14 @@ tabAbout.addEventListener("click", (event) => {
         inFlight = false;
       }
       if (queuedSize) {
-        flushResize();
+        await flushResize();
       }
-    })();
+    })().finally(() => {
+      if (!inFlight && !queuedSize) {
+        drainResizeQueue = null;
+      }
+    });
+    return drainResizeQueue;
   };
 
   const requestResize = (width: number, height: number) => {
@@ -463,7 +469,19 @@ tabAbout.addEventListener("click", (event) => {
       height: Math.max(1, Math.round(height)),
       dragId: dragStart?.dragId ?? 0,
     };
-    flushResize();
+    return flushResize();
+  };
+
+  const endResizeDragAfterDrain = (dragId: number) => {
+    void (async () => {
+      // Keep the native drag snapshot alive until the final queued resize request
+      // has returned. Otherwise a slow host can make the last request fall back to
+      // JS coordinates, exactly the coordinate source this path is trying to avoid.
+      await flushResize();
+      await invoke("end_gui_resize_drag", {
+        request: { dragId },
+      }).catch(() => undefined);
+    })();
   };
 
   const applyResizeDelta = (event: PointerEvent) => {
@@ -497,11 +515,7 @@ tabAbout.addEventListener("click", (event) => {
     const dragId = dragStart?.dragId;
     dragStart = null;
     if (dragId !== undefined) {
-      window.setTimeout(() => {
-        void invoke("end_gui_resize_drag", {
-          request: { dragId },
-        }).catch(() => undefined);
-      }, 250);
+      endResizeDragAfterDrain(dragId);
     }
     restoreHostFocusIfNeeded(event.target);
   };

--- a/src-gui/src/main.ts
+++ b/src-gui/src/main.ts
@@ -417,15 +417,22 @@ tabAbout.addEventListener("click", (event) => {
   let dragStart:
     | {
         pointerId: number;
-        x: number;
-        y: number;
+        dragId: number;
         width: number;
         height: number;
+        lastX: number;
+        lastY: number;
       }
     | null = null;
-  let resizeFrame = 0;
   let inFlight = false;
-  let queuedSize: { width: number; height: number } | null = null;
+  let resizeDragSeq = 0;
+  let queuedSize:
+    | {
+        width: number;
+        height: number;
+        dragId: number;
+      }
+    | null = null;
 
   const flushResize = () => {
     if (inFlight) {
@@ -433,39 +440,101 @@ tabAbout.addEventListener("click", (event) => {
     }
     inFlight = true;
     void (async () => {
-      while (queuedSize) {
-        const size = queuedSize;
-        queuedSize = null;
-        await invoke<ResizeResponse>("request_gui_resize", {
-          request: size,
-        }).catch(() => undefined);
+      try {
+        while (queuedSize) {
+          const size = queuedSize;
+          queuedSize = null;
+          await invoke<ResizeResponse>("request_gui_resize", {
+            request: size,
+          }).catch(() => undefined);
+        }
+      } finally {
+        inFlight = false;
       }
-      inFlight = false;
+      if (queuedSize) {
+        flushResize();
+      }
     })();
   };
 
-  const queueResize = (width: number, height: number) => {
+  const requestResize = (width: number, height: number) => {
     queuedSize = {
       width: Math.max(1, Math.round(width)),
       height: Math.max(1, Math.round(height)),
+      dragId: dragStart?.dragId ?? 0,
     };
-    if (resizeFrame) {
+    flushResize();
+  };
+
+  const applyResizeDelta = (event: PointerEvent) => {
+    if (!dragStart || dragStart.pointerId !== event.pointerId) {
+      return false;
+    }
+
+    // Treat browser pointer events as resize triggers, not the source of truth for
+    // coordinates. The host can move or relayout this WebView while processing the
+    // same resize request, so the next browser coordinate may include movement of the
+    // child view itself. We keep this JS delta only as the non-native fallback; on
+    // macOS the Rust command uses dragId to replace it with a desktop cursor delta.
+    const deltaX = event.screenX - dragStart.lastX;
+    const deltaY = event.screenY - dragStart.lastY;
+    if (deltaX === 0 && deltaY === 0) {
+      return true;
+    }
+
+    dragStart.width += deltaX;
+    dragStart.height += deltaY;
+    dragStart.lastX = event.screenX;
+    dragStart.lastY = event.screenY;
+    requestResize(dragStart.width, dragStart.height);
+    return true;
+  };
+
+  const finishResize = (event: PointerEvent) => {
+    if (!applyResizeDelta(event)) {
       return;
     }
-    resizeFrame = window.requestAnimationFrame(() => {
-      resizeFrame = 0;
-      flushResize();
-    });
+    const dragId = dragStart?.dragId;
+    dragStart = null;
+    if (dragId !== undefined) {
+      window.setTimeout(() => {
+        void invoke("end_gui_resize_drag", {
+          request: { dragId },
+        }).catch(() => undefined);
+      }, 250);
+    }
+    restoreHostFocusIfNeeded(event.target);
+  };
+
+  const cancelResize = (event: PointerEvent) => {
+    if (!dragStart || dragStart.pointerId !== event.pointerId) {
+      return;
+    }
+    const dragId = dragStart.dragId;
+    dragStart = null;
+    void invoke("end_gui_resize_drag", {
+      request: { dragId },
+    }).catch(() => undefined);
+    restoreHostFocusIfNeeded(event.target);
   };
 
   resizeGrip.addEventListener("pointerdown", (event) => {
+    const dragId = ++resizeDragSeq;
     dragStart = {
       pointerId: event.pointerId,
-      x: event.clientX,
-      y: event.clientY,
+      dragId,
       width: window.innerWidth,
       height: window.innerHeight,
+      lastX: event.screenX,
+      lastY: event.screenY,
     };
+    void invoke("begin_gui_resize_drag", {
+      request: {
+        dragId,
+        width: dragStart.width,
+        height: dragStart.height,
+      },
+    }).catch(() => undefined);
     resizeGrip.setPointerCapture(event.pointerId);
     event.preventDefault();
   });
@@ -474,27 +543,12 @@ tabAbout.addEventListener("click", (event) => {
     if (!dragStart || dragStart.pointerId !== event.pointerId) {
       return;
     }
-    queueResize(
-      dragStart.width + (event.clientX - dragStart.x),
-      dragStart.height + (event.clientY - dragStart.y),
-    );
+    applyResizeDelta(event);
+    event.preventDefault();
   });
 
-  const finishResize = (event: PointerEvent) => {
-    if (!dragStart || dragStart.pointerId !== event.pointerId) {
-      return;
-    }
-    const start = dragStart;
-    dragStart = null;
-    queueResize(
-      start.width + (event.clientX - start.x),
-      start.height + (event.clientY - start.y),
-    );
-    restoreHostFocusIfNeeded(event.target);
-  };
-
   window.addEventListener("pointerup", finishResize);
-  window.addEventListener("pointercancel", finishResize);
+  window.addEventListener("pointercancel", cancelResize);
 }
 
 // -----------------------------------------------------------------------

--- a/src-plugin/src/commands.rs
+++ b/src-plugin/src/commands.rs
@@ -4,6 +4,7 @@
 //! の形を変えるときは `src-gui` 側の `invoke(...)` / subscription と一緒に変更する。
 
 use std::cell::RefCell;
+#[cfg(target_os = "macos")]
 use std::ffi::c_void;
 use std::rc::Rc;
 use std::sync::Arc;

--- a/src-plugin/src/commands.rs
+++ b/src-plugin/src/commands.rs
@@ -3,6 +3,8 @@
 //! Rust 側から見ると、ここが TypeScript UI との約束事になる。command 名や payload
 //! の形を変えるときは `src-gui` 側の `invoke(...)` / subscription と一緒に変更する。
 
+use std::cell::RefCell;
+use std::ffi::c_void;
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -17,9 +19,88 @@ use crate::plugin::{parameter_default_value, parameter_host_value, parameter_tex
 use crate::state::{EditorPage, ProjectStateStore, SharedState};
 
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct RequestGuiResizeRequest {
     width: f64,
     height: f64,
+    drag_id: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct BeginGuiResizeDragRequest {
+    drag_id: u64,
+    width: f64,
+    height: f64,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct EndGuiResizeDragRequest {
+    drag_id: u64,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct NativeResizeDrag {
+    drag_id: u64,
+    start_mouse_x: f64,
+    start_mouse_y: f64,
+    start_width: f64,
+    start_height: f64,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct GlobalMouseLocation {
+    x: f64,
+    y: f64,
+}
+
+#[cfg(target_os = "macos")]
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+struct CGPoint {
+    x: f64,
+    y: f64,
+}
+
+#[cfg(target_os = "macos")]
+#[link(name = "CoreGraphics", kind = "framework")]
+unsafe extern "C" {
+    fn CGEventCreate(source: *const c_void) -> *mut c_void;
+    fn CGEventGetLocation(event: *mut c_void) -> CGPoint;
+}
+
+#[cfg(target_os = "macos")]
+#[link(name = "CoreFoundation", kind = "framework")]
+unsafe extern "C" {
+    fn CFRelease(cf: *const c_void);
+}
+
+fn global_mouse_location() -> Option<GlobalMouseLocation> {
+    #[cfg(target_os = "macos")]
+    {
+        // The resize grip lives inside the WebView, but the host owns the native
+        // editor window being resized. Hosts such as Logic can move/relayout that
+        // WebView during the same drag, which makes WebView pointer coordinates jump
+        // relative to the changing child view instead of tracking the physical mouse.
+        // Reading the OS cursor here gives the resize code one stable coordinate
+        // space: the desktop, outside both the WebView and the host's layout updates.
+        let event = unsafe { CGEventCreate(std::ptr::null()) };
+        if event.is_null() {
+            return None;
+        }
+        let location = unsafe { CGEventGetLocation(event) };
+        unsafe { CFRelease(event.cast()) };
+        Some(GlobalMouseLocation {
+            x: location.x,
+            y: location.y,
+        })
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        None
+    }
 }
 
 /// WebView (フロントエンド) から呼べる command を [`WxpCommandHandler`] に登録する。
@@ -35,6 +116,14 @@ pub(crate) fn register_commands(
     host_gui_resize_requester: Arc<dyn HostGuiResizeRequester>,
     gui_resize_handle: WxpGuiResizeHandle,
 ) {
+    // Split the resize drag into two responsibilities. JS owns the gesture lifetime
+    // because pointer capture/release is a browser concept, but Rust owns the resize
+    // coordinates on macOS because the browser's coordinate space is the surface the
+    // host is actively moving. The drag id ties those browser triggers to this native
+    // snapshot so every resize request can be recomputed from the original desktop
+    // cursor position instead of accumulating WebView-local pointer noise.
+    let native_resize_drag = Rc::new(RefCell::new(None::<NativeResizeDrag>));
+
     // editor page は音に関係しない project state。audio thread が読む SharedState とは
     // 別の store に置き、保存時に parameter snapshot と合成する。
     {
@@ -206,21 +295,74 @@ pub(crate) fn register_commands(
         Ok::<_, String>(json!({ "ok": true }))
     });
 
-    command_handler.register_sync("request_gui_resize", move |ctx| {
-        let request = ctx
-            .arg::<RequestGuiResizeRequest>("request")
-            .map_err(|e| e.to_string())?;
-        let size = gui_resize_handle
-            .request_resize(
-                wxp::dpi::LogicalSize::new(request.width, request.height),
-                ctx.webview(),
-                host_gui_resize_requester.as_ref(),
-            )
-            .map_err(|e| e.to_string())?;
-        Ok::<_, String>(json!({
-            "ok": true,
-            "width": size.width,
-            "height": size.height,
-        }))
-    });
+    {
+        let native_resize_drag = native_resize_drag.clone();
+        command_handler.register_sync("begin_gui_resize_drag", move |ctx| {
+            let request = ctx
+                .arg::<BeginGuiResizeDragRequest>("request")
+                .map_err(|e| e.to_string())?;
+            let Some(mouse) = global_mouse_location() else {
+                return Ok::<_, String>(json!({ "ok": false }));
+            };
+
+            *native_resize_drag.borrow_mut() = Some(NativeResizeDrag {
+                drag_id: request.drag_id,
+                start_mouse_x: mouse.x,
+                start_mouse_y: mouse.y,
+                start_width: request.width,
+                start_height: request.height,
+            });
+            Ok::<_, String>(json!({ "ok": true }))
+        });
+    }
+
+    {
+        let native_resize_drag = native_resize_drag.clone();
+        command_handler.register_sync("end_gui_resize_drag", move |ctx| {
+            let request = ctx
+                .arg::<EndGuiResizeDragRequest>("request")
+                .map_err(|e| e.to_string())?;
+            let mut drag = native_resize_drag.borrow_mut();
+            if drag
+                .as_ref()
+                .is_some_and(|drag| drag.drag_id == request.drag_id)
+            {
+                *drag = None;
+            }
+            Ok::<_, String>(json!({ "ok": true }))
+        });
+    }
+
+    {
+        let native_resize_drag = native_resize_drag.clone();
+        command_handler.register_sync("request_gui_resize", move |ctx| {
+            let request = ctx
+                .arg::<RequestGuiResizeRequest>("request")
+                .map_err(|e| e.to_string())?;
+
+            let native_request = request.drag_id.and_then(|drag_id| {
+                let drag = native_resize_drag.borrow();
+                let drag = drag.as_ref().filter(|drag| drag.drag_id == drag_id)?;
+                let mouse = global_mouse_location()?;
+                Some((
+                    drag.start_width + (mouse.x - drag.start_mouse_x),
+                    drag.start_height + (mouse.y - drag.start_mouse_y),
+                ))
+            });
+
+            let (width, height) = native_request.unwrap_or((request.width, request.height));
+            let size = gui_resize_handle
+                .request_resize(
+                    wxp::dpi::LogicalSize::new(width, height),
+                    ctx.webview(),
+                    host_gui_resize_requester.as_ref(),
+                )
+                .map_err(|e| e.to_string())?;
+            Ok::<_, String>(json!({
+                "ok": true,
+                "width": size.width,
+                "height": size.height,
+            }))
+        });
+    }
 }


### PR DESCRIPTION
## Summary
- handle reentrant host GUI resize callbacks without optimistic WebView resizing
- compute macOS resize drag deltas from native OS cursor coordinates instead of WebView pointer coordinates
- keep browser pointer events as gesture triggers with JS size math only as a non-native fallback
- avoid redundant WebView geometry updates for repeated accepted sizes

## Verification
- npm run build
- cargo fmt --all -- --check
- cargo check