### PR TITLE
Follow wxp ObjC source id update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1390,7 +1390,7 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 [[package]]
 name = "novonotes_run_loop"
 version = "0.6.0"
-source = "git+https://github.com/novonotes/wxp.git?rev=a934d407f172391913ef6d4c1478d656fcc00c7d#a934d407f172391913ef6d4c1478d656fcc00c7d"
+source = "git+https://github.com/novonotes/wxp.git?rev=c35108cb00357a509f61a5b8f3002321bc5f6d65#c35108cb00357a509f61a5b8f3002321bc5f6d65"
 dependencies = [
  "core-foundation",
  "futures",
@@ -1913,7 +1913,7 @@ dependencies = [
 [[package]]
 name = "run_loop_timer"
 version = "0.1.0"
-source = "git+https://github.com/novonotes/wxp.git?rev=a934d407f172391913ef6d4c1478d656fcc00c7d#a934d407f172391913ef6d4c1478d656fcc00c7d"
+source = "git+https://github.com/novonotes/wxp.git?rev=c35108cb00357a509f61a5b8f3002321bc5f6d65#c35108cb00357a509f61a5b8f3002321bc5f6d65"
 dependencies = [
  "novonotes_run_loop",
 ]
@@ -3142,7 +3142,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 [[package]]
 name = "wry"
 version = "0.55.1"
-source = "git+https://github.com/novonotes/wxp.git?rev=a934d407f172391913ef6d4c1478d656fcc00c7d#a934d407f172391913ef6d4c1478d656fcc00c7d"
+source = "git+https://github.com/novonotes/wxp.git?rev=c35108cb00357a509f61a5b8f3002321bc5f6d65#c35108cb00357a509f61a5b8f3002321bc5f6d65"
 dependencies = [
  "base64",
  "block2 0.6.2",
@@ -3185,7 +3185,7 @@ dependencies = [
 [[package]]
 name = "wxp"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/novonotes/wxp.git?rev=a934d407f172391913ef6d4c1478d656fcc00c7d#a934d407f172391913ef6d4c1478d656fcc00c7d"
+source = "git+https://github.com/novonotes/wxp.git?rev=c35108cb00357a509f61a5b8f3002321bc5f6d65#c35108cb00357a509f61a5b8f3002321bc5f6d65"
 dependencies = [
  "async-trait",
  "directories",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-novonotes_run_loop = { git = "https://github.com/novonotes/wxp.git", package = "novonotes_run_loop", rev = "a934d407f172391913ef6d4c1478d656fcc00c7d" }
-run_loop_timer = { git = "https://github.com/novonotes/wxp.git", package = "run_loop_timer", rev = "a934d407f172391913ef6d4c1478d656fcc00c7d" }
+novonotes_run_loop = { git = "https://github.com/novonotes/wxp.git", package = "novonotes_run_loop", rev = "c35108cb00357a509f61a5b8f3002321bc5f6d65" }
+run_loop_timer = { git = "https://github.com/novonotes/wxp.git", package = "run_loop_timer", rev = "c35108cb00357a509f61a5b8f3002321bc5f6d65" }
 wrac_clap_adapter = { path = "crates/wrac_clap_adapter" }
 wrac_wxp_gui = { path = "crates/wrac_wxp_gui" }
-wxp = { git = "https://github.com/novonotes/wxp.git", rev = "a934d407f172391913ef6d4c1478d656fcc00c7d" }
+wxp = { git = "https://github.com/novonotes/wxp.git", rev = "c35108cb00357a509f61a5b8f3002321bc5f6d65" }

--- a/xtask/src/commands.rs
+++ b/xtask/src/commands.rs
@@ -39,22 +39,21 @@ pub(crate) fn build(ctx: &Context, args: BuildArgs) -> Result<()> {
 
     build_gui(ctx)?;
 
+    let mut default_rust_plugin_built = false;
     if targets.contains(&Target::Clap) {
         build_rust_plugin(ctx, profile, RustPluginBuild::Default)?;
+        default_rust_plugin_built = true;
         package_clap(ctx, profile)?;
     }
 
-    if ctx.platform == Platform::Macos {
-        if targets.contains(&Target::Vst3) {
-            build_rust_plugin(ctx, profile, RustPluginBuild::Vst3)?;
-            build_wrapper_set(ctx, profile, WrapperBuild::Vst3)?;
+    if targets.iter().any(|target| target.is_wrapper()) {
+        // 旧 WRY_OBJC_SUFFIX 時代は macOS の ObjC class 名を format ごとに変えるため、
+        // VST3/AU で別々の Rust staticlib を作っていた。現在の wxp/wry は wry source id を
+        // objc2 の自動 class 名へ含めるため、同じ製品 build の VST3/AU は同じ staticlib を
+        // 共有できる。format ごとの compile-time 入力を再導入しない限り、ここで分けない。
+        if !default_rust_plugin_built {
+            build_rust_plugin(ctx, profile, RustPluginBuild::Default)?;
         }
-        if targets.contains(&Target::Au) {
-            build_rust_plugin(ctx, profile, RustPluginBuild::Au)?;
-            build_wrapper_set(ctx, profile, WrapperBuild::Au)?;
-        }
-    } else if targets.iter().any(|target| target.is_wrapper()) {
-        build_rust_plugin(ctx, profile, RustPluginBuild::Default)?;
         build_wrapper_set(
             ctx,
             profile,
@@ -98,8 +97,6 @@ fn npm_command(platform: Platform) -> &'static str {
 #[derive(Debug, Clone, Copy)]
 enum RustPluginBuild {
     Default,
-    Vst3,
-    Au,
     Standalone,
 }
 
@@ -107,8 +104,6 @@ impl RustPluginBuild {
     fn label(self) -> &'static str {
         match self {
             Self::Default => "default",
-            Self::Vst3 => "vst3",
-            Self::Au => "au",
             Self::Standalone => "standalone",
         }
     }
@@ -116,9 +111,7 @@ impl RustPluginBuild {
     fn cargo_target_dir(self, ctx: &Context) -> PathBuf {
         match self {
             Self::Default => ctx.target_dir.clone(),
-            Self::Vst3 | Self::Au | Self::Standalone => {
-                ctx.wrac_dir().join("cargo").join(self.label())
-            }
+            Self::Standalone => ctx.wrac_dir().join("cargo").join(self.label()),
         }
     }
 
@@ -213,8 +206,6 @@ fn package_clap(ctx: &Context, profile: BuildProfile) -> Result<()> {
 #[derive(Debug, Clone, Copy)]
 enum WrapperBuild {
     Plugin { vst3: bool, au: bool },
-    Vst3,
-    Au,
     Standalone,
 }
 
@@ -222,8 +213,6 @@ impl WrapperBuild {
     fn purpose(self) -> &'static str {
         match self {
             Self::Plugin { .. } => "wrap",
-            Self::Vst3 => "wrap-vst3",
-            Self::Au => "wrap-au",
             Self::Standalone => "standalone",
         }
     }
@@ -231,8 +220,6 @@ impl WrapperBuild {
     fn rust_build(self) -> RustPluginBuild {
         match self {
             Self::Plugin { .. } => RustPluginBuild::Default,
-            Self::Vst3 => RustPluginBuild::Vst3,
-            Self::Au => RustPluginBuild::Au,
             Self::Standalone => RustPluginBuild::Standalone,
         }
     }
@@ -246,9 +233,7 @@ fn build_wrapper_set(ctx: &Context, profile: BuildProfile, build: WrapperBuild) 
 
     let build_dir = ctx.cmake_dir(build.purpose(), profile);
     let stage_dir = match build {
-        WrapperBuild::Plugin { .. } | WrapperBuild::Vst3 | WrapperBuild::Au => {
-            ctx.plugins_dir(profile)
-        }
+        WrapperBuild::Plugin { .. } => ctx.plugins_dir(profile),
         WrapperBuild::Standalone => ctx.standalone_dir(profile),
     };
     fs::create_dir_all(&stage_dir)?;
@@ -292,18 +277,6 @@ fn build_wrapper_set(ctx: &Context, profile: BuildProfile, build: WrapperBuild) 
                     on_off(vst3)
                 ))
                 .arg(format!("-DCLAP_WRAPPER_BUILDER_BUILD_AUV2={}", on_off(au)))
-                .arg("-DCLAP_WRAPPER_BUILDER_BUILD_STANDALONE=OFF");
-        }
-        WrapperBuild::Vst3 => {
-            configure
-                .arg("-DCLAP_WRAPPER_BUILDER_BUILD_VST3=ON")
-                .arg("-DCLAP_WRAPPER_BUILDER_BUILD_AUV2=OFF")
-                .arg("-DCLAP_WRAPPER_BUILDER_BUILD_STANDALONE=OFF");
-        }
-        WrapperBuild::Au => {
-            configure
-                .arg("-DCLAP_WRAPPER_BUILDER_BUILD_VST3=OFF")
-                .arg("-DCLAP_WRAPPER_BUILDER_BUILD_AUV2=ON")
                 .arg("-DCLAP_WRAPPER_BUILDER_BUILD_STANDALONE=OFF");
         }
         WrapperBuild::Standalone => {
@@ -389,14 +362,6 @@ fn build_wrapper_set(ctx: &Context, profile: BuildProfile, build: WrapperBuild) 
                 // AU は AudioComponentRegistrar 経由で読むため、local build でも署名済みにしておく。
                 codesign_nested_macos_bundle(ctx, &ctx.au_bundle(profile))?;
             }
-        }
-        WrapperBuild::Vst3 => {
-            ensure_exists(&ctx.vst3_bundle(profile), "VST3 artifact")?;
-            codesign_nested_macos_bundle(ctx, &ctx.vst3_bundle(profile))?;
-        }
-        WrapperBuild::Au => {
-            ensure_exists(&ctx.au_bundle(profile), "AU artifact")?;
-            codesign_nested_macos_bundle(ctx, &ctx.au_bundle(profile))?;
         }
         WrapperBuild::Standalone => {
             ensure_exists(&ctx.standalone_artifact(profile), "standalone artifact")?;


### PR DESCRIPTION
## Summary
- Update wxp dependencies to the revision that includes the wry source id in autogenerated ObjC class names
- Remove the old WRY_OBJC_SUFFIX-era Rust staticlib rebuilds for separate VST3/AU outputs
- Document why VST3 and AU wrappers can share the same Rust staticlib for the same product build

## Verification
- cargo fmt
- cargo check -p xtask
- cargo check --manifest-path src-plugin/Cargo.toml
- cargo xtask build --target=vst3,au
- Confirmed the generated VST3/AU binaries contain WryWebView0.55.1+c35108cb0035 and WryNavigationDelegate0.55.1+c35108cb0035 with strings
- Confirmed no format-specific libwrac_gain_plugin.a is generated under target/wrac/cargo

## Notes
- npm install reports existing audit warnings: 2 vulnerabilities (1 moderate, 1 high).