### PR TITLE
Translate documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,5 @@
 # WRAC Plugin Template
 
-⚠️ Currently in **pre-release testing** for the official launch.
-- Feedback is welcome via issues, discussions, DM, email, or any other means.
-- The scope is currently intentionally limited to acquaintances and stakeholders.
-- Official launch is planned for early May 2026. Your shares and support at that time would be greatly appreciated!
-
----
-
 A template for implementing audio plugins with the WRAC stack.
 You can copy this repository as a starting point for new projects.
 
@@ -28,37 +21,47 @@ The WRAC stack is a technology stack for audio plugin development, built around 
 The code in this repository implements a simple plugin called WRAC Gain.
 It is also structured so it can be used as a template.
 
+- CLAP plugin implementation in Rust using [clap-sys](https://github.com/micahrj/clap-sys)
 - WebView GUI implementation using [wxp](https://github.com/novonotes/wxp)
-- CLAP plugin implementation in Rust using `clap-sys`
-- VST3 and AU plugin builds via [clap-wrapper](https://github.com/free-audio/clap-wrapper)
+- VST3 / AU / Standalone builds via [clap-wrapper](https://github.com/free-audio/clap-wrapper)
 
 ## Build
 
+Common commands:
+
 ```bash
+# Debug build for all formats
 cargo xtask build
+# Release build for all formats
 cargo xtask build --release
+# Debug build for VST3 only
 cargo xtask build --target=vst3
-cargo xtask build --target=au,standalone
+# Release build for AU and Standalone
+cargo xtask build --target=au,standalone --release
+# Validate built plugins
 cargo xtask validate
+# Install built plugins
 cargo xtask install
 ```
 
-`cargo xtask build` builds every target supported by the current OS:
-CLAP/VST3/AU/standalone on macOS and CLAP/VST3/standalone on Windows and Linux.
-Use `build --target` with a comma-separated list of `clap`, `vst3`,
-`au`, and `standalone` to build a smaller set. `install` and `uninstall` accept
-plugin formats only: `clap`, `vst3`, and `au`. `install --scope` accepts `user`
-or `system`; `uninstall --scope` accepts `user`, `system`, or `all`.
+Supported formats:
 
-Plugin artifacts are staged under `target/wrac/plugins/<profile>/`, and
-standalone apps are staged under `target/wrac/standalone/<profile>/`. On macOS,
-`cargo xtask validate` runs clap-validator, the VST3 validator, and
-`auval -v aufx WtGn YrCo`. On Windows and Linux, validation runs clap-validator
-and the VST3 validator. CLAP validation downloads clap-validator 0.3.2 into
-`target/tools` when needed. AU validation installs the built component under
-`~/Library/Audio/Plug-Ins/Components/` and fails if the same bundle exists under
-`/Library/Audio/Plug-Ins/Components/`.
+| OS | `cargo xtask build` targets | `cargo xtask validate` targets |
+|----|-----------------------------|-------------------------------|
+| macOS | CLAP / VST3 / AU / Standalone | CLAP / VST3 / AU |
+| Windows | CLAP / VST3 / Standalone | CLAP / VST3 |
+| Linux | CLAP / VST3 / Standalone | CLAP / VST3 |
 
+The `--target` option accepts `clap`, `vst3`, `au`, and `standalone` as comma-separated values.
+
+For detailed usage:
+
+```bash
+# Overall help
+cargo xtask --help
+# Subcommand help
+cargo xtask build --help
+```
 
 ## Setting Up a New Project
 
@@ -73,8 +76,12 @@ Even a quick comment like **"Works on Logic Pro 10.7"** is incredibly helpful fo
 Feel free to drop a quick note here:
 👉 [DAW Compatibility Reports](https://github.com/novonotes/wrac-plugin-template/discussions/6)
 
+## Notes
+
+This repository is intended as an implementation example and starting point, not a general-purpose framework. Future changes will not provide API backwards compatibility or migration support.
+
 ## Reference
 
-For usage of the wxp crate, see the [wxp README](https://github.com/novonotes/wxp/tree/main/crates/wxp).
-
 For known DAW compatibility status, see the [DAW Compatibility Matrix](https://github.com/novonotes/wrac-plugin-template/wiki/DAW-Compatibility-Matrix).
+
+For usage of the wxp crate, see the [wxp README](https://github.com/novonotes/wxp/tree/main/crates/wxp).

--- a/crates/wrac_clap_adapter/README.md
+++ b/crates/wrac_clap_adapter/README.md
@@ -1,49 +1,49 @@
 # wrac_clap_adapter
 
-各製品コードが実装するべき trait 群を定義し、
-その trait 実装を CLAP ABI に適合させ、プラグインとして利用可能にするアダプターを提供します。
+Defines the traits that each product crate must implement,
+and provides an adapter that maps those trait implementations to the CLAP ABI so they can be used as a plugin.
 
-VST3 / AU / AAX への変換は `clap-wrapper` の責務で、本 crate は CLAP plugin および CLAP extension を Rust 側で実装することに専念します。
+Conversion to VST3 / AU / AAX is the responsibility of `clap-wrapper`. This crate focuses solely on implementing CLAP plugins and CLAP extensions on the Rust side.
 
-## 目的
+## Purpose
 
-CLAP プラグインを clap-wrapper 経由で他フォーマットのホストから利用する場合、 CLAP の定義するスレッドモデルや呼び出し順序の契約が一部守られない場合があります。それらに対して防御的な機構で対応することを目的としています。
+When using a CLAP plugin through clap-wrapper with a VST3/AU/AAX host, certain contracts defined by CLAP's thread model and call-order guarantees may not be honored. This crate aims to handle those cases defensively.
 
-## clack との違い
+## Differences from clack
 
-CLAP のヘッダには、各関数を呼び出してよい thread が `[main-thread]` `[audio-thread]` `[thread-safe]` といったコメントで示されています。例えば `init` は `[main-thread]`、`process` は `[audio-thread]`、`get_extension` は `[thread-safe]` です。
+The CLAP headers annotate the allowed thread for each function using comments such as `[main-thread]`, `[audio-thread]`, and `[thread-safe]`. For example, `init` is `[main-thread]`, `process` is `[audio-thread]`, and `get_extension` is `[thread-safe]`.
 
-`clack` は host がこのコメント通りに関数を呼び出す前提で型を設計しており、Native CLAP host 向けには素直に動作します。
+`clack` is designed assuming the host calls functions according to these annotations, and works straightforwardly with native CLAP hosts.
 
-一方、本 crate は `clap-wrapper` 経由の VST3 / AU / AAX host も対象とします。これらの host を経由すると、`[main-thread]` 指定の query が別 thread から呼ばれるなど、コメント通りの呼び出し順・呼び出し thread にならない場合があります。本 crate はこれを adapter 側の lock や panic 捕捉などで受け、製品コードに `unsafe` を露出させずに動作させることを目的としています。
+This crate, on the other hand, also targets VST3/AU/AAX hosts via `clap-wrapper`. When routing through those hosts, annotated `[main-thread]` queries may be called from a different thread, among other deviations from the spec. This crate handles such cases through locks and panic catching on the adapter side, so that product code never exposes `unsafe` and still operates correctly.
 
-## 謝辞
+## Acknowledgements
 
-`wrac_clap_adapter` は、`clack` の safe で low-level な CLAP wrapper 設計、特に CLAP extension 境界と audio buffer access の考え方を参考にさせていただきました。本 crate は `clack` のコードの派生ではなく、`clap-sys` を直接用いた独立した実装です。
+`wrac_clap_adapter` is inspired by `clack`'s design for a safe, low-level CLAP wrapper — in particular, its approach to CLAP extension boundaries and audio buffer access. This crate is not derived from `clack`'s code; it is an independent implementation built directly on `clap-sys`.
 
 ## Public API
 
-- `PluginCore`: instance lifecycle と、サポートする extension の宣言
+- `PluginCore`: instance lifecycle and declaration of supported extensions
 - `PluginAudioPorts`: CLAP `audio-ports`
 - `PluginConfigurableAudioPorts`: CLAP `configurable-audio-ports`
 - `PluginNotePorts`: CLAP `note-ports`
 - `PluginParameters`: CLAP `params`
 - `PluginStateSupport`: CLAP `state`
 - `PluginGui`: CLAP `gui`
-- `export_clap_plugin!`: CLAP entry point の export
+- `export_clap_plugin!`: exports the CLAP entry point
 
-各 trait は CLAP C ABI に対応する薄い Rust 表現です。独自の plugin framework としては設計しません。
+Each trait is a thin Rust representation of the corresponding CLAP C ABI. This crate is not designed as a general plugin framework.
 
-## 制約
+## Limitations
 
-この crate は汎用フレームワークではなく、実装例の一部として提供しています。今後の変更では、API の後方互換性やマイグレーションサポートは提供しません。
+This crate is provided as part of an implementation example, not as a general-purpose framework. Future changes will not provide API backwards compatibility or migration support.
 
-また、現時点では CLAP の全 ABI には対応できておらず、以下の制限があります。
+Additionally, full CLAP ABI coverage is not yet complete. Known limitations:
 
-- `audio-ports`: 現在の port metadata の公開のみ。port 構成の動的変更通知 (rescan) は未対応
-- `configurable-audio-ports`: 非 active 時の layout 交渉のみ対応
-- `params`: state restore 後の value rescan は対応するが、parameter schema 自体の動的 rescan API は未提供
-- raw MIDI bytes 向けの helper は未実装（note-ports 経由の note event のみ対応）
-- output event の batching helper は最小限（sample accurate な event 整列は製品側の責務）
-- `audio-ports-activation` extension は未実装
-- 複数 plugin を 1 binary から export する構成は未対応
+- `audio-ports`: exposes current port metadata only; dynamic port rescan notifications are not supported
+- `configurable-audio-ports`: only layout negotiation while inactive is supported
+- `params`: value rescan after state restore is supported, but a dynamic rescan API for the parameter schema itself is not provided
+- No helper for raw MIDI bytes (only note events via note-ports are supported)
+- Output event batching helpers are minimal (sample-accurate event ordering is the product's responsibility)
+- The `audio-ports-activation` extension is not implemented
+- Exporting multiple plugins from a single binary is not supported

--- a/crates/wrac_clap_adapter/src/abi.rs
+++ b/crates/wrac_clap_adapter/src/abi.rs
@@ -1,7 +1,7 @@
-//! CLAP ABI と `PluginCore` instance を結びつける module。
+//! Module that binds the CLAP ABI to `PluginCore` instances.
 //!
-//! public API は `lib.rs` の re-export と `export_clap_plugin!` に集約し、この module
-//! は C ABI callback と adapter state の所有だけを扱う。
+//! The public API is surfaced through re-exports in `lib.rs` and `export_clap_plugin!`.
+//! This module is responsible only for C ABI callbacks and owning the adapter state.
 
 use std::cell::UnsafeCell;
 use std::ffi::{CStr, c_char, c_void};
@@ -50,25 +50,25 @@ use crate::{
     ProcessStatus, Processor,
 };
 
-// clap-wrapper は AUv2 metadata 生成時にこの draft factory を読む。CLAP descriptor とは
-// 別に AU manufacturer/subtype を渡さないと、generic wrapper identity と衝突して
-// auval が古い別 plugin を検証することがある。
+// clap-wrapper reads this draft factory when generating AUv2 metadata. Without a
+// separate AU manufacturer/subtype, it can collide with the generic wrapper identity
+// and cause auval to validate a different, older plugin instead.
 const CLAP_PLUGIN_FACTORY_INFO_AUV2: &CStr = c"clap.plugin-factory-info-as-auv2.draft0";
 
-/// CLAP instance と Rust core の同期境界。
+/// Synchronization boundary between a CLAP instance and the Rust core.
 ///
-/// 設計の要: 「lifecycle lock」と「host-facing callback が直接読む capability」を
-/// 分ける。`core` lock は processor 所有権を動かす `activate`/`deactivate` だけで
-/// 使い、parameter/state/port query は instance 作成時に固定した `Arc` を読む。
-/// 分けないと、wrapper が `activate()` 中に query を再入させたとき core lock を
-/// 取れず「parameter なし」「state 保存失敗」を host に返してしまう (crash は
-/// しないが project data や routing を壊す)。
+/// Key design: separate the "lifecycle lock" from "capabilities read directly by
+/// host-facing callbacks". The `core` lock is used only by `activate`/`deactivate`,
+/// which move processor ownership. Parameter/state/port queries read `Arc`s frozen at
+/// instance creation. Without this separation, a wrapper that re-enters a query during
+/// `activate()` would fail to acquire the core lock and return "no parameters" or "state
+/// save failed" to the host — no crash, but project data and routing can be corrupted.
 pub(crate) struct PluginInstance {
     plugin: clap_plugin,
-    // processor lifecycle の所有者。lock を取るのは activate/deactivate だけ。
+    // Owner of the processor lifecycle; only activate/deactivate take this lock.
     core: RwLock<Box<dyn PluginCore>>,
-    // capability の有無は instance 作成時に固定する。runtime state と連動させると
-    // 「query した瞬間だけ extension が消える」不安定な見え方になるため。
+    // Capability presence is frozen at instance creation. Coupling it to runtime state
+    // would make extensions appear to disappear transiently during queries.
     capabilities: PluginCapabilities,
     audio_ports: Option<Arc<dyn PluginAudioPorts>>,
     configurable_audio_ports: Option<Arc<dyn PluginConfigurableAudioPorts>>,
@@ -76,12 +76,13 @@ pub(crate) struct PluginInstance {
     parameters: Option<Arc<dyn PluginParameters>>,
     state: Option<Arc<dyn PluginStateSupport>>,
     gui: Option<Arc<dyn PluginGui>>,
-    // GUI mutation callback の再入 guard。再入時は待たず失敗させ deadlock を避ける
-    // (GUI query callback はこの guard を通らない)。
+    // Re-entry guard for GUI mutation callbacks. Fails immediately on re-entry to avoid
+    // deadlock (GUI query callbacks do not go through this guard).
     gui_callback_busy: Mutex<()>,
     parameter_edits: Arc<ParameterEditQueue>,
-    // wrapper が thread/lifecycle 注釈を崩しても soundness を保つため、RT 経路は
-    // lock せず atomic guard が取れた callback だけ `Processor` への `&mut` を作る。
+    // To preserve soundness even when a wrapper violates thread/lifecycle annotations,
+    // the RT path never takes a lock — only a callback that wins the atomic guard
+    // constructs a `&mut` to `Processor`.
     processor: UnsafeCell<Option<Box<dyn Processor>>>,
     processor_busy: AtomicBool,
     lifecycle_busy: AtomicBool,
@@ -97,25 +98,25 @@ pub(crate) struct PluginCapabilities {
     gui: bool,
 }
 
-// 安全性: CLAP は callback 間で同じ opaque plugin pointer を共有する。adapter state は
-// lock/atomic 経由で共有し、host の thread annotation や callback 順序が崩れても Rust
-// aliasing だけは破らない。
+// Safety: CLAP shares the same opaque plugin pointer across callbacks. Adapter state is
+// shared via locks and atomics, so Rust aliasing rules are never violated even when the
+// host's thread annotations or callback ordering breaks down.
 unsafe impl Send for PluginInstance {}
 unsafe impl Sync for PluginInstance {}
 
 impl PluginInstance {
     fn new(registration: &'static PluginRegistration, host: *const clap_host) -> Box<Self> {
         let parameter_edits = Arc::new(ParameterEditQueue::new(host));
-        // notifier は safe proxy として渡す。製品 GUI は host pointer や CLAP event
-        // lifetime を知らずにこれを保持できる。
+        // Pass as a safe proxy so product GUI code can hold it without knowing about
+        // host pointers or CLAP event lifetimes.
         let context = PluginCoreContext {
             host_parameter_edit_notifier: parameter_edits.clone(),
             host_gui_resize_requester: Arc::new(HostGuiResizeRequest::new(host)),
         };
         let core = (registration.create)(context);
-        // capability は callback 開始前のここで固定する (get_extension 中に core
-        // lock を待つと host の再入順に依存するため)。得た Arc は入口にすぎず、
-        // 値の SoT は plugin 実装側の store に残る。
+        // Freeze capabilities here, before callbacks begin. Waiting on the core lock
+        // inside get_extension would make us dependent on host re-entry order. The Arc
+        // is just an entry point; the source of truth remains in the plugin's store.
         let audio_ports = core.audio_ports();
         let configurable_audio_ports = core.configurable_audio_ports();
         let note_ports = core.note_ports();
@@ -221,8 +222,8 @@ impl PluginInstance {
                 drop(old);
                 return;
             }
-            // activate は非 RT。Processor の有無を別状態へ複製せず、実体の borrow guard が
-            // 空くまで待ってから格納する。
+            // activate is not realtime. Rather than duplicating processor presence as
+            // separate state, wait until the borrow guard is free, then store.
             std::thread::yield_now();
         }
     }
@@ -232,9 +233,9 @@ impl PluginInstance {
             if let Some(processor) = self.try_take_processor() {
                 return processor;
             }
-            // deactivate/destroy は非 RT の lifecycle callback です。ここで待つことで、
-            // lifecycle と audio を競合させる wrapper でも `process()` が一時的な
-            // Processor borrow を持ったまま instance を解放しないようにする。
+            // deactivate/destroy are non-realtime lifecycle callbacks. Waiting here
+            // ensures that even a wrapper which races lifecycle against audio never
+            // frees the instance while process() holds a temporary Processor borrow.
             std::thread::yield_now();
         }
     }
@@ -256,8 +257,9 @@ impl PluginInstance {
             if let Some(guard) = self.try_enter_lifecycle() {
                 return guard;
             }
-            // `destroy()` は待てる callback です。待たずに解放すると、順序の崩れた
-            // wrapper lifecycle callback が adapter state を保持したままになる。
+            // `destroy()` is a callback that can afford to wait. Releasing without
+            // waiting would leave out-of-order wrapper lifecycle callbacks holding
+            // stale adapter state.
             std::thread::yield_now();
         }
     }
@@ -491,8 +493,9 @@ unsafe extern "C" fn plugin_deactivate(plugin: *const clap_plugin) {
             log::warn!("plugin.deactivate: missing plugin instance");
             return;
         };
-        // deactivate は host へ完了を返す前に Processor を必ず回収したい cleanup callback。
-        // wrapper が lifecycle callback を並行させても、ここでは待って破棄漏れを避ける。
+        // deactivate is a cleanup callback that must reclaim the Processor before
+        // returning completion to the host. Even if a wrapper runs lifecycle callbacks
+        // concurrently, wait here to avoid missing the teardown.
         let _guard = instance.enter_lifecycle_blocking();
         if let Some(processor) = instance.take_processor_blocking() {
             if let Err(error) = instance.core.write().deactivate(processor) {
@@ -508,9 +511,10 @@ unsafe extern "C" fn plugin_start_processing(plugin: *const clap_plugin) -> bool
             log::warn!("plugin.start_processing: missing plugin instance");
             return false;
         };
-        // `start_processing` / `stop_processing` は wrapper format では VST3/AU 側の
-        // activate と同期しないことがある。専用 flag は host 都合で audio を止める
-        // 故障点になるため、処理可否は Processor の有無だけで判断する。
+        // In wrapper formats, `start_processing` / `stop_processing` may not be
+        // synchronized with the VST3/AU activate. A dedicated flag would become a
+        // failure point that stops audio at the host's discretion, so whether processing
+        // is possible is determined solely by the presence of a Processor.
         let can_process = instance.has_processor_or_busy();
         if !can_process {
             log::warn!("plugin.start_processing: no processor is available");
@@ -570,9 +574,10 @@ unsafe extern "C" fn plugin_process(
             }
         };
 
-        // audio callback は `PluginCore` の lock を取らない。処理可能かどうかも別 flag ではなく
-        // 実際の `Processor` の有無だけで決める。wrapper が lifecycle 順序を崩した場合でも、
-        // RT 経路では待たずに sleep/error へ倒す。
+        // The audio callback never takes the `PluginCore` lock. Whether processing is
+        // possible is determined by the actual presence of a `Processor`, not a separate
+        // flag. If a wrapper violates lifecycle ordering, the RT path falls through to
+        // sleep/error without waiting.
         let Some(result) = instance.with_processor_mut(|processor| {
             let Some(processor) = processor else {
                 log::debug!("plugin.process: no processor is available");

--- a/crates/wrac_clap_adapter/src/abi/audio_buffers.rs
+++ b/crates/wrac_clap_adapter/src/abi/audio_buffers.rs
@@ -3,9 +3,9 @@ use clap_sys::process::clap_process;
 
 use crate::{AudioBufferError, AudioProcessBuffer};
 
-// CLAP の audio buffer 配列は callback 中だけ有効です。ここでは port/channel の解釈を
-// せず、callback lifetime に縛った slice へ変換する。alias 判定や sample type 判定は
-// `AudioProcessBuffer` 側で必要になったタイミングにまとめる。
+// CLAP audio buffer arrays are valid only for the duration of the callback. Here they are
+// converted to slices bound to the callback lifetime without interpreting port or channel layout.
+// Alias detection and sample type checks are deferred to `AudioProcessBuffer` as needed.
 pub(super) unsafe fn audio_buffers(
     process: &clap_process,
 ) -> Result<AudioProcessBuffer<'_>, AudioBufferError> {

--- a/crates/wrac_clap_adapter/src/abi/configurable_audio_ports.rs
+++ b/crates/wrac_clap_adapter/src/abi/configurable_audio_ports.rs
@@ -28,10 +28,10 @@ unsafe extern "C" fn configurable_audio_ports_can_apply_configuration(
             log::warn!("configurable_audio_ports.can_apply: missing plugin instance");
             return false;
         };
-        // layout は Processor の buffer view 契約を変えるので active 中は拒否。
-        // active 判定は実際の Processor の有無と lifecycle busy だけで行う
-        // (wrapper は start/stop_processing を省略・遅延し得るため SoT にしない)。
-        // これで plugin 側は「Processor 生存中は layout 不変」を前提にできる。
+        // Layout changes invalidate the Processor's buffer view contract, so reject while active.
+        // Activity is determined solely by whether a Processor exists and whether lifecycle is busy
+        // (wrappers may omit or delay start/stop_processing, so they are not the source of truth).
+        // This lets the plugin assume the layout is stable for the lifetime of any Processor.
         if instance.has_processor_or_busy() || instance.lifecycle_busy.load(Ordering::Acquire) {
             log::warn!(
                 "configurable_audio_ports.can_apply: rejected while processor/lifecycle is busy"
@@ -81,9 +81,9 @@ unsafe extern "C" fn configurable_audio_ports_apply_configuration(
             return false;
         };
 
-        // host が `can_apply` を省いても安全なよう `apply` でも同条件を再確認する。
-        // 確認と apply を同じ lifecycle guard 内で行わないと、processor 不在確認の
-        // 直後に `activate()` が古い layout を snapshot する race が残る。
+        // Re-check the same conditions in `apply` for hosts that skip `can_apply`.
+        // Performing the check and the apply under the same lifecycle guard closes the race
+        // where `activate()` could snapshot a stale layout immediately after the processor-absent check.
         let Some(_guard) = instance.try_enter_lifecycle() else {
             log::warn!("configurable_audio_ports.apply: rejected while lifecycle is busy");
             return false;
@@ -143,8 +143,9 @@ fn convert_port_type(port_type: *const std::ffi::c_char) -> AudioPortType {
     } else if port_type == CLAP_PORT_STEREO {
         AudioPortType::Stereo
     } else {
-        // port_type 文字列は callback 中だけ有効。`Other` で製品へ渡すと lifetime を
-        // 偽ることになるので、未知 type は channel_count だけで判断させる。
+        // The port_type string is valid only during the callback. Passing it as `Other` to product
+        // code would lie about its lifetime, so unknown types are represented as Unspecified
+        // and the product is expected to decide based on channel_count alone.
         AudioPortType::Unspecified
     }
 }

--- a/crates/wrac_clap_adapter/src/abi/ffi.rs
+++ b/crates/wrac_clap_adapter/src/abi/ffi.rs
@@ -101,8 +101,8 @@ pub(super) fn four_char_code(bytes: [u8; 4]) -> [c_char; 5] {
     ]
 }
 
-// panic を C ABI の外へ出してはいけない。各 callback は Rust 側の失敗を返り値ごとの
-// conservative な CLAP value に変換し、foreign frame を unwind せず host に拒否させる。
+// Panics must not escape the C ABI boundary. Each callback converts Rust failures into
+// conservative CLAP return values so the host receives a rejection without unwinding foreign frames.
 pub(super) fn ffi_bool(f: impl FnOnce() -> bool) -> bool {
     match catch_unwind(AssertUnwindSafe(f)) {
         Ok(value) => value,

--- a/crates/wrac_clap_adapter/src/abi/gui_extension.rs
+++ b/crates/wrac_clap_adapter/src/abi/gui_extension.rs
@@ -382,8 +382,8 @@ unsafe fn plugin_gui_mutation(
         log::error!("rejecting reentrant or concurrent CLAP GUI callback: {callback_name}");
         return None;
     };
-    // GUI callback を `PluginCore` の lifecycle/state lock と結合させないため、
-    // capability handle だけを取り出す (GUI runtime は独自の thread 規則を持つ)。
+    // Extract only the capability handle to avoid coupling GUI callbacks to the
+    // `PluginCore` lifecycle/state lock (the GUI runtime has its own thread rules).
     instance
         .gui
         .clone()

--- a/crates/wrac_clap_adapter/src/abi/params_extension.rs
+++ b/crates/wrac_clap_adapter/src/abi/params_extension.rs
@@ -26,9 +26,9 @@ pub(super) static PARAMS: clap_plugin_params = clap_plugin_params {
     flush: Some(params_flush),
 };
 
-// VST3/AU/AAX wrapper では parameter query が CLAP の `[main-thread]` 前提から外れて
-// 呼ばれることがある。parameters capability は instance 作成時に固定した Arc を直接読み、
-// GUI/runtime 所有権や lifecycle mutation に入らない。
+// VST3/AU/AAX wrappers may invoke parameter queries outside the CLAP `[main-thread]` assumption.
+// The parameters capability reads the Arc fixed at instance creation and does not touch
+// GUI/runtime ownership or lifecycle mutation.
 unsafe extern "C" fn params_count(plugin: *const clap_plugin) -> u32 {
     ffi_u32(|| {
         let Some(instance) = (unsafe { PluginInstance::from_plugin(plugin) }) else {

--- a/crates/wrac_clap_adapter/src/abi/state_extension.rs
+++ b/crates/wrac_clap_adapter/src/abi/state_extension.rs
@@ -13,9 +13,9 @@ pub(super) static STATE: clap_plugin_state = clap_plugin_state {
 
 const MAX_STATE_BYTES: usize = 64 * 1024 * 1024;
 
-// state callback は host format により active 中にも来る。ここで lifecycle 用の
-// `PluginCore` write lock を待つ/諦めると、project save が欠落し得るため、instance 作成時に
-// 固定した thread-safe state capability だけを呼ぶ。
+// State callbacks may arrive while the plugin is active, depending on the host format.
+// Waiting for or giving up on the `PluginCore` write lock here could silently drop a project save,
+// so only the thread-safe state capability fixed at instance creation is called.
 unsafe extern "C" fn state_save(plugin: *const clap_plugin, stream: *const clap_ostream) -> bool {
     ffi_bool(|| {
         if stream.is_null() {

--- a/crates/wrac_clap_adapter/src/api.rs
+++ b/crates/wrac_clap_adapter/src/api.rs
@@ -1,10 +1,10 @@
-//! 製品実装と adapter の間の safe なインターフェース。
+//! Safe interface between product implementations and the adapter.
 //!
-//! 設計の前提を 1 つだけ覚えておけば全 trait の doc が読める:
-//! **clap-wrapper 経由の VST3/AU/AAX では CLAP の `[main-thread]` 注釈や
-//! lifecycle 順序がそのまま守られない**。そのため query 系 trait は `&self` で、
-//! 任意 thread から並行に呼ばれても答えられる実装を要求する。FFI・raw pointer・
-//! panic 遮断は adapter 内部に閉じ、製品はこの safe trait だけを実装すればよい。
+//! One design assumption unlocks all trait docs: **VST3/AU/AAX via clap-wrapper does
+//! not preserve CLAP `[main-thread]` annotations or lifecycle ordering.** Query traits
+//! therefore take `&self` and must be answerable from any thread concurrently. FFI,
+//! raw pointers, and panic barriers are contained inside the adapter; products only
+//! need to implement these safe traits.
 
 use std::error::Error;
 use std::ffi::{CStr, c_void};
@@ -54,26 +54,28 @@ impl From<AudioBufferError> for PluginError {
     }
 }
 
-/// instance ごとに adapter から製品 core へ渡す環境。
+/// Per-instance environment passed from the adapter to the product core.
 ///
-/// FFI pointer を直接渡さず、製品が安全に保持できる adapter proxy だけを入れる。
+/// Contains only adapter proxies that the product can hold safely, not raw FFI pointers.
 #[derive(Clone)]
 pub struct PluginCoreContext {
     pub host_parameter_edit_notifier: Arc<dyn HostParameterEditNotifier>,
     pub host_gui_resize_requester: Arc<dyn HostGuiResizeRequester>,
 }
 
-/// GUI 操作などで起きた parameter edit を host automation へ通知する。
+/// Notifies the host automation lane of a parameter edit triggered by the GUI or other
+/// product-side action.
 ///
-/// SoT を更新する API ではない。製品が自分の store を先に更新し、その edit を
-/// host へ返すために呼ぶ (begin → update → end が 1 つの undo 単位)。
+/// This is not an API to update the source of truth. The product updates its own store
+/// first, then calls this to report the edit back to the host
+/// (begin → update → end forms one undo unit).
 pub trait HostParameterEditNotifier: Send + Sync {
     fn begin_edit(&self, parameter_id: u32);
     fn update_edit(&self, parameter_id: u32, value: f64);
     fn end_edit(&self, parameter_id: u32);
 }
 
-/// GUI など製品側操作から host へ GUI client area の resize を要求する。
+/// Requests the host to resize the GUI client area on behalf of the product (e.g., from the GUI).
 pub trait HostGuiResizeRequester: Send + Sync {
     fn request_resize(&self, size: GuiSize) -> PluginResult<()>;
 }
@@ -111,8 +113,8 @@ pub struct NotePortInfo {
     pub name: &'static str,
 }
 
-/// CLAP note dialect bitset の薄い Rust 表現。
-/// host とどの note dialect を送受信できるかを note-ports extension で交渉する値。
+/// Thin Rust representation of the CLAP note dialect bitset.
+/// Used in the note-ports extension to negotiate which note dialects can be sent and received.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct NoteDialects(u32);
 
@@ -217,8 +219,8 @@ pub struct GuiResizeHints {
     pub aspect_ratio_height: u32,
 }
 
-/// CLAP `clap_window_t` の薄い Rust 表現。
-/// toolkit 中立にするため、特定 toolkit の型へは変換しない。
+/// Thin Rust representation of `clap_window_t`.
+/// Does not convert to toolkit-specific types in order to remain toolkit-neutral.
 #[derive(Debug, Clone, Copy)]
 pub enum ClapWindow {
     Cocoa { ns_view: NonNull<c_void> },
@@ -246,75 +248,78 @@ impl ClapWindow {
     }
 }
 
-/// 1 plugin instance の lifecycle と capability の入口。
+/// Entry point for a single plugin instance's lifecycle and capabilities.
 ///
-/// ここに全 state を集めない。`&mut self` の `activate`/`deactivate` と、並行に
-/// 呼ばれる parameter/state/GUI の query を同じ mutable state に集めると、片方の
-/// 実行中にもう片方へ答えられなくなる。各 capability は専用の thread-safe store に
-/// 分け、この trait からは `Arc<dyn …>` で返すのが推奨形 (実例は `src-plugin`)。
+/// Do not concentrate all state here. Placing `&mut self` `activate`/`deactivate` and
+/// concurrently-called parameter/state/GUI queries in the same mutable state would make
+/// it impossible to answer one while the other is running. Split each capability into
+/// its own thread-safe store and return it as `Arc<dyn …>` from this trait (see
+/// `src-plugin` for examples).
 pub trait PluginCore: Send + Sync + 'static {
     fn activate(&mut self, context: ActivateContext) -> PluginResult<Box<dyn Processor>>;
     fn deactivate(&mut self, processor: Box<dyn Processor>) -> PluginResult<()>;
 
-    /// audio port query の capability。adapter が instance 作成時に Arc を保持し、
-    /// 以降 `PluginCore` を借用せず呼ぶ (並行 read できる store に置くこと)。
+    /// Capability for audio port queries. The adapter holds the Arc at instance creation
+    /// and calls it without borrowing `PluginCore` thereafter (store in a parallel-readable store).
     fn audio_ports(&self) -> Option<Arc<dyn PluginAudioPorts>> {
         None
     }
 
-    /// host からの port layout 変更要求を扱う capability。
+    /// Capability for handling host-initiated port layout change requests.
     ///
-    /// `&self` だが active 中に変えてよい訳ではない。adapter は processor 存在中や
-    /// lifecycle callback 中の apply を拒否する。実装は「次回 activate 用の layout」を
-    /// non-realtime store に記録するだけにし、`activate()` で snapshot して
-    /// [`Processor`] に渡す (processor 生存中は契約不変、と構造で示せる)。
+    /// Takes `&self` but must not be changed while active. The adapter rejects apply
+    /// calls while a Processor exists or during lifecycle callbacks. Implementations
+    /// should only record the "layout for the next activate" in a non-realtime store,
+    /// snapshot it in `activate()`, and pass it to the [`Processor`] (making the
+    /// invariant explicit in the structure: layout is stable while a processor lives).
     fn configurable_audio_ports(&self) -> Option<Arc<dyn PluginConfigurableAudioPorts>> {
         None
     }
 
-    /// note port query の capability。count/dialect は host の routing 判断に使われる。
-    /// lifecycle の busy 状態に左右されない schema store から答えること。
+    /// Capability for note port queries. Count and dialect inform the host's routing
+    /// decisions. Answer from a schema store unaffected by lifecycle busy state.
     fn note_ports(&self) -> Option<Arc<dyn PluginNotePorts>> {
         None
     }
 
-    /// parameter schema/value と flush 時 input を扱う capability。
+    /// Capability for parameter schema/values and input during flush.
     ///
-    /// automation・generic editor・restore 後 rescan から並行に触られる。schema は
-    /// immutable、現在値は atomic/seqlock に置き、GUI/project state の lock を
-    /// ここから辿らないこと。
+    /// Accessed concurrently from automation, generic editors, and post-restore rescans.
+    /// Schema is immutable; current values live in atomics or a seqlock. Do not reach
+    /// into GUI or project state locks from here.
     fn parameters(&self) -> Option<Arc<dyn PluginParameters>> {
         None
     }
 
-    /// project state の save/restore を扱う capability。ユーザーデータを守る経路。
-    /// 再生中・automation 中に呼ばれても committed snapshot を返せること
-    /// (`&mut self` 依存にすると host が retry しない場合に編集を失う)。
+    /// Capability for project state save/restore — the path that guards user data.
+    /// Must return a committed snapshot even when called during playback or automation
+    /// (relying on `&mut self` risks losing edits when the host does not retry).
     fn state(&self) -> Option<Arc<dyn PluginStateSupport>> {
         None
     }
 
-    /// GUI を扱う capability。backend は thread affinity が強い。adapter は
-    /// callback を UI thread へ marshal しないので、その契約は実装側で守る。
+    /// Capability for the GUI. The backend has strong thread affinity. The adapter does
+    /// not marshal callbacks to the UI thread; that contract must be upheld by the implementation.
     fn gui(&self) -> Option<Arc<dyn PluginGui>> {
         None
     }
 }
 
-/// CLAP audio-ports extension。host が routing/bus layout を決める metadata を返す。
-/// 任意 thread から並行に呼ばれる read 専用 API。busy 状態で値が揺れると host が
-/// 正しく配線できないので、安定した値を返すこと。
+/// CLAP audio-ports extension. Returns metadata the host uses to determine routing and
+/// bus layout. This is a read-only API called concurrently from any thread. Return
+/// stable values — fluctuating under busy state prevents the host from wiring correctly.
 pub trait PluginAudioPorts: Send + Sync + 'static {
     fn audio_port_count(&self, is_input: bool) -> u32;
     fn audio_port_info(&self, index: u32, is_input: bool) -> Option<AudioPortInfo>;
 }
 
-/// CLAP configurable-audio-ports extension。「inactive 時に次回 activate 用の
-/// layout store を更新する」API として実装する。file IO・GUI callback・audio が
-/// 待つ lock には入らないこと。
+/// CLAP configurable-audio-ports extension. Implement as "update the layout store for
+/// the next activate when inactive." Do not enter locks that file IO, GUI callbacks, or
+/// audio threads wait on.
 ///
-/// VST3/AU wrapper は host の speaker arrangement をこれに対応付ける。対応 layout を
-/// 受け入れないと wrapper の buffer channel 数と合わず、process が呼ばれないことがある。
+/// VST3/AU wrappers map the host's speaker arrangement through this extension. Rejecting
+/// a supported layout can mismatch the wrapper's buffer channel count, causing process
+/// to not be called.
 pub trait PluginConfigurableAudioPorts: Send + Sync + 'static {
     fn can_apply_audio_port_configuration(
         &self,
@@ -327,21 +332,22 @@ pub trait PluginConfigurableAudioPorts: Send + Sync + 'static {
     ) -> PluginResult<()>;
 }
 
-/// CLAP note-ports extension。note event 自体は process stream に流れるが、
-/// port 数と dialect は host が先に query する。audio ports 同様、immutable schema /
-/// 軽量 read-only store から答えること。
+/// CLAP note-ports extension. Note events themselves flow in the process stream, but
+/// port count and dialect are queried by the host up front. As with audio ports, answer
+/// from an immutable schema or lightweight read-only store.
 pub trait PluginNotePorts: Send + Sync + 'static {
     fn note_port_count(&self, is_input: bool) -> u32;
     fn note_port_info(&self, index: u32, is_input: bool) -> Option<NotePortInfo>;
 }
 
-/// CLAP params extension。schema と現在値を host が任意 thread から読める前提で設計する。
-/// 特に `parameter_value` / `apply_parameter_value` は automation/flush と audio processing の
-/// 境界に近いので、audio thread が待つ lock を共有しない store に寄せる。
+/// CLAP params extension. Design assuming the host reads schema and current values from
+/// any thread. In particular, `parameter_value` / `apply_parameter_value` sit close to
+/// the automation/flush and audio processing boundary, so keep them in a store that does
+/// not share locks the audio thread waits on.
 pub trait PluginParameters: Send + Sync + 'static {
     fn parameter_count(&self) -> u32;
     fn parameter_info(&self, index: u32) -> Option<ParameterInfo>;
-    /// parameter の現在の plain value (CLAP `get_value` 相当)。
+    /// Current plain value of a parameter (equivalent to CLAP `get_value`).
     fn parameter_value(&self, parameter_id: u32) -> PluginResult<f64>;
     fn apply_parameter_value(&self, event: ParameterValueEvent) -> PluginResult<f64>;
     fn parameter_value_to_text(&self, parameter_id: u32, value: f64) -> PluginResult<String>;
@@ -359,25 +365,27 @@ pub struct ParameterValueEvent {
     pub key: i16,
 }
 
-/// CLAP state extension。[`PluginCore`] lifecycle から独立した project state 境界として
-/// 実装する (host は active 中にも save/restore し得る)。
+/// CLAP state extension. Implement as a project state boundary independent of the
+/// [`PluginCore`] lifecycle (the host may save/restore while active).
 ///
-/// `save_state` は committed snapshot を**短時間で**返す。lock 中に serialize/file IO/
-/// GUI dispatch を挟むと host の project save を詰まらせる。`restore_state` は decode 済み
-/// state を SoT に commit する。audio と共有する値は realtime-safe store、editor-only は
-/// project store、と state の種類で同期境界を分けるのが定石。
+/// `save_state` must return a committed snapshot **quickly**. Serializing, doing file IO,
+/// or dispatching to the GUI while holding a lock will stall the host's project save.
+/// `restore_state` commits the decoded state to the source of truth. The standard
+/// pattern is to split sync boundaries by state kind: realtime-safe store for audio-shared
+/// values, project store for editor-only values.
 pub trait PluginStateSupport: Send + Sync + 'static {
     fn save_state(&self) -> PluginResult<PluginState>;
     fn restore_state(&self, state: PluginState) -> PluginResult<()>;
 }
 
-/// CLAP gui extension。GUI backend の thread affinity はこの trait 内で守る
-/// (adapter は callback を UI thread へ marshal しない)。
+/// CLAP gui extension. GUI backend thread affinity must be enforced within this trait
+/// (the adapter does not marshal callbacks to the UI thread).
 ///
-/// `get_size`/`can_resize`/`resize_hints` は host の layout 計算中に再入し得る。
-/// cached size や static hints から答え、重い mutation に入らないこと。
-/// `create`/`destroy`/`set_parent` は adapter が再入 guard するが、backend 固有の
-/// lifecycle 制約までは隠せない (必要なら controller 内に command queue を持つ)。
+/// `get_size`/`can_resize`/`resize_hints` may be re-entered during host layout
+/// computation. Answer from cached size or static hints without entering heavy mutations.
+/// `create`/`destroy`/`set_parent` are re-entry-guarded by the adapter, but
+/// backend-specific lifecycle constraints are not hidden (use a command queue inside the
+/// controller if needed).
 pub trait PluginGui: Send + Sync + 'static {
     fn is_api_supported(&self, api: GuiApi, is_floating: bool) -> bool;
     fn preferred_api(&self) -> Option<GuiConfiguration>;
@@ -396,12 +404,12 @@ pub trait PluginGui: Send + Sync + 'static {
     fn hide(&self) -> PluginResult<()>;
 }
 
-/// audio thread で動く processing object。
+/// Processing object that runs on the audio thread.
 ///
-/// `PluginCore` と分けてあるのは、audio callback を core の write lock や
-/// GUI/project state から切り離すため。渡す state は activate 時に copy した
-/// immutable 設定か、audio thread が待たない atomic/lock-free 共有のみ
-/// (`Arc<Mutex<_>>` を渡す場合も process 中に lock しない設計にする)。
+/// Kept separate from `PluginCore` to decouple the audio callback from the core's write
+/// lock and from GUI/project state. State passed in must be either an immutable snapshot
+/// copied at activate time, or atomic/lock-free shared state the audio thread never
+/// waits on (even when passing `Arc<Mutex<_>>`, design it so process() never locks).
 pub trait Processor: Send {
     fn reset(&mut self) {}
     fn process(&mut self, context: ProcessContext<'_>) -> PluginResult<ProcessStatus>;

--- a/crates/wrac_clap_adapter/src/descriptor.rs
+++ b/crates/wrac_clap_adapter/src/descriptor.rs
@@ -62,18 +62,20 @@ pub struct Auv2Descriptor {
     pub plugin_subtype: [u8; 4],
 }
 
-/// plugin binary に固定される descriptor と factory 関数。
+/// Descriptor and factory function fixed for the plugin binary.
 ///
-/// factory callback は任意タイミングで呼ばれるので static に置く。不変にすることで
-/// global mutable registry や pointer リークに頼らず C ABI に渡せる。
+/// The factory callback may be called at any time, so it is stored statically. Being
+/// immutable allows it to be passed to the C ABI without relying on a global mutable
+/// registry or pointer leaks.
 pub struct PluginRegistration {
     pub(crate) descriptor: PluginDescriptor,
     pub(crate) create: CreatePluginCore,
     storage: OnceLock<PluginRegistrationStorage>,
 }
 
-// 安全性: `descriptor` と `create` は static registration の不変データで、mutable state は
-// `OnceLock` が同期する。C ABI から複数 thread で factory query されても共有参照だけを返す。
+// Safety: `descriptor` and `create` are immutable data in the static registration;
+// mutable state is synchronized by `OnceLock`. Factory queries from multiple threads
+// via the C ABI return only shared references.
 unsafe impl Sync for PluginRegistration {}
 unsafe impl Send for PluginRegistration {}
 
@@ -98,8 +100,9 @@ pub(crate) struct PluginRegistrationStorage {
     pub descriptor: ClapDescriptorStorage,
 }
 
-// 安全性: storage 作成後は factory/descriptor の pointer を読み出すだけにしている。
-// 内部 pointer は同じ storage が所有する buffer を指し、`OnceLock` で初期化競合も防ぐ。
+// Safety: after creation the storage only reads out factory/descriptor pointers.
+// Internal pointers point to buffers owned by this same storage, and `OnceLock`
+// prevents initialization races.
 unsafe impl Sync for PluginRegistrationStorage {}
 unsafe impl Send for PluginRegistrationStorage {}
 
@@ -128,8 +131,8 @@ impl PluginRegistrationStorage {
     }
 }
 
-// CLAP factory callback は factory pointer だけを受け取るため、先頭 field に C ABI
-// struct を置き、callback 内で state へ戻す。
+// CLAP factory callbacks receive only a factory pointer, so the C ABI struct is placed
+// as the first field and cast back to the state inside the callback.
 #[repr(C)]
 pub(crate) struct ClapFactoryState {
     pub factory: clap_plugin_factory,
@@ -170,8 +173,9 @@ pub(crate) struct ClapPluginFactoryAsAuv2 {
 unsafe impl Sync for ClapPluginFactoryAsAuv2 {}
 unsafe impl Send for ClapPluginFactoryAsAuv2 {}
 
-// `clap_plugin_descriptor` は C string pointer だけを保持するため、CString/feature
-// pointer の owner を同じ storage に置いて descriptor pointer の有効期間を揃える。
+// `clap_plugin_descriptor` holds only C string pointers, so the owners of the CString
+// and feature pointer arrays are placed in the same storage to keep their lifetimes
+// aligned with the descriptor pointer.
 pub(crate) struct ClapDescriptorStorage {
     _id: CString,
     _name: CString,
@@ -187,8 +191,9 @@ pub(crate) struct ClapDescriptorStorage {
     clap_descriptor: clap_plugin_descriptor,
 }
 
-// 安全性: descriptor storage は初期化後に変更しない。raw pointer は外部所有物ではなく、
-// この struct 内の CString/Vec へ向いているため、共有しても data race にはならない。
+// Safety: the descriptor storage is not mutated after initialization. Raw pointers point
+// into CString/Vec fields owned by this struct, not external memory, so sharing them
+// causes no data race.
 unsafe impl Sync for ClapDescriptorStorage {}
 unsafe impl Send for ClapDescriptorStorage {}
 

--- a/crates/wrac_clap_adapter/src/events.rs
+++ b/crates/wrac_clap_adapter/src/events.rs
@@ -14,10 +14,11 @@ use clap_sys::events::{
 
 use crate::api::ParameterValueEvent;
 
-/// `process()`/`flush()` の CLAP event list を callback lifetime に閉じ込める view。
+/// View that confines the CLAP event lists from `process()`/`flush()` to the callback lifetime.
 ///
-/// 実体は host 所有で callback 終了後は無効。raw pointer を製品へ渡さず typed enum に
-/// 寄せ、event を扱える範囲を audio callback 内に限定する。
+/// The underlying data is owned by the host and is invalid after the callback returns.
+/// Raw pointers are not exposed to the product; events are converted to typed enums so
+/// they can only be handled within the audio callback.
 pub struct ProcessEvents<'a> {
     pub input: InputEvents<'a>,
     pub output: OutputEvents<'a>,

--- a/crates/wrac_clap_adapter/src/host_gui.rs
+++ b/crates/wrac_clap_adapter/src/host_gui.rs
@@ -38,8 +38,9 @@ struct HostGuiRequestResize {
     request_resize: unsafe extern "C" fn(host: *const clap_host, width: u32, height: u32) -> bool,
 }
 
-// host pointer の instance lifetime は CLAP ABI で避けられない最小前提です。用途は
-// GUI thread からの request_resize に限定し、製品側へ raw pointer は公開しない。
+// The instance lifetime of the host pointer is the minimal unavoidable assumption of the
+// CLAP ABI. Use is limited to request_resize from the GUI thread; the raw pointer is
+// not exposed to product code.
 unsafe impl Send for HostGuiRequestResize {}
 unsafe impl Sync for HostGuiRequestResize {}
 

--- a/crates/wrac_clap_adapter/src/lib.rs
+++ b/crates/wrac_clap_adapter/src/lib.rs
@@ -1,8 +1,9 @@
-//! CLAP ABI と plugin core を繋ぐ adapter crate。
+//! Adapter crate that connects the CLAP ABI to the plugin core.
 //!
-//! 製品 crate は [`api`] の safe trait を実装し、[`export_clap_plugin!`] で CLAP
-//! entry を宣言するだけでよい。`clap-sys`・raw pointer・event 変換・host callback
-//! は adapter 内部に閉じる。trait の契約は `api.rs` を参照。
+//! Product crates only need to implement the safe traits in [`api`] and declare
+//! the CLAP entry with [`export_clap_plugin!`]. `clap-sys`, raw pointers, event
+//! conversion, and host callbacks are all encapsulated inside the adapter.
+//! See `api.rs` for the trait contracts.
 
 mod abi;
 mod api;
@@ -45,9 +46,10 @@ macro_rules! export_clap_plugin {
     (descriptor: $descriptor:expr, create: $create:path $(,)?) => {
         #[allow(non_snake_case)]
         mod __wrac_clap_export {
-            // CLAP entry symbol は binary ごとに 1 つ必要なので、adapter ではなく
-            // 製品 crate 側で展開する。adapter は再利用可能なまま、descriptor と
-            // factory の static lifetime を binary に閉じ込められる。
+            // The CLAP entry symbol must appear exactly once per binary, so this macro
+            // expands in the product crate rather than in the adapter. The adapter
+            // stays reusable while the static lifetimes of descriptor and factory are
+            // confined to the binary.
             static WRAC_CLAP_PLUGIN_REGISTRATION: $crate::__private::PluginRegistration =
                 $crate::__private::PluginRegistration::new($descriptor, $create);
 

--- a/crates/wrac_clap_adapter/src/params.rs
+++ b/crates/wrac_clap_adapter/src/params.rs
@@ -9,11 +9,12 @@ use crate::{
     ParameterValueEvent, PluginParameters,
 };
 
-/// UI 由来の parameter edit を host が受け取れるまで保持する queue。
+/// Queue that holds UI-originated parameter edits until the host can receive them.
 ///
-/// CLAP output queue は `flush()`/`process()` callback 中しか存在しない。GUI に
-/// 直接 CLAP event を作らせると callback lifetime 越えの pointer を握ることになるので、
-/// adapter は意味情報だけ保存し、出力 queue が来た時点で CLAP event へ変換する。
+/// The CLAP output queue only exists during `flush()`/`process()` callbacks. Letting
+/// the GUI construct CLAP events directly would mean holding pointers beyond the
+/// callback lifetime, so the adapter stores only semantic information and converts to
+/// CLAP events when the output queue becomes available.
 pub(crate) struct ParameterEditQueue {
     pending: Mutex<VecDeque<ParameterEditEvent>>,
     host_params: Option<HostParams>,
@@ -44,8 +45,9 @@ impl ParameterEditQueue {
     }
 
     pub(crate) fn drain_output_parameter_events(&self, events: &mut OutputEvents<'_>) {
-        // audio callback 上で UI thread と待ち合わないため、queue が一瞬 busy なら次回
-        // flush/process へ回す。host への request_flush は edit 追加時点で発行済み。
+        // Avoid waiting on the UI thread from the audio callback. If the queue is
+        // momentarily busy, defer to the next flush/process. request_flush to the host
+        // was already issued when the edit was enqueued.
         let Some(mut pending) = self.pending.try_lock() else {
             log::debug!("parameter_edits.drain: pending queue try_lock failed; retrying later");
             return;
@@ -53,9 +55,10 @@ impl ParameterEditQueue {
 
         while let Some(event) = pending.pop_front() {
             if !push_parameter_edit(events, event) {
-                // CLAP output queue は host 所有で、queue full や no-buffer flush では拒否され得る。
-                // 送れなかった edit を捨てると automation gesture が欠けるため、順序を保って
-                // 次回の flush/process に回す。
+                // The CLAP output queue is host-owned and may reject events when full
+                // or during a no-buffer flush. Discarding an unsent edit would drop an
+                // automation gesture, so preserve ordering and defer to the next
+                // flush/process.
                 pending.push_front(event);
                 break;
             }
@@ -64,8 +67,8 @@ impl ParameterEditQueue {
 
     fn push(&self, event: ParameterEditEvent) {
         self.pending.lock().push_back(event);
-        // request_flush は queue 追加後に出す。host によってはこの通知がないと
-        // `flush()` を呼ばないため、UI edit を automation lane へ返す機会を失う。
+        // Issue request_flush after enqueuing. Some hosts will not call `flush()`
+        // without this notification, causing UI edits to never reach the automation lane.
         self.request_flush();
     }
 
@@ -160,8 +163,9 @@ struct HostParams {
     request_flush: Option<unsafe extern "C" fn(host: *const clap_host)>,
 }
 
-// host pointer の instance lifetime は CLAP ABI で避けられない最小前提です。wrapper
-// 固有の thread/order は信じず、adapter 内では `request_flush()` だけに用途を限定する。
+// The instance lifetime of the host pointer is the minimal unavoidable assumption of the
+// CLAP ABI. Wrapper-specific thread/order guarantees are not trusted; within the adapter
+// usage is limited to `request_flush()` only.
 unsafe impl Send for HostParams {}
 unsafe impl Sync for HostParams {}
 

--- a/crates/wrac_clap_adapter/src/process_buffer.rs
+++ b/crates/wrac_clap_adapter/src/process_buffer.rs
@@ -27,11 +27,11 @@ impl Display for AudioBufferError {
 
 impl Error for AudioBufferError {}
 
-/// 1 回の `process()` だけで借りる audio buffer。
+/// Audio buffer borrowed for a single `process()` call.
 ///
-/// CLAP audio は port → channel → samples の非 interleaved 構造。raw pointer を
-/// callback lifetime に縛ったまま保持し、channel へ降りる時点で in-place alias を
-/// 判定して safe slice へ変換する。
+/// CLAP audio follows a non-interleaved port → channel → samples structure. Raw pointers
+/// are held within the callback lifetime; in-place aliasing is detected and resolved
+/// into safe slices at the point of descending to individual channels.
 pub struct AudioProcessBuffer<'a> {
     inputs: &'a [clap_audio_buffer],
     outputs: &'a mut [clap_audio_buffer],

--- a/crates/wrac_wxp_gui/README.md
+++ b/crates/wrac_wxp_gui/README.md
@@ -1,16 +1,16 @@
 # wrac_wxp_gui
 
-`wrac_wxp_gui` は `wrac_clap_adapter` の `PluginGui` と wxp WebView runtime を接続する helper crate です。
+`wrac_wxp_gui` is a helper crate that connects `wrac_clap_adapter`'s `PluginGui` with the wxp WebView runtime.
 
-責務は 2 つです。1 つは CLAP の `clap_window_t` 由来の `ClapWindow` を `raw-window-handle` の型に変換して wxp に渡すこと、もう 1 つは特定の thread からしか操作できない WebView runtime を host UI thread 上に保持することです。CLAP C ABI とのインタラクションはこのクレートの責務ではなく、wrac_clap_adapter の責務です。
+It has two responsibilities: converting the `ClapWindow` derived from CLAP's `clap_window_t` into `raw-window-handle` types for passing to wxp, and holding a WebView runtime (which can only be operated from a specific thread) on the host UI thread. Interaction with the CLAP C ABI is the responsibility of `wrac_clap_adapter`, not this crate.
 
-## 前提
+## Assumptions
 
-- `set_parent()` で UI thread を固定し、GUI runtime はその thread 上で `show()` 時に作る
-- 1 process 内の host UI thread は単一とみなす
-- 複数 UI thread を使う host は unsupported として失敗させる
-- floating window はこの helper では扱わない
-- 汎用的なフレームワークではなく実装例の一部です。今後の変更に伴う、API の後方互換性やマイグレーションサポートは提供しません。
+- `set_parent()` fixes the UI thread, and the GUI runtime is created on that thread when `show()` is called
+- A single host UI thread per process is assumed
+- Hosts that use multiple UI threads are treated as unsupported and will fail
+- Floating windows are not handled by this helper
+- This is part of an implementation example, not a general-purpose framework. Future changes will not provide API backwards compatibility or migration support.
 
-## 参考
-wxp クレートの使い方は [wxp の README](https://github.com/novonotes/wxp/tree/main/crates/wxp) に記載しています。
+## Reference
+For wxp crate usage, see the [wxp README](https://github.com/novonotes/wxp/tree/main/crates/wxp).

--- a/crates/wrac_wxp_gui/src/controller.rs
+++ b/crates/wrac_wxp_gui/src/controller.rs
@@ -22,11 +22,11 @@ pub struct GuiSizeLimits {
     pub max: GuiSize,
 }
 
-/// wxp WebView runtime を [`PluginGui`] として公開する Send/Sync controller。
+/// Send/Sync controller that exposes the wxp WebView runtime as a [`PluginGui`].
 ///
-/// 実 runtime は UI thread の TLS 上に保持し、この型は CLAP instance から共有される
-/// [`PluginGui`] handle として GUI lifecycle callback を受ける。現在は host parent に
-/// child view として貼る embedded GUI のみ対応し、floating window は拒否する。
+/// The actual runtime lives in TLS on the UI thread; this type receives GUI lifecycle
+/// callbacks as the [`PluginGui`] handle shared across CLAP instances. Only embedded GUI
+/// (attached as a child view to the host parent) is supported; floating windows are rejected.
 pub struct WxpGuiController {
     factory: Arc<dyn WxpGuiFactory>,
     layout: Arc<HostGuiLayout>,
@@ -35,11 +35,12 @@ pub struct WxpGuiController {
 }
 
 struct HostGuiLayout {
-    // CLAP layout query が GUI runtime に入らず読む host 契約値 (runtime の複製ではない)。
+    // Host-contract size value read by CLAP layout queries without entering the GUI runtime
+    // (not a copy of the runtime state).
     accepted_size: AtomicGuiSize,
-    // 一部 wrapper は `request_resize()` の中から `set_size()` を再入で呼び (戻り値は
-    // false でも)。この revision で、runtime lock も戻り値の推測も無しに
-    // 「host が確定したサイズ」を request 側が検出できる。
+    // Some wrappers call `set_size()` re-entrantly from within `request_resize()` (even
+    // when the return value is false). This revision counter lets the request side detect
+    // "the size the host confirmed" without holding the runtime lock or guessing the return value.
     accepted_size_revision: AtomicU64,
     limits: GuiSizeLimits,
     resize_policy: GuiResizePolicy,
@@ -47,27 +48,30 @@ struct HostGuiLayout {
 
 struct GuiRuntimeState {
     session: Option<GuiSession>,
-    // editor の開閉を連打すると create/set_parent/show/destroy が高速に来る。
-    // WebView 作成は GUI run loop に post するので callback が元の CLAP 呼び出し
-    // 後に届く。generation で遅れた callback が stale session を検出し、閉じた
-    // editor に繋がず作りかけ runtime を畳めるようにする。
+    // Rapid open/close of the editor sends create/set_parent/show/destroy in quick
+    // succession. WebView creation is posted to the GUI run loop, so the callback arrives
+    // after the originating CLAP call returns. The generation counter lets a delayed
+    // callback detect a stale session and tear down the half-created runtime without
+    // attaching it to an already-closed editor.
     generation: u64,
     last_runtime_destroyed_at: Option<Instant>,
-    // Windows host (特に Ableton Live) は前回 teardown 中に editor を再生成し得る。
-    // child WebView 作成を single-flight にし、最新要求 generation だけ覚える。
+    // Some Windows hosts (notably Ableton Live) may recreate the editor while the
+    // previous teardown is still in progress. Keep child WebView creation single-flight
+    // and remember only the latest requested generation.
     is_creating_runtime: bool,
     creating_generation: Option<u64>,
     pending_creation_generation: Option<u64>,
     destroy_requested_while_creating: bool,
 }
 
-// runtime 破棄後の静止期間。これが無いと editor 連打時、前回 teardown 完了前に
-// 次の child WebView を要求してしまう。
+// Quiet period after runtime teardown. Without it, rapid editor reopens can request a
+// new child WebView before the previous teardown completes.
 const WEBVIEW_RECREATE_QUIET_PERIOD: Duration = Duration::from_millis(500);
 
-// CLAP の `create()` は GUI session の開始だが、embedded WebView の native child は
-// parent handle がないと作れない。session と runtime を分けることで、`create()` 後の
-// size/scale query には答えつつ、parent が来るまで native object 作成を遅延できる。
+// CLAP `create()` starts a GUI session, but an embedded WebView's native child cannot
+// be created without a parent handle. Separating session from runtime allows size/scale
+// queries to be answered after `create()` while deferring native object creation until
+// the parent arrives.
 struct GuiSession {
     generation: u64,
     configuration: GuiConfiguration,
@@ -148,9 +152,10 @@ fn schedule_runtime_creation(
     layout: Arc<HostGuiLayout>,
     generation: u64,
 ) -> PluginResult<()> {
-    // CLAP GUI callback とは意図的に非同期にする。inline で WebView を作ると host
-    // lifecycle の再入が起きやすい。run loop に post すれば、作成の直列化・保留中の
-    // visibility/size 適用・stale generation 破棄を 1 か所に集約できる。
+    // Intentionally asynchronous with CLAP GUI callbacks. Creating a WebView inline
+    // makes host lifecycle re-entry more likely. Posting to the run loop centralizes
+    // creation serialization, pending visibility/size application, and stale-generation
+    // teardown in one place.
     let (configuration, parent) = {
         let mut state = runtime.lock();
         if state.is_creating_runtime {
@@ -575,20 +580,20 @@ impl WxpGuiResizeHandle {
         let resize_result = host_gui_resize_requester.request_resize(gui_size);
         let current_revision = self.layout.accepted_size_revision();
 
-        // Logic の AUv2 wrapper は `request_resize()` 中に NSView frame を適用し
-        // `set_size()` を再入で呼んだ上で CLAP には false を返す。この再入 `set_size()`
-        // を真実とみなす。ここで楽観的に WebView を resize すると host と geometry を
-        // 奪い合い、grip ドラッグ中に視覚的な揺れが出る。
+        // Logic's AUv2 wrapper applies the NSView frame inside `request_resize()`, calls
+        // `set_size()` re-entrantly, and then returns false to CLAP. Treat that re-entrant
+        // `set_size()` as the ground truth. Optimistically resizing the WebView here would
+        // race geometry with the host and cause visual jitter during grip dragging.
         if current_revision != previous_revision {
             return Ok(self.layout.accepted_size());
         }
 
         match resize_result {
             Ok(()) => {
-                // request を受理しても即 `set_size()` を呼ばない host がある。その場合は
-                // plugin 側で WebView を更新し、任意 callback を待たず resize する。
-                // command には native owner ではなく `WebViewDispatch` を渡す。閉じかけ
-                // editor の寿命を延ばさずに command handler から resize できる。
+                // Some hosts accept the request but never call `set_size()`. In that case,
+                // update the WebView directly without waiting for an async callback.
+                // Pass `WebViewDispatch` rather than the native owner so the command handler
+                // can resize without extending the lifetime of a closing editor.
                 let scale = *self.scale.lock();
                 web_view
                     .post_set_bounds(DpiConverter::new(scale).create_webview_bounds(logical_size))
@@ -597,8 +602,9 @@ impl WxpGuiResizeHandle {
                 Ok(gui_size)
             }
             Err(error) => {
-                // 本当の拒否は上の AUv2 再入ケースとは別。child WebView を投機的に
-                // 動かして後で戻すより、host 確定済みの最後のサイズを保つ。
+                // A genuine rejection is distinct from the AUv2 re-entry case above. Rather
+                // than speculatively moving the child WebView and rolling it back, keep the
+                // last host-confirmed size.
                 Err(error)
             }
         }
@@ -683,8 +689,9 @@ impl PluginGui for WxpGuiController {
                 parent: None,
                 parent_lease: None,
                 handle: None,
-                // 一部 wrapper は embedded view を parent に付けた時点で表示扱いにし、`show()`
-                // を呼ばない。初回 parent attach は表示状態として扱い、明示的な `hide()` を優先する。
+                // Some wrappers treat attachment to the parent as an implicit show and never
+                // call `show()`. Default to visible so the first parent attach works; an
+                // explicit `hide()` overrides this.
                 visible: true,
             });
             generation
@@ -752,10 +759,11 @@ impl PluginGui for WxpGuiController {
                 .and_then(|session| session.handle.clone())
         };
 
-        // editor window が落ち着くまで同じ size を再送する host がある。同一 bounds の
-        // 再適用は契約を変えないが、child view に冗長な geometry 処理を与え、resize
-        // ドラッグが pointer に遅れて感じる。それでも下で size は記録し、再入
-        // `request_resize()` 検出が host callback を観測できるようにする。
+        // Some hosts repeatedly send the same size until the editor window settles.
+        // Re-applying identical bounds does not violate the contract but adds redundant
+        // geometry processing to the child view, making resize drags feel laggy. Size is
+        // still recorded below so re-entrant `request_resize()` detection can observe
+        // host callbacks.
         if let Some(handle) = handle {
             if size_changed {
                 handle.set_size(size)?;
@@ -798,8 +806,8 @@ impl PluginGui for WxpGuiController {
                 drop(parent_lease);
                 return Err(PluginError::InvalidState);
             }
-            // parent handle が変わると、既存 child WebView を安全に reparent できる保証が
-            // wxp/wry 側にない。古い runtime を先に落として、新しい parent 上に作り直す。
+            // wxp/wry gives no guarantee that an existing child WebView can be safely
+            // reparented. Tear down the old runtime first and recreate it on the new parent.
             session.handle.take()
         };
         if let Some(handle) = old_handle {
@@ -829,9 +837,10 @@ impl PluginGui for WxpGuiController {
             session.parent_lease = Some(parent_lease);
         }
         drop(state);
-        // ここは parent を受理して WebView 作成を予約するだけ。実作成を host
-        // lifecycle callback から外すことで create/destroy 再入を避ける。失敗時は
-        // log だけ残し runtime 無しの session にして、後の show/set_parent で再予約させる。
+        // Only accept the parent and schedule WebView creation here. Deferring actual
+        // creation outside the host lifecycle callback avoids create/destroy re-entry.
+        // On failure, leave the session without a runtime and let a subsequent
+        // show/set_parent reschedule it.
         self.schedule_runtime_creation(generation)?;
         log::debug!("wxp controller: set_parent completed");
         Ok(())
@@ -916,8 +925,8 @@ fn drop_session(session: Option<GuiSession>) -> bool {
             handle.destroy();
             destroyed_runtime = true;
         }
-        // runtime drop が終わってから parent lease を解放する。timer stop や WebView teardown が
-        // run loop 上で完了する前に owner thread を解放しないため。
+        // Release the parent lease only after the runtime has been dropped, so the owner
+        // thread is not freed before timer stop and WebView teardown complete on the run loop.
         drop(session.parent_lease.take());
         log::debug!("wxp controller: drop_session completed");
         destroyed_runtime

--- a/crates/wrac_wxp_gui/src/dpi.rs
+++ b/crates/wrac_wxp_gui/src/dpi.rs
@@ -1,10 +1,10 @@
 use wrac_clap_adapter::GuiSize;
 use wxp::dpi::{LogicalPosition, LogicalSize, Size};
 
-/// CLAP GUI size と wxp bounds の変換。
+/// Conversion between CLAP GUI sizes and wxp bounds.
 ///
-/// macOS/Windows と Linux で WebView が期待する単位が違うため、製品ごとに同じ DPI
-/// 分岐を持たせず、wxp integration 側に寄せる。
+/// The unit expected by WebView differs between macOS/Windows and Linux.
+/// Centralising the DPI branch here avoids duplicating it in every product.
 pub struct DpiConverter {
     scale_factor: f64,
     uses_logical: bool,
@@ -38,9 +38,11 @@ pub fn gui_size_to_logical(size: GuiSize) -> LogicalSize<f64> {
     LogicalSize::new(size.width as f64, size.height as f64)
 }
 
-/// wxp の logical size を CLAP `GuiSize` へ戻す helper。
-/// WebView/layout 由来のサイズを resize request や state に返すとき、platform
-/// ごとの変換を製品側に散らさないよう public API として残している。
+/// Converts a wxp logical size back to a CLAP [`GuiSize`].
+///
+/// Keeping this as a public API prevents per-platform conversion logic from leaking
+/// into product code when returning a WebView- or layout-derived size as a resize
+/// request or state value.
 pub fn logical_size_to_gui(size: LogicalSize<f64>) -> GuiSize {
     GuiSize {
         width: size.width as u32,

--- a/crates/wrac_wxp_gui/src/lib.rs
+++ b/crates/wrac_wxp_gui/src/lib.rs
@@ -1,7 +1,8 @@
-//! wxp WebView GUI を `wrac_clap_adapter::PluginGui` として公開する helper。
+//! Helper that exposes the wxp WebView GUI as a `wrac_clap_adapter::PluginGui`.
 //!
-//! CLAP ABI を知る必要がある部分は `wrac_clap_adapter` に残し、この crate は
-//! window handle の toolkit 変換と GUI runtime の thread affinity だけを持つ。
+//! Parts that need to know about the CLAP ABI remain in `wrac_clap_adapter`. This crate
+//! is responsible only for toolkit conversion of window handles and the thread affinity
+//! of the GUI runtime.
 
 mod controller;
 mod dpi;

--- a/crates/wrac_wxp_gui/src/runtime.rs
+++ b/crates/wrac_wxp_gui/src/runtime.rs
@@ -10,14 +10,15 @@ use wrac_clap_adapter::{GuiConfiguration, GuiSize, PluginError, PluginResult};
 use crate::window::ParentWindowHandle;
 
 thread_local! {
-    // WebView などの native GUI object は、生成 thread 以外へ移動できない実装が多い。
-    // `WxpGuiController` は Send/Sync な `PluginCore` の中に置かれるため、実体は TLS に閉じ込める。
+    // Native GUI objects such as WebViews are typically bound to the thread that created them.
+    // `WxpGuiController` lives inside a Send/Sync `PluginCore`, so runtimes are confined to TLS.
     static GUI_RUNTIMES: RefCell<HashMap<u64, GuiRuntimeEntry>> = RefCell::new(HashMap::new());
 }
 
 static NEXT_GUI_ID: AtomicU64 = AtomicU64::new(1);
-// この helper は template 用の割り切りとして単一 UI thread を前提にする。複数 UI thread
-// まで受け入れるには runtime storage と run loop ownership を per-thread に再設計する必要がある。
+// This helper assumes a single UI thread — an acceptable simplification for a template.
+// Supporting multiple UI threads would require redesigning runtime storage and run loop
+// ownership on a per-thread basis.
 static GUI_THREAD_STATE: Mutex<GuiThreadState> = Mutex::new(GuiThreadState {
     owner: None,
     ref_count: 0,
@@ -30,23 +31,26 @@ struct GuiThreadState {
 
 struct GuiRuntimeEntry {
     runtime: Box<dyn WxpGuiRuntime>,
-    // runtime が TLS から remove されるまで run loop を生かす。handle 側で手動 release
-    // すると、runtime drop 中に timer や WebView teardown が run loop を必要とする場合に
-    // 順序を間違えやすいので、entry の lifetime に lease を結び付ける。
+    // Keep the run loop alive until the runtime is removed from TLS. Releasing the lease
+    // manually from the handle side is error-prone when timer teardown or WebView cleanup
+    // still needs the run loop during the runtime's drop, so tie the lease lifetime to
+    // the entry's.
     _lease: GuiThreadLease,
 }
 
-/// GUI thread の run loop 参照を表す RAII token。
+/// RAII token representing a reference to the GUI thread's run loop.
 ///
-/// TODO: `novonotes_run_loop` 側に transactional な guard API が入ったら、この型は
-/// その thin wrapper に寄せる。現状の `RunLoop::init()` は失敗時 rollback が API 契約に
-/// なっていないため、ここではローカル state を進めない範囲で防御する。
+/// TODO: once `novonotes_run_loop` gains a transactional guard API, this type should
+/// become a thin wrapper around it. The current `RunLoop::init()` does not guarantee
+/// full rollback on failure, so the local state is not advanced beyond what can be
+/// safely undone.
 pub(crate) struct GuiThreadLease;
 
-/// UI thread が所有する実際の WebView runtime。
+/// The actual WebView runtime owned by the UI thread.
 ///
-/// `Send` / `Sync` を要求しないのは意図的です。native GUI object は作成 thread に縛られる
-/// ため、`GuiRuntimeHandle` から run loop に戻して操作する。
+/// Not requiring `Send` / `Sync` is intentional: native GUI objects are bound to the
+/// thread that created them, so operations are dispatched back through the run loop via
+/// `GuiRuntimeHandle`.
 pub trait WxpGuiRuntime: 'static {
     fn set_scale(&mut self, scale: f64) -> PluginResult<()>;
     fn set_size(&mut self, size: GuiSize) -> PluginResult<()>;
@@ -58,10 +62,10 @@ pub trait WxpGuiRuntime: 'static {
     }
 }
 
-/// 製品固有 runtime を作る factory。
+/// Factory that creates a product-specific GUI runtime.
 ///
-/// factory 自体は `PluginCore` 内に保持されるため `Send + Sync` を要求するが、返す
-/// runtime は UI thread の TLS に置くので `Send` を要求しない。
+/// The factory itself is `Send + Sync` because it is held inside `PluginCore`, but the
+/// runtime it returns does not need to be `Send` — it lives in the UI thread's TLS.
 pub trait WxpGuiFactory: Send + Sync + 'static {
     fn create_gui_runtime(
         &self,
@@ -99,8 +103,8 @@ pub(crate) fn create_gui_runtime_handle(
 ) -> PluginResult<GuiRuntimeHandle> {
     log::debug!("wxp runtime: acquiring GUI thread lease");
     let lease = GuiThreadLease::acquire()?;
-    // `create` が失敗した場合、lease はここで drop される。失敗した runtime 作成が
-    // GUI thread ref を残さないことを型の drop 順で保証する。
+    // If `create` fails, the lease is dropped here. Drop order guarantees that a failed
+    // runtime creation leaves no GUI thread reference behind.
     match create() {
         Ok(runtime) => {
             log::debug!("wxp runtime: factory returned runtime");
@@ -227,8 +231,9 @@ impl GuiThreadLease {
             return Err(PluginError::UnsupportedHostGuiThreadingModel);
         }
 
-        // owner は `RunLoop::init()` 成功後にだけ進める。依存 crate の init が失敗時に
-        // 完全 rollback する保証はまだないため、少なくともこちらの SoT は汚さない。
+        // Advance the owner only after `RunLoop::init()` succeeds. The dependency's init
+        // does not guarantee full rollback on failure, so at least keep our own source of
+        // truth clean.
         gui_thread.owner = Some(current_thread);
         gui_thread.ref_count += 1;
         log::debug!(
@@ -252,8 +257,8 @@ impl Drop for GuiThreadLease {
             gui_thread.ref_count
         );
         if gui_thread.ref_count == 0 {
-            // 最後の runtime だけでなく `set_parent()` 由来の thread 固定も解放された時点で、
-            // 次の GUI session が別 host window から来ることを許可する。
+            // Once both the last runtime and the thread affinity acquired via `set_parent()`
+            // are released, allow the next GUI session to arrive from a different host window.
             gui_thread.owner = None;
             log::debug!("wxp GUI thread lease: owner cleared");
         }

--- a/crates/wrac_wxp_gui/src/window.rs
+++ b/crates/wrac_wxp_gui/src/window.rs
@@ -8,8 +8,9 @@ use raw_window_handle::{
 };
 use wrac_clap_adapter::{ClapWindow, PluginError, PluginResult};
 
-/// host の親 window を `raw-window-handle` として公開する wrapper。
-/// platform 分岐と handle lifetime をここで一度だけ吸収し、製品へ漏らさない。
+/// Wrapper that exposes the host parent window as a `raw-window-handle`.
+/// Platform branching and handle lifetime concerns are absorbed here once and
+/// kept out of product code.
 #[derive(Debug)]
 pub struct ParentWindowHandle {
     raw: RawWindowHandle,
@@ -73,9 +74,9 @@ impl StoredParentWindow {
 
 impl HasWindowHandle for ParentWindowHandle {
     fn window_handle(&self) -> Result<WindowHandle<'_>, HandleError> {
-        // 安全性: `ParentWindowHandle` は CLAP `set_parent()` で渡された handle から作る。
-        // 実体の lifetime は host の parent window 契約に従い、この wrapper は WebView
-        // 作成と後続 resize のためだけに使う。
+        // Safety: `ParentWindowHandle` is constructed from the handle passed in CLAP
+        // `set_parent()`. The underlying lifetime is governed by the host's parent window
+        // contract; this wrapper is used only for WebView creation and subsequent resize.
         Ok(unsafe { WindowHandle::borrow_raw(self.raw) })
     }
 }

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -46,6 +46,9 @@ cd my_plugin
 git submodule update --init --recursive
 ```
 
+Submodules are not needed if you are only building CLAP.
+The clap-wrapper-related submodules are required if you are building or validating VST3 / AU / Standalone.
+
 ### 2. Configure Plugin Identity
 
 Plugin identity is centralized in `src-plugin/Cargo.toml`.
@@ -61,10 +64,6 @@ auv2_subtype = "MyPl"
 auv2_manufacturer_code = "YrCo"
 standalone_name = "My Plugin Standalone"
 ```
-
-These values drive the Rust plugin descriptor, GUI About page, bundle names,
-standalone app name, wrapper build arguments, CLAP Info.plist, AUv2 validation,
-WebView data directory namespace, and debug log app name.
 
 > **Important:** The plugin ID must be globally unique. It cannot be changed once published.
 > AUv2 `auv2_type`, `auv2_subtype`, and `auv2_manufacturer_code` must each be exactly 4 ASCII bytes.
@@ -82,8 +81,7 @@ Use your IDE's find-and-replace, `rg`, or an LLM agent to search all files and r
 | kebab-case name in GUI / scripts / etc. | `wrac-gain-plugin` | `my-plugin` |
 | Repository URL in `Cargo.toml` files | `https://github.com/novonotes/wrac-plugin-template` | `https://github.com/your-org/my-plugin` |
 
-The repository URL points to this template by default. After generating a new
-project, update it to your own repository if you publish the crate metadata.
+The repository URL points to this template by default. After generating a new project, update it to your own repository if you publish the crate metadata.
 
 **Steps:**
 
@@ -113,23 +111,9 @@ cargo xtask build
 cargo xtask install
 ```
 
-The built plugin will be installed to the following directories:
-
-| OS | Install path |
-|----|-------------|
-| macOS | `~/Library/Audio/Plug-Ins/CLAP/` |
-| Windows | `%LOCALAPPDATA%/Programs/Common/CLAP/` and `%LOCALAPPDATA%/Programs/Common/VST3/` |
-| Linux | `~/.clap/` |
-
-On Windows, `cargo xtask install` installs to the user-local paths by default.
-Use `cargo xtask install --scope=system` to install to `%COMMONPROGRAMFILES%/CLAP/`
-and `%COMMONPROGRAMFILES%/VST3/` for hosts that only scan system-wide plug-in
-folders. `cargo xtask uninstall` removes both user-local and system-wide copies by default;
-use `cargo xtask uninstall --scope=user` or `--scope=system` to remove only one scope.
-
-VST3 / AU / standalone are built where supported by the current OS. Standalone
-apps do not have a plugin install destination, so xtask prints their artifact
-path instead.
+`cargo xtask install` installs to user-local paths by default.
+Use `cargo xtask install --scope=system` for hosts that only scan system-wide plugin folders.
+The `--target` option accepts `clap`, `vst3`, and `au` as comma-separated values.
 
 ### 5. Verify
 
@@ -142,6 +126,8 @@ npm install
 npm run dev
 ```
 
+For release builds, `src-plugin/build.rs` zips `src-gui/dist` and embeds it in the plugin binary, so the dev server is not needed.
+
 Launch your DAW and try inserting the plugin.
 Some DAWs may require a plugin rescan.
 The GUI supports hot reload — try editing the HTML files.
@@ -152,6 +138,11 @@ Attaching a debugger to a DAW can be difficult, so we recommend debugging as a s
 In VS Code, select the "Debug gain plugin standalone" configuration and run it.
 
 > **Note:** Audio feedback is present in standalone mode. **Use headphones.**
+
+### Reading Debug Logs
+
+Debug build logs are written to `.log/<plugin_name> Latest.log`.
+To follow the log, use `tail -f ".log/<plugin_name> Latest.log"` on macOS/Linux, or `Get-Content ".log\<plugin_name> Latest.log" -Wait` in Windows PowerShell.
 
 ## Next Steps
 

--- a/src-gui/src/main.ts
+++ b/src-gui/src/main.ts
@@ -98,8 +98,8 @@ if (
 }
 
 const buildType = import.meta.env.PROD ? "Release" : "Debug";
-// About に出す identity は Vite が src-plugin/Cargo.toml から埋め込んだ値だけを使う。
-// テンプレート利用者が plugin を改名した時に、Rust descriptor と GUI 表示が分岐しないようにする。
+// Identity shown in About uses only values injected by Vite from src-plugin/Cargo.toml.
+// This prevents the Rust descriptor and the GUI display from diverging when the template user renames the plugin.
 pluginName.textContent = __WRAC_PLUGIN_METADATA__.pluginName;
 aboutTitle.textContent = __WRAC_PLUGIN_METADATA__.pluginName;
 aboutPluginName.textContent = __WRAC_PLUGIN_METADATA__.pluginName;
@@ -222,8 +222,8 @@ void (async () => {
     },
   );
   editorPageSubscriptionId = editorPageSubscription.subscriptionId;
-  // WebView console に頼らず、native log だけで frontend 初期化完了を確認できるようにする。
-  // DAW 上の plugin GUI では devtools を開けない環境があるため、この境界ログを残す。
+  // Log frontend initialization to the native log without relying on the WebView console.
+  // Some environments inside a DAW do not allow opening devtools, so this boundary log is preserved.
   await invoke("write_to_log", {
     message: "GUI initialization completed",
   });
@@ -449,15 +449,17 @@ gainInput.addEventListener("keydown", (event) => {
 });
 gainInput.addEventListener("pointerdown", (event) => event.stopPropagation());
 
-// About は設定画面ではなく plugin identity の詳細表示なので、常設タブではなく
-// plugin 名そのものを入口/切り替えにする。メイン操作面の余計な segmented control を避けるため。
+// About is a detail view of plugin identity rather than a settings screen, so the plugin name
+// itself is used as the entry point/toggle instead of a permanent tab, to avoid an extra
+// segmented control on the main controls surface.
 pluginName.addEventListener("click", (event) => {
   setEditorPage(pageAbout.hidden ? "about" : "controls");
   restoreHostFocusIfNeeded(event.target);
 });
 
-// About は full-screen modal 相当の一時表示なので、右上の明示的な close affordance で戻す。
-// 中央の plugin 名は情報表示に留め、閉じる操作と混同させない。
+// About is a temporary overlay equivalent to a full-screen modal, so the explicit close
+// affordance in the top-right returns to controls. The plugin name in the center is kept
+// as an information display only, to avoid conflating it with the close action.
 headerAction.addEventListener("click", (event) => {
   setEditorPage("controls");
   restoreHostFocusIfNeeded(event.target);

--- a/src-gui/vite.config.ts
+++ b/src-gui/vite.config.ts
@@ -10,9 +10,10 @@ type PluginMetadata = {
 };
 
 function readCargoMetadata(): PluginMetadata {
-  // テンプレート利用者が plugin 名や company 名を変える場所を 1 箇所に絞るため、
-  // GUI も Rust descriptor と同じ src-plugin/Cargo.toml の metadata を読む。
-  // フロント側に直書きすると、host に見える plugin 名と About 表示がずれやすい。
+  // To keep plugin name and company name changes in a single place,
+  // the GUI reads metadata from the same src-plugin/Cargo.toml as the Rust descriptor.
+  // Hardcoding values on the frontend side easily causes the host-visible plugin name
+  // and the About display to diverge.
   const cargoToml = readFileSync(
     resolve(__dirname, "../src-plugin/Cargo.toml"),
     "utf8",
@@ -20,7 +21,7 @@ function readCargoMetadata(): PluginMetadata {
   const versionMatch = cargoToml.match(/^\s*version\s*=\s*"([^"]+)"\s*$/m);
   if (!versionMatch) {
     throw new Error(
-      "src-plugin/Cargo.toml から version を取得できませんでした",
+      "Failed to read version from src-plugin/Cargo.toml",
     );
   }
   return {
@@ -48,20 +49,21 @@ function readWracMetadataString(cargoToml: string, key: string): string {
     }
   }
   throw new Error(
-    `src-plugin/Cargo.toml から package.metadata.wrac.${key} を取得できませんでした`,
+    `Failed to read package.metadata.wrac.${key} from src-plugin/Cargo.toml`,
   );
 }
 
 export default defineConfig({
   define: {
-    // plugin 固有名を定数名に含めると、テンプレートから別 plugin を作るたびに
-    // TypeScript 側の識別子まで変更が必要になる。中身だけ metadata として差し替える。
+    // Including the plugin-specific name in the constant identifier would require
+    // updating the TypeScript identifier every time a new plugin is created from the template.
+    // Only the contents are swapped via metadata.
     __WRAC_PLUGIN_METADATA__: JSON.stringify(readCargoMetadata()),
   },
   server: {
-    // Debug plugin は WebView から 127.0.0.1 を読む。Vite の default `localhost`
-    // だと環境によって IPv6 loopback だけに bind され、DAW 内 WebView の解決先と
-    // ずれて黒画面になり得る。
+    // Debug plugins load the WebView from 127.0.0.1. Vite's default `localhost`
+    // may bind only to the IPv6 loopback in some environments, causing a mismatch
+    // with the address the WebView inside the DAW resolves to, which can result in a black screen.
     host: "127.0.0.1",
     port: 5173,
     strictPort: true,

--- a/src-plugin/build.rs
+++ b/src-plugin/build.rs
@@ -1,8 +1,9 @@
-//! release build 時に `src-gui/dist` を 1 つの zip にまとめて `OUT_DIR` に出力する build script。
+//! Build script that bundles `src-gui/dist` into a single zip and writes it to `OUT_DIR`
+//! for release builds.
 //!
-//! 出力された zip は `gui.rs` で `include_bytes!` により plugin バイナリへ
-//! 埋め込まれ、実行時に WebView が `wxp-plugin://` scheme として配信する。
-//! debug build では Vite dev server を使うので、このスクリプトは何もしない。
+//! The resulting zip is embedded into the plugin binary via `include_bytes!` in `gui.rs`
+//! and served at runtime by the WebView under the `wxp-plugin://` scheme.
+//! In debug builds Vite's dev server is used instead, so this script does nothing.
 
 use std::env;
 use std::fs::{self, File};
@@ -14,7 +15,7 @@ use zip::ZipWriter;
 use zip::write::SimpleFileOptions;
 
 fn main() {
-    // frontend ソースが変わったら再ビルドする (zip を作り直す) ように Cargo に伝える。
+    // Tell Cargo to rebuild (regenerate the zip) whenever frontend source files change.
     println!("cargo:rerun-if-changed=../src-gui/index.html");
     println!("cargo:rerun-if-changed=../src-gui/src");
     println!("cargo:rerun-if-changed=../src-gui/package.json");
@@ -23,9 +24,10 @@ fn main() {
 
     let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR"));
     let manifest_path = manifest_dir.join("Cargo.toml");
-    // Cargo.toml の [package.metadata.wrac] を plugin identity の SoT にする。
-    // descriptor / AUv2 codes / GUI / xtask が別々の値を持つと、テンプレートを
-    // 改名した時に一部 artifact だけ古い名前で出るため、Rust へ compile-time env で渡す。
+    // Make [package.metadata.wrac] in Cargo.toml the single source of truth for plugin
+    // identity. If descriptor, AUv2 codes, GUI, and xtask each held their own values, a
+    // template rename could leave some artifacts with the old name, so pass them to Rust
+    // as compile-time env vars.
     let metadata = read_wrac_metadata(&manifest_path).expect("failed to read WRAC metadata");
     println!("cargo:rustc-env=WRAC_PLUGIN_ID={}", metadata.plugin_id);
     println!("cargo:rustc-env=WRAC_PLUGIN_NAME={}", metadata.plugin_name);
@@ -43,7 +45,7 @@ fn main() {
         metadata.auv2_manufacturer_code
     );
 
-    // debug build 時は zip を作らない (Vite dev server を使うため)。
+    // Skip zip creation for debug builds (the Vite dev server is used instead).
     if env::var("PROFILE").ok().as_deref() != Some("release") {
         return;
     }
@@ -56,7 +58,7 @@ fn main() {
     let out_zip =
         PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR")).join("wrac_gain_plugin_gui.zip");
 
-    // release build の前に `npm run build` を回し忘れていた場合は早めに止める。
+    // Fail early if `npm run build` was not run before the release build.
     if !gui_dist_dir.exists() {
         panic!(
             "frontend build output was not found at {}. Run `npm install && npm run build` in src-gui before release builds.",
@@ -150,7 +152,7 @@ fn validate_four_ascii(key: &str, value: &str) -> io::Result<()> {
     }
 }
 
-/// `src_dir` 以下を丸ごと deflate 圧縮の zip にまとめて `out_zip` に書き出す。
+/// Compresses everything under `src_dir` into a deflate-compressed zip and writes it to `out_zip`.
 fn create_zip(src_dir: &Path, out_zip: &Path) -> io::Result<()> {
     let file = File::create(out_zip)?;
     let mut zip = ZipWriter::new(file);
@@ -161,10 +163,10 @@ fn create_zip(src_dir: &Path, out_zip: &Path) -> io::Result<()> {
     Ok(())
 }
 
-/// directory を再帰的に walk して zip へ追加する。
+/// Recursively walks a directory and adds its contents to the zip.
 ///
-/// build を decisive (= 同じ入力なら常に同じ出力) にするため、entry を
-/// path 順に sort してから処理する。
+/// Entries are sorted by path before processing to make the build deterministic
+/// (same inputs always produce the same output).
 fn add_directory_contents(
     root: &Path,
     current: &Path,
@@ -179,7 +181,7 @@ fn add_directory_contents(
         let relative = path
             .strip_prefix(root)
             .expect("walked path must be inside root");
-        // zip 内部は OS 非依存の `/` 区切りに揃える (Windows 対策)。
+        // Normalise internal zip paths to the OS-independent `/` separator (Windows fix).
         let zip_path = relative.to_string_lossy().replace('\\', "/");
 
         if path.is_dir() {

--- a/src-plugin/src/audio.rs
+++ b/src-plugin/src/audio.rs
@@ -1,8 +1,9 @@
-//! audio thread 上で動く DSP。
+//! DSP running on the audio thread.
 //!
-//! このサンプルは入力に gain を掛けて書き戻すだけ。[`Processor::process`] は
-//! 小さな buffer ごとに繰り返し呼ばれる realtime 関数なので、**allocation と
-//! lock を避ける**のが鉄則。共有 state は [`SharedState`] から lock-free に読む。
+//! This sample simply multiplies the input by a gain and writes it back.
+//! [`Processor::process`] is a realtime function called repeatedly for each small buffer,
+//! so the rule is to **avoid allocations and locks**. Shared state is read lock-free from
+//! [`SharedState`].
 
 use std::sync::Arc;
 
@@ -14,20 +15,21 @@ use wrac_clap_adapter::{
 use crate::plugin::{PARAM_BYPASS_ID, PARAM_GAIN_ID, host_value_to_gain};
 use crate::state::SharedState;
 
-/// `activate()` で生成され、host の audio thread が所有する DSP 実体。
-/// `deactivate()` まで生き続け、その間 `process()` が何度も呼ばれる。
+/// The DSP instance created at `activate()` and owned by the host's audio thread.
+/// It lives until `deactivate()`, during which `process()` is called repeatedly.
 ///
-/// field は **audio thread が待たずに読めるもの**だけにする。`shared` は atomic
-/// なので process 中に読める。`audio_channel_count` は activate 時点で
-/// plugin の audio layout store から copy した snapshot。adapter が active 中の
-/// layout 変更を拒否するので、走行中の Processor の契約は途中で変わらない。製品で
-/// layout に応じ DSP を変える場合も、`Arc<RwLock<Layout>>` を持たせず activate
-/// 時に必要な設定へ変換して渡すのが安全。
+/// Fields should contain only things **the audio thread can read without waiting**.
+/// `shared` uses atomics and is safe to read during `process()`.
+/// `audio_channel_count` is a snapshot copied from the plugin's audio layout store at
+/// activate time. Because the adapter rejects layout changes while active, the running
+/// Processor's contract cannot change mid-flight. Even when a product's DSP must vary
+/// with layout, it is safer to convert the needed settings at activate time and pass them
+/// in rather than storing an `Arc<RwLock<Layout>>`.
 pub(crate) struct WracGainAudioProcessor {
     shared: Arc<SharedState>,
-    // gain 自体は channel count を使わないが、「layout は activate で snapshot して
-    // field に持つ」形をテンプレートとして示すために保持する。
-    // debug build では実 buffer がこの snapshot と一致するか検査する。
+    // Gain itself does not use channel count, but this field demonstrates the pattern
+    // "snapshot layout at activate time and store it as a field."
+    // In debug builds, the actual buffer is verified to match this snapshot.
     audio_channel_count: u32,
 }
 
@@ -41,16 +43,17 @@ impl WracGainAudioProcessor {
 }
 
 impl Processor for WracGainAudioProcessor {
-    /// 1 ブロック分を処理する。`context` には入出力 `audio`、このブロックの
-    /// parameter event 列 `events.input`、sample 数 `frames_count` が入る。
+    /// Processes one block. `context` contains the audio I/O, the parameter event list
+    /// `events.input` for this block, and the sample count `frames_count`.
     ///
-    /// parameter event の発生時刻で buffer を区切り、区間ごとに当時の gain を
-    /// 掛けることで sample 精度の automation を実現する (event 間は gain 一定)。
+    /// The buffer is split at each parameter event's timestamp, and the gain current at
+    /// that moment is applied to each segment, achieving sample-accurate automation
+    /// (gain is constant between events).
     fn process(&mut self, context: ProcessContext<'_>) -> PluginResult<ProcessStatus> {
         #[cfg(debug_assertions)]
         {
-            // allocation 違反を即 abort。DAW/adapter が panic を握りつぶしても
-            // 見逃さないため、debug build で全 process を包む。
+            // Abort immediately on any allocation. Wrapping every process() call in
+            // debug builds ensures violations are not swallowed by the DAW or adapter.
             assert_no_alloc::assert_no_alloc(|| self.process_no_alloc(context))
         }
 
@@ -69,16 +72,16 @@ impl WracGainAudioProcessor {
             self.audio_channel_count,
         );
 
-        // ブロック開始時点の gain。event が来るたびに更新される。
+        // Gain at the start of this block; updated each time a parameter event arrives.
         let mut gain = self.shared.gain();
         let mut bypass = self.shared.bypass();
-        // 「ここまで処理した」位置を表すカーソル。
+        // Cursor tracking how far into the block has been processed.
         let mut segment_start = 0;
         let frames_count = context.frames_count as usize;
 
         for event in context.events.input.iter() {
-            // event 発生位置までを現在の gain で処理する。
-            // event time は host から信用しない (= buffer 範囲外を防ぐ) ため clamp。
+            // Process up to the event position with the current gain.
+            // Clamp event time rather than trusting the host, to prevent out-of-bounds access.
             let event_time = (event.time() as usize).min(frames_count);
             if event_time > segment_start {
                 let effective_gain = if bypass { 1.0 } else { gain };
@@ -91,7 +94,7 @@ impl WracGainAudioProcessor {
                 segment_start = event_time;
             }
 
-            // 今回扱うのは gain / bypass の parameter event だけ。それ以外 (note 等) は無視。
+            // Only gain/bypass parameter events are handled here; others (notes, etc.) are ignored.
             if let InputEvent::ParamValue(event) = event {
                 if event.parameter_id == PARAM_GAIN_ID {
                     gain = self
@@ -108,7 +111,7 @@ impl WracGainAudioProcessor {
             }
         }
 
-        // 最後の event 以降、ブロック末尾まで残った範囲を処理する。
+        // Process the remaining range from the last event to the end of the block.
         if segment_start < frames_count {
             let effective_gain = if bypass { 1.0 } else { gain };
             process_audio_range(
@@ -119,8 +122,8 @@ impl WracGainAudioProcessor {
             )?;
         }
 
-        // 入力が無音でなければ次のブロックも処理を続けてほしい、という宣言。
-        // `Quiet` を返すと host が optimization の判断材料に使う。
+        // Signal that processing should continue for the next block unless the input is silent.
+        // Returning `Quiet` lets the host use it as a hint for optimisation.
         Ok(ProcessStatus::ContinueIfNotQuiet)
     }
 }
@@ -130,10 +133,10 @@ fn assert_audio_layout_matches_processor_snapshot(
     audio: &mut AudioProcessBuffer<'_>,
     expected_channel_count: u32,
 ) {
-    // activate 時の snapshot と実 buffer が一致するかを debug build で確認するだけ。
-    // store の lock は読まない。memory safety を不正 buffer から守る責務は adapter
-    // 側にあり、これはその代替ではなく snapshot の使い方を示すデモ。channel count
-    // を使わない製品 DSP ならこの assertion ごと削ってよい。
+    // Debug-only verification that the actual buffer matches the activate-time snapshot.
+    // The store's lock is not read here. Protecting memory safety from invalid buffers
+    // is the adapter's responsibility; this is a demonstration of snapshot usage, not a
+    // replacement. Product DSPs that don't use channel count may remove this assertion entirely.
     debug_assert_eq!(
         audio.port_pair_count(),
         1,
@@ -152,8 +155,8 @@ fn assert_audio_layout_matches_processor_snapshot(
     }
 }
 
-/// 各 port の `[start, end)` 区間に gain を適用する。
-/// host が渡す buffer は `f32` / `f64` どちらもあり得るので両方扱う。
+/// Applies gain to the `[start, end)` range of each port.
+/// The buffer passed by the host can be either `f32` or `f64`, so both are handled.
 fn process_audio_range(
     audio: &mut AudioProcessBuffer<'_>,
     start: usize,
@@ -172,10 +175,10 @@ fn process_audio_range(
     Ok(())
 }
 
-/// 1 つの port (paired in/out) の各 channel について sample に gain を掛ける。
+/// Applies gain to each sample in every channel of one port (paired in/out).
 ///
-/// `map_samples_range` は in-place 書き換えで、in/out が同じ buffer を指す
-/// "in-place processing" にも対応している。
+/// `map_samples_range` operates in-place and supports "in-place processing"
+/// where the input and output point to the same buffer.
 fn process_channels_range<T>(
     channels: AudioPairedChannels<'_, T>,
     start: usize,

--- a/src-plugin/src/commands.rs
+++ b/src-plugin/src/commands.rs
@@ -1,7 +1,8 @@
-//! WebView frontend から呼べる command の登録。
+//! Registration of commands callable from the WebView frontend.
 //!
-//! Rust 側から見ると、ここが TypeScript UI との約束事になる。command 名や payload
-//! の形を変えるときは `src-gui` 側の `invoke(...)` / subscription と一緒に変更する。
+//! From Rust's perspective this module is the contract with the TypeScript UI.
+//! When renaming commands or changing payload shapes, update the `invoke(...)` calls
+//! and subscriptions in `src-gui` at the same time.
 
 use std::rc::Rc;
 use std::sync::Arc;
@@ -19,10 +20,10 @@ mod resize;
 
 use resize::register_resize_commands;
 
-/// WebView (フロントエンド) から呼べる command を [`WxpCommandHandler`] に登録する。
+/// Registers commands callable from the WebView frontend with the [`WxpCommandHandler`].
 ///
-/// フロントエンド側 (`src-gui` の TypeScript) は `invoke("set_parameter_value",
-/// { parameterId, value })` のような形でこれらの command を呼び出す。
+/// The frontend (TypeScript in `src-gui`) invokes these commands using calls like
+/// `invoke("set_parameter_value", { parameterId, value })`.
 pub(crate) fn register_commands(
     command_handler: Rc<WxpCommandHandler>,
     project_state: Arc<ProjectStateStore>,
@@ -32,16 +33,17 @@ pub(crate) fn register_commands(
     host_gui_resize_requester: Arc<dyn HostGuiResizeRequester>,
     gui_resize_handle: WxpGuiResizeHandle,
 ) {
-    // WebView console は DAW では見えないことが多い。frontend のログを
-    // plugin 側 logger に橋渡しし、GUI 初期化の進行を native log で追えるようにする。
+    // The WebView console is often invisible inside a DAW. Bridge frontend logs to the
+    // plugin's logger so GUI initialisation progress is visible in native log output.
     command_handler.register_sync("write_to_log", move |ctx| {
         let message = ctx.arg::<String>("message").map_err(|e| e.to_string())?;
         log::info!("frontend: {message}");
         Ok::<_, String>(json!({ "ok": true }))
     });
 
-    // editor page は音に関係しない project state。audio thread が読む SharedState とは
-    // 別の store に置き、保存時に parameter snapshot と合成する。
+    // Editor page is project state unrelated to audio. It lives in a separate store from
+    // the SharedState read by the audio thread and is merged with the parameter snapshot
+    // at save time.
     {
         let project_state = project_state.clone();
         command_handler.register_sync("get_editor_page", move |_| {
@@ -62,7 +64,7 @@ pub(crate) fn register_commands(
         });
     }
 
-    // 現在の parameter 値を取得する。GUI 起動直後の初期表示などに使う。
+    // Returns the current parameter value. Used for initial display when the GUI launches.
     {
         let shared = shared.clone();
         command_handler.register_sync("get_parameter_state", move |ctx| {
@@ -74,7 +76,7 @@ pub(crate) fn register_commands(
         });
     }
 
-    // 表示文字列を Rust 側の parameter parser で plain value に戻して反映する。
+    // Converts a display string back to a plain value via the Rust parameter parser and applies it.
     {
         let shared = shared.clone();
         let gui_notifier = gui_notifier.clone();
@@ -98,7 +100,7 @@ pub(crate) fn register_commands(
         });
     }
 
-    // frontend が default 値を持たずに reset intent だけを送れるようにする。
+    // Allows the frontend to signal a reset without knowing the default value itself.
     {
         let shared = shared.clone();
         let gui_notifier = gui_notifier.clone();
@@ -121,7 +123,7 @@ pub(crate) fn register_commands(
         });
     }
 
-    // control に触れ始めたタイミング。host に「これから undo 単位」と伝える。
+    // Called when the user first touches a control. Signals the start of an undo unit to the host.
     {
         let host_parameter_edit_notifier = host_parameter_edit_notifier.clone();
         command_handler.register_sync("begin_parameter_gesture", move |ctx| {
@@ -131,7 +133,7 @@ pub(crate) fn register_commands(
         });
     }
 
-    // control が動いたタイミング。値を反映して host にも通知する。
+    // Called while the control is moving. Applies the value and notifies the host.
     {
         let shared = shared.clone();
         let gui_notifier = gui_notifier.clone();
@@ -152,7 +154,7 @@ pub(crate) fn register_commands(
         });
     }
 
-    // control から指を離したタイミング。undo 単位の終了を host に伝える。
+    // Called when the user releases the control. Signals the end of the undo unit to the host.
     {
         let host_parameter_edit_notifier = host_parameter_edit_notifier.clone();
         command_handler.register_sync("end_parameter_gesture", move |ctx| {
@@ -162,10 +164,11 @@ pub(crate) fn register_commands(
         });
     }
 
-    // parameter の変化を受け取る subscription を開始する。
-    // `channel` は JS 側で作った callback channel で、plugin はここに値の変化を push する。
-    // 戻り値の `subscriptionId` は購読の識別子。JS は cleanup 時にこの id を返すことで、
-    // 自分が始めた購読だけを確実に解除できる。
+    // Starts a subscription that receives parameter changes.
+    // `channel` is a callback channel created on the JS side; the plugin pushes value
+    // changes into it. The returned `subscriptionId` identifies the subscription so the
+    // JS side can unsubscribe precisely at cleanup, without cancelling subscriptions it
+    // didn't create.
     {
         let gui_notifier = gui_notifier.clone();
         command_handler.register_sync("subscribe_parameters", move |ctx| {
@@ -190,9 +193,9 @@ pub(crate) fn register_commands(
         });
     }
 
-    // subscription を解除する。指定の id が登録されていなければ no-op。
-    // id 指定にすることで、遅れて届いた古い cleanup が、後から始まった別の購読を
-    // 誤って解除してしまう事故を防げる。
+    // Cancels a subscription. If the given ID is not registered this is a no-op.
+    // Using an explicit ID prevents a delayed, stale cleanup from accidentally cancelling
+    // a subscription that was created later.
     {
         let gui_notifier = gui_notifier.clone();
         command_handler.register_sync("unsubscribe_gui_subscription", move |ctx| {

--- a/src-plugin/src/commands/resize.rs
+++ b/src-plugin/src/commands/resize.rs
@@ -71,10 +71,11 @@ unsafe extern "C" {
 fn global_mouse_location() -> Option<GlobalMouseLocation> {
     #[cfg(target_os = "macos")]
     {
-        // resize grip は WebView 内にあるが、リサイズ対象の editor window は host が
-        // 所有する。Logic などはドラッグ中にその WebView を動かすため、WebView 座標は
-        // 物理マウスではなく動く子 view に対して飛んでしまう。OS カーソルを直接読めば、
-        // WebView と host の layout 更新の外にある安定した座標系 (デスクトップ) を使える。
+        // The resize grip lives inside the WebView, but the editor window being resized is
+        // owned by the host. Hosts such as Logic move the WebView during a drag, so WebView
+        // coordinates land relative to the moving child view rather than the physical mouse.
+        // Reading the OS cursor directly gives a stable coordinate space (the desktop) that
+        // is unaffected by WebView and host layout updates.
         let event = unsafe { CGEventCreate(std::ptr::null()) };
         if event.is_null() {
             return None;
@@ -98,11 +99,12 @@ pub(super) fn register_resize_commands(
     host_gui_resize_requester: Arc<dyn HostGuiResizeRequester>,
     gui_resize_handle: WxpGuiResizeHandle,
 ) {
-    // resize ドラッグを 2 責務に分ける。ジェスチャの寿命は JS が持つ (pointer
-    // capture/release は browser の概念)。macOS の座標は Rust が持つ (browser の
-    // 座標系こそ host が動かしている面だから)。drag id がブラウザ側トリガと
-    // この native snapshot を結び付け、毎回の resize 要求を元のデスクトップ
-    // カーソル位置から再計算できる (WebView 内座標の誤差を累積しない)。
+    // Split resize dragging between two responsibilities. JS owns the gesture lifetime
+    // (pointer capture/release are browser concepts). Rust owns the macOS coordinates
+    // (because the browser coordinate space is exactly the surface the host is moving).
+    // The drag ID links the browser-side trigger to this native snapshot so that every
+    // resize request can be recomputed from the original desktop cursor position,
+    // avoiding accumulated error from WebView-relative coordinates.
     let native_resize_drag = Rc::new(RefCell::new(None::<NativeResizeDrag>));
 
     {

--- a/src-plugin/src/gui.rs
+++ b/src-plugin/src/gui.rs
@@ -1,13 +1,14 @@
-//! この plugin 固有の WebView GUI runtime。
+//! Product-specific WebView GUI runtime for this plugin.
 //!
-//! GUI 本体は `src-gui/` の HTML/CSS/TypeScript。この module はそれを embed した
-//! WebView を host window に貼り付け、[`wxp`] の command/channel で frontend と
-//! 通信する。
+//! The GUI itself is the HTML/CSS/TypeScript in `src-gui/`. This module attaches
+//! a WebView containing that content to the host window and communicates with the
+//! frontend via [`wxp`] commands and channels.
 //!
-//! 役割分担:
-//! - `wrac_wxp_gui`: host UI thread の所有、callback dispatch、parent handle 変換
-//!   といった format 共通の厄介事
-//! - この module    : WebView の中身・登録 command・resize/scale など製品固有部分
+//! Responsibilities:
+//! - `wrac_wxp_gui`: format-neutral boilerplate — host UI thread ownership, callback
+//!   dispatch, parent handle conversion
+//! - this module   : WebView content, registered commands, resize/scale, and other
+//!   product-specific details
 
 use std::sync::Arc;
 
@@ -31,8 +32,8 @@ pub(crate) struct GuiIntegration {
     pub(crate) notifier: Arc<GuiStateNotifier>,
 }
 
-/// plugin core が使う GUI extension 一式を組み立てる。
-/// GUI 固有の詳細を `plugin.rs` から切り離すための入口。
+/// Assembles the complete GUI extension set used by the plugin core.
+/// Entry point that keeps GUI-specific details out of `plugin.rs`.
 pub(crate) fn create_gui_integration(
     project_state: Arc<ProjectStateStore>,
     shared: Arc<SharedState>,

--- a/src-plugin/src/gui/notifier.rs
+++ b/src-plugin/src/gui/notifier.rs
@@ -9,23 +9,23 @@ use wxp::Channel;
 use crate::plugin::parameter_value_text;
 use crate::state::EditorPage;
 
-/// WebView 側へ GUI state を push する通知口。通知タイミングは呼び出し元が決める。
+/// Outbound notification channel that pushes GUI state to the WebView. The caller decides when to notify.
 pub(crate) struct GuiStateNotifier {
     next_subscription_id: AtomicU64,
     subscriptions: Mutex<HashMap<GuiSubscriptionId, GuiSubscription>>,
 }
 
-/// WebView 側 subscriber 1 つぶんの登録情報。
+/// Registration record for a single WebView subscriber.
 ///
-/// `kind` (何の stream か) と `channel` (送り先) を分けて持つことで、parameter /
-/// meter / analyzer などを個別に購読・解除でき、古い cleanup が別の購読を
-/// 巻き込んで消す事故も防げる。
+/// Separating `kind` (which stream) from `channel` (the destination) lets parameters,
+/// meters, and analysers be subscribed and unsubscribed independently, and prevents a
+/// stale cleanup from accidentally cancelling an unrelated subscription.
 #[derive(Clone)]
 struct GuiSubscription {
     kind: GuiSubscriptionKind,
-    // 通知を UI thread に戻すための run loop sender。
+    // Run loop sender for dispatching notifications back to the UI thread.
     sender: RunLoopSender,
-    // WebView 側 JS の subscriber に値を送る channel。
+    // Channel for sending values to the JS subscriber in the WebView.
     channel: Channel,
 }
 
@@ -42,9 +42,9 @@ impl GuiSubscriptionId {
     }
 }
 
-/// 購読の種類。meter や analyzer の stream を足すときは variant を追加し、
-/// `notify_*` でその variant の subscription にだけ配信する
-/// (Channel を増やさず種別で振り分ける設計)。
+/// Subscription kind. Add a variant when adding meter or analyser streams, and deliver
+/// to only matching subscriptions in `notify_*` — this design routes by kind rather than
+/// multiplying channels.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum GuiSubscriptionKind {
     Parameters,
@@ -68,8 +68,8 @@ impl GuiStateNotifier {
     }
 
     fn subscribe(&self, kind: GuiSubscriptionKind, channel: Channel) -> GuiSubscriptionId {
-        // id は wxp の Channel id とは独立に採番。transport と購読 lifecycle を
-        // 別々に管理するため。
+        // IDs are assigned independently of wxp's Channel IDs so that transport and
+        // subscription lifecycle can be managed separately.
         let id = GuiSubscriptionId(self.next_subscription_id.fetch_add(1, Ordering::Relaxed));
         self.subscriptions.lock().insert(
             id,
@@ -105,8 +105,8 @@ impl GuiStateNotifier {
     }
 
     fn notify(&self, kind: GuiSubscriptionKind, payload: serde_json::Value) {
-        // 送り先が notifier を再入しても deadlock しないよう、配信対象を
-        // clone してから lock を離す。
+        // Clone the delivery targets before releasing the lock so that a re-entrant
+        // call from a recipient cannot deadlock.
         let subscriptions: Vec<_> = self
             .subscriptions
             .lock()
@@ -115,15 +115,15 @@ impl GuiStateNotifier {
             .cloned()
             .collect();
         if subscriptions.is_empty() {
-            // GUI が開いていなければ送り先がないので何もしない。
+            // No subscribers when the GUI is closed; nothing to do.
             return;
         }
 
         for subscription in subscriptions {
             let payload = payload.clone();
-            // WebView channel は GUI runtime と同じ UI thread でしか触れない。
-            // host/audio thread から直接送ると thread affinity を破るので、
-            // 必ず run loop に戻してから channel に渡す。
+            // WebView channels may only be touched on the same UI thread as the GUI
+            // runtime. Sending directly from a host or audio thread would violate thread
+            // affinity, so always dispatch back through the run loop first.
             subscription.sender.send(move || {
                 let _ = subscription.channel.send(payload);
             });
@@ -131,8 +131,8 @@ impl GuiStateNotifier {
     }
 }
 
-/// WebView へ送る JSON payload。TypeScript 側はこの形を期待する。
-/// 新しい parameter でも payload の形は変えず `parameterId` で振り分ける。
+/// JSON payload sent to the WebView. The TypeScript side expects this shape.
+/// The shape is unchanged for new parameters; routing is done by `parameterId`.
 pub(crate) fn parameter_payload(parameter_id: u32, value: f32) -> serde_json::Value {
     json!({
         "type": "parameter-value",

--- a/src-plugin/src/gui/runtime.rs
+++ b/src-plugin/src/gui/runtime.rs
@@ -19,7 +19,7 @@ use crate::gui::GuiStateNotifier;
 use crate::plugin::{PARAM_GAIN_ID, PLUGIN_ID};
 use crate::state::{ProjectStateStore, SharedState};
 
-// GUI window のサイズ範囲 (pixel)。host は default で開き、resize は min..=max に clamp。
+// GUI window size bounds (pixels). The host opens at the default; resize is clamped to min..=max.
 pub(super) const DEFAULT_GUI_SIZE: GuiSize = GuiSize {
     width: 320,
     height: 380,
@@ -33,11 +33,11 @@ pub(super) const MAX_GUI_SIZE: GuiSize = GuiSize {
     height: 720,
 };
 
-// resize 時にクランプする論理ピクセルの上下限。
+// Logical-pixel bounds applied when clamping a resize request.
 const MIN_LOGICAL_GUI_SIZE: LogicalSize<f64> = LogicalSize::new(320.0, 340.0);
 const MAX_LOGICAL_GUI_SIZE: LogicalSize<f64> = LogicalSize::new(720.0, 720.0);
 
-// release のみ frontend zip を埋め込む。debug は Vite dev server を見るので不要。
+// Embed the frontend zip only for release builds; debug builds use the Vite dev server.
 #[cfg(not(debug_assertions))]
 const FRONTEND_ZIP: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/wrac_gain_plugin_gui.zip"));
 
@@ -51,32 +51,32 @@ pub(super) struct GuiRuntimeDependencies {
     pub(super) resize_handle: WxpGuiResizeHandle,
 }
 
-/// GUI window 1 つ分の runtime。host が GUI を開くたびに作られ、閉じると drop。
+/// Runtime for one GUI window. Created each time the host opens the GUI; dropped when closed.
 pub(crate) struct WracGainGuiRuntime {
     gui_notifier: Arc<GuiStateNotifier>,
-    // native WebView の寿命を持つ !Send + !Sync token。Drop 順を制御するため Option。
+    // !Send + !Sync token owning the native WebView. Stored as Option to control drop order.
     web_view: Option<WxpWebView>,
-    // WebView より長く生かす必要があるので保持する (Drop 順は下の Drop 実装参照)。
+    // Kept alive longer than the WebView (see the Drop impl below for ordering).
     wxp_context: Option<WebContext>,
     command_handler: Rc<WxpCommandHandler>,
-    // shared state の現在値を定期的に GUI へ反映する timer。
+    // Timer that periodically pushes the current shared state to the GUI.
     gui_update_timer: Timer,
     gui_size: LogicalSize<f64>,
-    // DPI スケールを考慮した bounds 変換に使う。
+    // Used for bounds conversion that accounts for DPI scaling.
     dpi_converter: DpiConverter,
 }
 
 impl WracGainGuiRuntime {
-    /// host が「GUI を開いて」と要求してきたタイミングで `plugin.rs` の closure
-    /// から呼ばれる factory。parent window に貼り付ける WebView を作って返す。
+    /// Factory called from the closure in `plugin.rs` when the host requests the GUI to open.
+    /// Creates a WebView attached to the parent window and returns it.
     pub(super) fn create(
         dependencies: GuiRuntimeDependencies,
         configuration: GuiConfiguration,
         initial_size: GuiSize,
         parent: ParentWindowHandle,
     ) -> PluginResult<Self> {
-        // このサンプルは embedded (parent に貼り付けるタイプ) しか対応していない。
-        // floating window が必要な場合は別途実装する。
+        // This sample supports only embedded mode (attached to the parent).
+        // Implement floating window support separately if needed.
         if configuration.is_floating {
             log::warn!("rejecting floating GUI configuration");
             return Err(PluginError::Message("unsupported GUI configuration"));
@@ -87,7 +87,7 @@ impl WracGainGuiRuntime {
             initial_size.height
         );
 
-        // WebView から呼べる parameter command を登録する。
+        // Register parameter commands callable from the WebView.
         log::debug!("creating GUI runtime: creating command handler");
         let command_handler = Rc::new(WxpCommandHandler::new());
         log::debug!("creating GUI runtime: registering commands");
@@ -102,8 +102,9 @@ impl WracGainGuiRuntime {
         );
         log::debug!("creating GUI runtime: commands registered");
 
-        // WebView2 は同じ user data folder を別の Environment options で共有すると作成に
-        // 失敗し得るため、OS 標準のアプリデータ配下に plugin ID 単位で分離する。
+        // WebView2 can fail to initialise when two instances share the same user data folder
+        // with different Environment options, so isolate each plugin by ID under the
+        // OS standard app-data directory.
         let data_dir = webview_data_dir(PLUGIN_ID);
         std::fs::create_dir_all(&data_dir)
             .map_err(|_| PluginError::Message("failed to create GUI data directory"))?;
@@ -111,7 +112,7 @@ impl WracGainGuiRuntime {
 
         log::debug!("creating GUI runtime: creating WebContext");
         let mut wxp_context = WebContext::new(data_dir);
-        // 初期 scale は 1.0 とし、後で host から `set_scale` で書き換えられる。
+        // Initial scale is 1.0; the host will override it via `set_scale` later.
         let dpi_converter = DpiConverter::new(1.0);
         let gui_size = gui_size_to_logical(initial_size);
         let bounds = dpi_converter.create_webview_bounds(gui_size);
@@ -121,8 +122,8 @@ impl WracGainGuiRuntime {
             gui_size.height
         );
 
-        // debug は Vite dev server を見る (frontend 変更で native の再 build 不要)。
-        // release は dev server に依存できないので build.rs が固めた zip を serve する。
+        // Debug builds point to the Vite dev server (no native rebuild needed on frontend changes).
+        // Release builds cannot depend on a dev server, so the zip bundled by build.rs is served.
         #[cfg(debug_assertions)]
         let builder = {
             let url = "http://127.0.0.1:5173/";
@@ -144,23 +145,24 @@ impl WracGainGuiRuntime {
                 .with_devtools(cfg!(debug_assertions))
                 .with_visible(true)
                 .with_bounds(bounds)
-                // 埋め込み zip を `wxp-plugin://` scheme で配信する。
+                // Serve the embedded zip under the `wxp-plugin://` scheme.
                 .with_serve_zip("wxp-plugin", FRONTEND_ZIP)
                 .map_err(|_| PluginError::Message("failed to serve GUI assets"))?
                 .with_url(url)
         };
 
-        // parent window 上に子として WebView を作る。これで host UI に埋め込まれる。
+        // Create the WebView as a child of the parent window, embedding it in the host UI.
         log::debug!("creating GUI runtime: build_as_child start");
         let web_view = builder
             .build_as_child(&parent)
             .map_err(|_| PluginError::Message("failed to build webview"))?;
         log::debug!("creating GUI runtime: build_as_child completed");
 
-        // 33ms ≒ 30Hz で現在値を GUI に流す。dirty flag を持たず毎回 shared state
-        // を読む方が構造が単純。CLAP の `request_callback()` は wrapper 経由だと
-        // host の dispatch 実装に依存し GUI だけ値が古くなることがあるので、
-        // GUI runtime 自身の run loop の timer で定期回収する。
+        // Push the current value to the GUI at ~30 Hz (33 ms). Reading shared state on
+        // every tick is simpler than maintaining a dirty flag. CLAP's `request_callback()`
+        // depends on the host's dispatch implementation when going through a wrapper and
+        // can leave the GUI with stale values, so a timer on the GUI runtime's own run
+        // loop is used instead.
         let gui_update_timer = Timer::new(Duration::from_millis(33), {
             let shared = dependencies.shared.clone();
             let gui_notifier = dependencies.gui_notifier.clone();
@@ -185,16 +187,16 @@ impl WracGainGuiRuntime {
     }
 }
 
-// host から呼ばれる resize / scale / size 取得などの操作を実装する trait。
+// Trait implementation for resize, scale, and size operations called by the host.
 impl WxpGuiRuntime for WracGainGuiRuntime {
-    /// host が表示倍率 (HiDPI 等) を伝えてきたときに呼ばれる。
+    /// Called when the host reports a display scale factor (e.g. HiDPI).
     fn set_scale(&mut self, scale: f64) -> PluginResult<()> {
         log::debug!("setting GUI scale: scale={scale}");
         self.dpi_converter.set_scale(scale);
         Ok(())
     }
 
-    /// host が window サイズを変えたときに呼ばれる。範囲を clamp してから WebView に反映する。
+    /// Called when the host changes the window size. Clamps to the valid range before applying.
     fn set_size(&mut self, size: GuiSize) -> PluginResult<()> {
         let requested = LogicalSize::new(size.width as f64, size.height as f64);
         self.gui_size = LogicalSize::new(
@@ -214,8 +216,9 @@ impl WxpGuiRuntime for WracGainGuiRuntime {
         );
 
         if let Some(web_view) = &self.web_view {
-            // wxp は native WebView の直接操作を owner から分離している。ここは GUI thread 上だが、
-            // stale-close checks と post/enqueue semantics を同じ経路に揃えるため dispatch 経由にする。
+            // wxp separates direct native WebView manipulation from the owner. Even though this
+            // is already on the GUI thread, dispatch is used to align with stale-close checks
+            // and the post/enqueue semantics used elsewhere.
             web_view
                 .dispatch()
                 .post_set_bounds(self.dpi_converter.create_webview_bounds(self.gui_size))
@@ -227,8 +230,8 @@ impl WxpGuiRuntime for WracGainGuiRuntime {
     fn show(&mut self) -> PluginResult<()> {
         log::debug!("showing GUI runtime");
         if let Some(web_view) = &self.web_view {
-            // show/hide は host lifecycle と競合しやすいので、owner を直接触らず wxp 側の
-            // close-aware dispatch path に寄せる。
+            // show/hide often races with host lifecycle events, so the close-aware dispatch
+            // path in wxp is used rather than touching the owner directly.
             web_view
                 .dispatch()
                 .post_set_visible(true)
@@ -243,8 +246,8 @@ impl WxpGuiRuntime for WracGainGuiRuntime {
         log::debug!("hiding GUI runtime");
         self.gui_update_timer.stop();
         if let Some(web_view) = &self.web_view {
-            // hide は destroy 直前に呼ばれることがある。dispatch は WebView が閉じていれば
-            // WebViewClosed を返し、native object の寿命を延ばさない。
+            // hide can be called just before destroy. If the WebView is already closed,
+            // dispatch returns WebViewClosed without extending the native object's lifetime.
             web_view
                 .dispatch()
                 .post_set_visible(false)
@@ -257,8 +260,8 @@ impl WxpGuiRuntime for WracGainGuiRuntime {
 
 fn webview_data_dir(plugin_id: &str) -> PathBuf {
     let plugin_dir = sanitize_plugin_data_dir(plugin_id);
-    // WebView user-data も plugin_id 由来にする。ここだけ template 名を持つと、
-    // rename 後の plugin が旧 plugin と cookie/cache/storage を共有してしまう。
+    // Derive the WebView user-data path from plugin_id too. Hard-coding the template name
+    // here would cause a renamed plugin to share cookies, cache, and storage with the original.
     match project_dirs_from_plugin_id(plugin_id) {
         Some(dirs) => dirs.data_dir().join("webview").join(plugin_dir),
         None => std::env::temp_dir()
@@ -292,25 +295,27 @@ fn sanitize_plugin_data_dir(plugin_id: &str) -> String {
         .collect()
 }
 
-// drop 順を field 宣言順に任せず、切断 → WebView 破棄 → context 破棄の順に
-// 明示する。callback が解放済み object を触る事故を防ぐため。
+// Override the field-declaration drop order and explicitly sequence:
+// disconnect → destroy WebView → destroy context.
+// This prevents callbacks from touching already-freed objects.
 impl Drop for WracGainGuiRuntime {
     fn drop(&mut self) {
         log::debug!("dropping GUI runtime");
-        // timer callback は run loop と GUI subscription に依存する。native WebView を
-        // 落とす前に止めて、破棄途中の GUI state を tick が見る余地をなくす。
+        // The timer callback depends on the run loop and GUI subscriptions. Stop it before
+        // dropping the native WebView so no tick can observe partially-destroyed GUI state.
         self.gui_update_timer.stop();
         log::debug!("dropping GUI runtime: timer stopped");
-        // GUI が消えるので、shared state からも channel を外しておく。
+        // The GUI is going away; clear channels from shared state as well.
         self.gui_notifier.clear_subscriptions();
         log::debug!("dropping GUI runtime: subscriptions cleared");
-        // WebView → WebContext の順で drop。逆だと wry が context 不在で panic することがある。
+        // Drop WebView before WebContext. The reverse order can cause wry to panic
+        // when the context is absent during WebView teardown.
         self.web_view = None;
         log::debug!("dropping GUI runtime: webview dropped");
         self.wxp_context = None;
         log::debug!("dropping GUI runtime: web context dropped");
-        // `command_handler` と `gui_update_timer` は field drop に任せる。
-        // 下記 2 行は「ここまで生かしたい」ことを明示するためのダミー read。
+        // `command_handler` and `gui_update_timer` are left to field drop order.
+        // The two reads below make the intended "keep alive until here" explicit.
         let _ = Rc::strong_count(&self.command_handler);
         let _ = self.gui_update_timer.is_running();
     }

--- a/src-plugin/src/lib.rs
+++ b/src-plugin/src/lib.rs
@@ -1,22 +1,22 @@
-//! WRAC Gain plugin —— このテンプレートの読み始めの crate。
+//! WRAC Gain plugin — the entry-point crate for this template.
 //!
-//! 最小構成の gain (音量) plugin です。`src-plugin` には製品固有のロジック
-//! (parameter / state / DSP / GUI) だけを置き、CLAP ABI や FFI の面倒な不変条件は
-//! 別 crate `wrac_clap_adapter` に閉じ込めてあります。プラグインを作るときは
-//! 基本的にこの crate の各ファイルを書き換えていきます。
+//! A minimal gain (volume) plugin. `src-plugin` contains only product-specific logic
+//! (parameters, state, DSP, GUI); the messy CLAP ABI and FFI invariants are encapsulated
+//! in the separate `wrac_clap_adapter` crate. When building a plugin from this template,
+//! you'll mostly be editing the files in this crate.
 //!
-//! ファイル構成:
-//! - `plugin.rs`   : host から見える plugin の契約。詳細実装は `plugin/` 配下。
-//! - `state.rs`    : audio / GUI / host で共有する lock-free な state。
-//! - `audio.rs`    : audio thread 上で動く DSP (このサンプルでは gain を掛けるだけ)。
-//! - `gui.rs`      : WebView ベースの GUI integration。runtime / notifier は `gui/` 配下。
-//! - `commands.rs` : WebView frontend から呼べる Rust command。resize 補助は `commands/` 配下。
+//! File layout:
+//! - `plugin.rs`   : the plugin contract as seen by the host; details live under `plugin/`.
+//! - `state.rs`    : lock-free state shared by the audio thread, GUI, and host.
+//! - `audio.rs`    : DSP running on the audio thread (just applies gain in this sample).
+//! - `gui.rs`      : WebView-based GUI integration; runtime/notifier live under `gui/`.
+//! - `commands.rs` : Rust commands callable from the WebView frontend; resize helpers under `commands/`.
 //!
-//! ログは `log` facade 経由。`logging.rs` は debug build 用の簡易 logger で、
-//! 製品では独自 logger に差し替える前提です。
+//! Logging goes through the `log` facade. `logging.rs` provides a simple logger for debug
+//! builds; production plugins are expected to replace it with a custom logger.
 
-// debug build では allocator を差し替え、audio thread での allocation を
-// 即座に検出する (使い方は audio.rs の process() を参照)。
+// In debug builds, swap in a custom allocator to detect allocations on the audio
+// thread immediately (see process() in audio.rs for usage).
 #[cfg(debug_assertions)]
 use assert_no_alloc::*;
 
@@ -31,8 +31,9 @@ mod logging;
 mod plugin;
 mod state;
 
-// CLAP entry point を export する。C ABI / factory / lifecycle は adapter が生成するので、
-// ここでは「どんな plugin か」(descriptor) と「core の作り方」(create) を渡すだけ。
+// Export the CLAP entry point. The adapter generates the C ABI, factory, and lifecycle
+// machinery; here we only supply "what this plugin is" (descriptor) and "how to create
+// the core" (create).
 wrac_clap_adapter::export_clap_plugin! {
     descriptor: crate::plugin::PLUGIN_DESCRIPTOR,
     create: crate::plugin::create_plugin_core,

--- a/src-plugin/src/logging.rs
+++ b/src-plugin/src/logging.rs
@@ -1,8 +1,8 @@
-//! テンプレート用の debug logger。
+//! Debug logger for the template.
 //!
-//! DAW 上で開発すると stderr が見えないことが多いので、開発中すぐにログを
-//! 確認できるようにこの helper を用意している。製品では独自の logging backend
-//! に差し替える前提。
+//! stderr is often hidden when developing inside a DAW, so this helper makes logs
+//! immediately accessible during development. Production plugins are expected to
+//! replace it with a custom logging backend.
 
 use std::fs::{File, OpenOptions};
 use std::io::Write;

--- a/src-plugin/src/plugin.rs
+++ b/src-plugin/src/plugin.rs
@@ -1,13 +1,14 @@
-//! host から見える plugin の契約をまとめる場所。
+//! The plugin contract as seen by the host.
 //!
-//! ここで宣言するもの:
-//! 1. plugin の自己紹介 ([`PLUGIN_DESCRIPTOR`])
-//! 2. audio / GUI / host で共有する [`SharedState`]
-//! 3. activate 時に渡す audio [`Processor`] と、host extension capability の束ね方
+//! What is declared here:
+//! 1. The plugin's self-description ([`PLUGIN_DESCRIPTOR`])
+//! 2. [`SharedState`] shared by the audio thread, GUI, and host
+//! 3. The audio [`Processor`] handed over at activation, and how host extension
+//!    capabilities are bundled
 //!
-//! parameter / audio port / state persistence の実装は `plugin/` 配下に分ける。
-//! CLAP / VST3 / AU の format 差分は `wrac_clap_adapter` が吸収するので、ここは
-//! 「この plugin がどの capability を持つか」だけに集中できる。
+//! Parameter, audio port, and state-persistence implementations live under `plugin/`.
+//! Format differences between CLAP, VST3, and AU are absorbed by `wrac_clap_adapter`,
+//! so this module focuses solely on "which capabilities this plugin offers."
 
 use std::sync::Arc;
 
@@ -35,9 +36,10 @@ use crate::audio::WracGainAudioProcessor;
 use crate::gui::create_gui_integration;
 use crate::state::{ProjectStateStore, SharedState};
 
-// plugin identity の SoT は src-plugin/Cargo.toml の [package.metadata.wrac]。
-// GUI / xtask / wrapper build も同じ metadata を読むので、ここを直書きせず
-// env! 経由にすることで rename 時の不整合 (bundle 名や About 表示のズレ) を防ぐ。
+// The single source of truth for plugin identity is [package.metadata.wrac] in
+// src-plugin/Cargo.toml. The GUI, xtask, and wrapper build all read the same metadata,
+// so env! macros are used here instead of hard-coded strings to prevent mismatches
+// (mismatched bundle names or About-dialog text) when renaming the template.
 pub(crate) const PLUGIN_ID: &str = env!("WRAC_PLUGIN_ID");
 pub(crate) const PLUGIN_NAME: &str = env!("WRAC_PLUGIN_NAME");
 pub(crate) const COMPANY_NAME: &str = env!("WRAC_COMPANY_NAME");
@@ -45,7 +47,7 @@ const AUV2_TYPE: [u8; 4] = four_char_code(env!("WRAC_AUV2_TYPE"));
 const AUV2_SUBTYPE: [u8; 4] = four_char_code(env!("WRAC_AUV2_SUBTYPE"));
 const AUV2_MANUFACTURER_CODE: [u8; 4] = four_char_code(env!("WRAC_AUV2_MANUFACTURER_CODE"));
 
-// host への自己紹介。adapter がこれを CLAP / AUv2 の descriptor に変換する。
+// Plugin self-description sent to the host. The adapter converts this into CLAP / AUv2 descriptors.
 pub(crate) const PLUGIN_DESCRIPTOR: PluginDescriptor = PluginDescriptor {
     id: PLUGIN_ID,
     name: PLUGIN_NAME,
@@ -60,8 +62,8 @@ pub(crate) const PLUGIN_DESCRIPTOR: PluginDescriptor = PluginDescriptor {
         PluginFeature::Utility,
         PluginFeature::Stereo,
     ],
-    // AUv2 (macOS Audio Unit v2) 用。code 類は 4 文字 ASCII の固有 ID で、
-    // 同じ会社の他 plugin と重複させない。
+    // For AUv2 (macOS Audio Unit v2). The codes are 4-character ASCII identifiers
+    // that must be unique within a company's plugin catalogue.
     auv2: Some(Auv2Descriptor {
         manufacturer_code: AUV2_MANUFACTURER_CODE,
         manufacturer_name: COMPANY_NAME,
@@ -78,25 +80,27 @@ const fn four_char_code(value: &str) -> [u8; 4] {
     [bytes[0], bytes[1], bytes[2], bytes[3]]
 }
 
-/// plugin 1 instance。host が plugin を読み込むごとに 1 つ作られる。
+/// One instance of the plugin, created each time the host loads the plugin.
 ///
-/// audio 処理本体は [`PluginCore::activate`] で [`Processor`] に切り出すので、
-/// この struct 自体は lifecycle と host へ公開する extension の保持だけを担う。
+/// The audio processing core is split into a [`Processor`] by [`PluginCore::activate`],
+/// so this struct is responsible only for lifecycle management and holding the host
+/// extension capabilities.
 ///
-/// extension capability を `Arc` で持つのは、host (wrapper) が lifecycle callback の
-/// 最中に capability を再入 query してくるため。`PluginCore` の `&mut self` lock を
-/// 取らずに到達できる必要がある。
+/// Capabilities are held behind `Arc` because the host (wrapper) may query them
+/// re-entrantly during lifecycle callbacks, requiring them to be reachable without
+/// acquiring the `&mut self` lock on `PluginCore`.
 pub(crate) struct WracGainPlugin {
-    // audio / GUI / host が共有する parameter state。詳細は [`SharedState`]。
+    // Parameter state shared by the audio thread, GUI, and host. See [`SharedState`].
     shared: Arc<SharedState>,
-    // host と交渉した audio layout。non-realtime 専用。詳細は [`AudioLayoutStore`]。
+    // Audio layout negotiated with the host. Non-realtime only. See [`AudioLayoutStore`].
     audio_layout: Arc<AudioLayoutStore>,
     audio_ports: Arc<WracGainAudioPorts>,
     configurable_audio_ports: Arc<WracGainConfigurableAudioPorts>,
     parameters: Arc<WracGainParameters>,
     gui: Arc<WxpGuiController>,
-    // project state の save/restore。active 中や wrapper 再入中でも committed
-    // snapshot を返せるよう、lifecycle lock から独立した専用 capability にしている。
+    // Project state save/restore. A dedicated capability independent of the lifecycle
+    // lock so that a committed snapshot can be returned even while active or during a
+    // wrapper re-entry.
     state_support: Arc<WracGainStateSupport>,
 }
 
@@ -133,8 +137,8 @@ impl WracGainPlugin {
     }
 }
 
-/// [`wrac_clap_adapter::export_clap_plugin!`] から呼ばれる factory。
-/// host が instance を要求するたびに呼ばれ、[`PluginCore`] を返す。
+/// Factory called by [`wrac_clap_adapter::export_clap_plugin!`].
+/// Called each time the host requests a new instance; returns a [`PluginCore`].
 pub(crate) fn create_plugin_core(context: PluginCoreContext) -> Box<dyn PluginCore> {
     crate::logging::init_debug_logging_once(PLUGIN_DESCRIPTOR.name);
 
@@ -161,18 +165,19 @@ pub(crate) fn create_plugin_core(context: PluginCoreContext) -> Box<dyn PluginCo
 }
 
 // ---------------------------------------------------------------------------
-// PluginCore: plugin の lifecycle と、提供する extension の宣言
+// PluginCore: plugin lifecycle and the extension capabilities offered
 // ---------------------------------------------------------------------------
 impl PluginCore for WracGainPlugin {
-    /// host が audio 処理を開始する直前に呼ばれる。
-    /// ここで返した [`Processor`] が以降 audio thread 上で `process()` される。
+    /// Called just before the host starts audio processing.
+    /// The returned [`Processor`] is subsequently `process()`-ed on the audio thread.
     fn activate(&mut self, context: ActivateContext) -> PluginResult<Box<dyn Processor>> {
-        // non-RT layout store と RT processor の境界。
+        // Boundary between the non-RT layout store and the RT processor.
         //
-        // adapter は active 中の layout apply を拒否するので、ここで snapshot した
-        // channel count は deactivate まで不変な契約になる。`Arc<AudioLayoutStore>`
-        // ごと渡すと process() 中に lock を読む余地が残るため、必要な値だけ copy して
-        // 渡す。これで「audio thread は immutable な設定だけを見る」が構造で保証される。
+        // The adapter rejects layout changes while active, so the channel count
+        // snapshotted here is contractually immutable until deactivate. Passing the
+        // full `Arc<AudioLayoutStore>` would leave room for process() to acquire the
+        // lock; copying only the needed value instead structurally enforces "the audio
+        // thread sees only immutable configuration."
         let audio_channel_count = self.audio_layout.channel_count();
         log::debug!(
             "activating audio processor: sample_rate={}, min_frames_count={}, max_frames_count={}, audio_channel_count={}",
@@ -187,14 +192,14 @@ impl PluginCore for WracGainPlugin {
         )))
     }
 
-    /// host が audio 処理を停止したときに呼ばれる。`_processor` は `activate` で
-    /// 返した実体で、drop されれば後始末は済む。
+    /// Called when the host stops audio processing. `_processor` is the value returned
+    /// from `activate`; dropping it is sufficient cleanup.
     fn deactivate(&mut self, _processor: Box<dyn Processor>) -> PluginResult<()> {
         log::debug!("deactivating audio processor");
         Ok(())
     }
 
-    // 各 extension の宣言。Some = 実装あり / None = 未対応。本体は別 module。
+    // Extension declarations. Some = implemented, None = unsupported. Implementations live in separate modules.
 
     fn audio_ports(&self) -> Option<Arc<dyn PluginAudioPorts>> {
         Some(self.audio_ports.clone())

--- a/src-plugin/src/plugin/audio_ports.rs
+++ b/src-plugin/src/plugin/audio_ports.rs
@@ -6,14 +6,15 @@ use wrac_clap_adapter::{
     PluginConfigurableAudioPorts, PluginError, PluginResult,
 };
 
-/// host と交渉した audio layout の SoT。**non-realtime 専用**。
+/// Source of truth for the audio layout negotiated with the host. **Non-realtime only.**
 ///
-/// host の port query と configurable-audio-ports apply がここを読み書きするが、
-/// `Processor::process()` は読まない。audio thread から RwLock を読むと priority
-/// inversion を招くため、layout は「次に activate する processor の設定」として扱い、
-/// `activate()` で snapshot して渡す ([`WracGainAudioProcessor`](crate::audio::WracGainAudioProcessor) 参照)。sidechain や
-/// ambisonics など複雑な layout でも、この「store に記録 → activate で snapshot」の
-/// 形は同じ。
+/// Host port queries and configurable-audio-ports apply operations read/write this store,
+/// but `Processor::process()` never does. Reading an `RwLock` from the audio thread risks
+/// priority inversion, so the layout is treated as "the configuration for the next
+/// processor to be activated" and snapshotted in `activate()` before being passed in
+/// (see [`WracGainAudioProcessor`](crate::audio::WracGainAudioProcessor)). The same
+/// "record in store → snapshot at activate" pattern applies to complex layouts such as
+/// sidechain or ambisonics.
 pub(super) struct AudioLayoutStore {
     channel_count: RwLock<u32>,
 }
@@ -44,8 +45,8 @@ impl WracGainAudioPorts {
     }
 }
 
-// gain なので main in / main out が 1 つずつ。channel 数は configurable audio
-// ports 経由で host が変更できる。
+// Gain has one main input and one main output. Channel count can be changed by the
+// host via configurable audio ports.
 impl PluginAudioPorts for WracGainAudioPorts {
     fn audio_port_count(&self, _is_input: bool) -> u32 {
         1
@@ -81,11 +82,12 @@ impl PluginAudioPorts for WracGainAudioPorts {
     }
 }
 
-/// host からの layout 変更要求を [`AudioLayoutStore`] に反映する capability。
+/// Capability that applies host-requested layout changes to [`AudioLayoutStore`].
 ///
-/// `&self` で更新するのは、adapter が `&mut self` lock を通らずに呼ぶため
-/// ([`WracGainPlugin`](super::WracGainPlugin) 参照)。active 中に変えてよい訳ではなく、adapter が
-/// Processor 不在 (inactive) のときだけ呼ぶことで安全を保証している。
+/// Mutation via `&self` is intentional: the adapter calls this without acquiring the
+/// `&mut self` lock (see [`WracGainPlugin`](super::WracGainPlugin)). This does not mean
+/// changes are allowed while active — the adapter enforces that this is only called when
+/// no `Processor` exists (inactive).
 pub(super) struct WracGainConfigurableAudioPorts {
     layout: Arc<AudioLayoutStore>,
 }
@@ -96,8 +98,8 @@ impl WracGainConfigurableAudioPorts {
     }
 }
 
-// 例: host が stereo→mono を提案 → 受理可否を `can_apply_*` で答え、
-// 実反映を `apply_*` で行う。
+// Example: host proposes stereo→mono → answer feasibility via `can_apply_*`,
+// commit the change via `apply_*`.
 impl PluginConfigurableAudioPorts for WracGainConfigurableAudioPorts {
     fn can_apply_audio_port_configuration(
         &self,
@@ -111,8 +113,8 @@ impl PluginConfigurableAudioPorts for WracGainConfigurableAudioPorts {
         &self,
         requests: &[AudioPortConfigurationRequest],
     ) -> PluginResult<()> {
-        // adapter 側が Processor の存在中は configuration apply を拒否する。ここは非 RT
-        // query 専用 store だけを更新し、audio thread は activate 時の snapshot を使う。
+        // The adapter rejects configuration apply while a Processor exists. This updates
+        // only the non-RT query store; the audio thread uses the snapshot captured at activate.
         let previous_channel_count = self.layout.channel_count();
         let channel_count =
             resolve_audio_channel_count(previous_channel_count, requests).ok_or_else(|| {
@@ -139,10 +141,11 @@ fn audio_port_type(channel_count: u32) -> AudioPortType {
     }
 }
 
-/// port 構成要求を解析し、受理できるなら新しい channel 数を返す。
+/// Parses port configuration requests and returns the new channel count if acceptable.
 ///
-/// 入出力が対称な main port のみ受理する。sidechain のような非対称構成は
-/// 製品固有の routing 意味論が必要で、汎用 gain サンプルでは定義できないため。
+/// Only symmetric main-port configurations (same channel count for input and output) are
+/// accepted. Asymmetric configurations such as sidechain require product-specific routing
+/// semantics that cannot be defined in a generic gain sample.
 fn resolve_audio_channel_count(
     current_channel_count: u32,
     requests: &[AudioPortConfigurationRequest],
@@ -163,7 +166,7 @@ fn resolve_audio_channel_count(
         }
     }
 
-    // 入出力で channel 数が一致しているときだけ受理する。
+    // Accept only when input and output channel counts match.
     (input_channel_count == output_channel_count).then_some(input_channel_count)
 }
 
@@ -177,7 +180,7 @@ fn is_supported_audio_port_request(request: &AudioPortConfigurationRequest) -> b
 
 #[cfg(test)]
 mod tests {
-    // host や CLAP runtime 無しで検証できる純粋ロジックの単体テスト例。
+    // Unit test examples for pure logic that can be verified without a host or CLAP runtime.
 
     use wrac_clap_adapter::{AudioPortConfigurationRequest, AudioPortType};
 

--- a/src-plugin/src/plugin/parameters.rs
+++ b/src-plugin/src/plugin/parameters.rs
@@ -6,22 +6,22 @@ use wrac_clap_adapter::{
 
 use crate::state::SharedState;
 
-// parameter ID は host が automation / project 保存に使う安定値。一度公開したら変えない。
-// 新しい parameter を追加するとき: ここに ID を足し、`PluginParameters` 実装と
-// `SharedState` の match を揃える。
+// Parameter IDs are stable values used by the host for automation and project saving.
+// Never change them after publishing. To add a new parameter: append an ID here and
+// keep the `PluginParameters` impl and `SharedState` match arms in sync.
 pub(crate) const PARAM_GAIN_ID: u32 = 1;
 pub(crate) const PARAM_BYPASS_ID: u32 = 9;
 
-// gain は線形 amplitude。1.0 = 0 dB (素通し)、0.0 = 無音、2.0 = +6 dB。
+// Gain is a linear amplitude. 1.0 = 0 dB (unity), 0.0 = silence, 2.0 = +6 dB.
 pub(crate) const DEFAULT_GAIN: f32 = 1.0;
 pub(crate) const MIN_GAIN: f32 = 0.0;
 pub(crate) const MAX_GAIN: f32 = 2.0;
 
-/// host から見える parameter API。
+/// The parameter API as seen by the host.
 ///
-/// schema / 値は generic editor・automation・restore 後の rescan から並行に読まれる。
-/// [`SharedState`] の atomic SoT だけを触り、GUI runtime や project state には
-/// 踏み込まないことで、host query を lifecycle と切り離している。
+/// Schema and values are read concurrently from generic editors, automation, and post-restore
+/// rescans. Touching only the atomic source of truth in [`SharedState`] — without reaching
+/// into the GUI runtime or project state — decouples host queries from the plugin lifecycle.
 pub(super) struct WracGainParameters {
     shared: Arc<SharedState>,
 }
@@ -32,16 +32,16 @@ impl WracGainParameters {
     }
 }
 
-// 新しい parameter を追加するときの host 公開ポイント (schema と文字列表現)。
+// The host-facing publication point for new parameters (schema and string representation).
 impl PluginParameters for WracGainParameters {
     fn parameter_count(&self) -> u32 {
-        // 新しい parameter を追加するとき: この数と `parameter_info()` の match を揃える。
+        // When adding a new parameter: keep this count in sync with the `parameter_info()` match.
         log::debug!("parameter_count -> 2");
         2
     }
 
     fn parameter_info(&self, index: u32) -> Option<ParameterInfo> {
-        // index ↔ stable id の対応表。id は project/automation に残るので変えない。
+        // Mapping of sequential index to stable ID. IDs persist in project/automation data — never change them.
         let info = match index {
             0 => Some(gain_parameter_info()),
             1 => Some(bypass_parameter_info()),
@@ -54,7 +54,7 @@ impl PluginParameters for WracGainParameters {
         info
     }
 
-    /// host が「今この parameter の値はいくつ?」と尋ねてきたときに答える。
+    /// Answers the host's query for the current value of a parameter.
     fn parameter_value(&self, parameter_id: u32) -> PluginResult<f64> {
         match parameter_id {
             PARAM_GAIN_ID => self
@@ -71,7 +71,7 @@ impl PluginParameters for WracGainParameters {
         }
     }
 
-    /// host から input event として parameter 値が届いたときの経路。
+    /// Called when a parameter value arrives from the host as an input event.
     fn apply_parameter_value(&self, event: ParameterValueEvent) -> PluginResult<f64> {
         if event.parameter_id == PARAM_BYPASS_ID {
             return self
@@ -87,7 +87,7 @@ impl PluginParameters for WracGainParameters {
         Ok(gain_to_host_value(value))
     }
 
-    /// 内部値 → 表示文字列。例: 1.0 → "0.0 dB"。
+    /// Converts an internal value to a display string. Example: 1.0 → "0.0 dB".
     fn parameter_value_to_text(&self, parameter_id: u32, value: f64) -> PluginResult<String> {
         match parameter_id {
             PARAM_GAIN_ID => parameter_value_text(parameter_id, host_value_to_gain(value)),
@@ -96,7 +96,7 @@ impl PluginParameters for WracGainParameters {
         }
     }
 
-    /// 表示文字列 → 内部値。ユーザーが host UI に "3 dB" のように入力したとき呼ばれる。
+    /// Converts a display string to an internal value. Called when the user types "3 dB" into the host UI.
     fn parameter_text_to_value(&self, parameter_id: u32, text: &str) -> PluginResult<f64> {
         match parameter_id {
             PARAM_GAIN_ID => parameter_text_value(parameter_id, text)
@@ -111,7 +111,7 @@ impl PluginParameters for WracGainParameters {
     }
 }
 
-/// gain を有効範囲に収める。外部から来た値はすべてこれを通してから使う。
+/// Clamps gain to the valid range. All externally supplied values must pass through this.
 pub(crate) fn clamp_gain(gain: f32) -> f32 {
     gain.clamp(MIN_GAIN, MAX_GAIN)
 }
@@ -125,7 +125,7 @@ pub(crate) fn gain_parameter_info() -> ParameterInfo {
         max_value: 1.0,
         default_value: gain_to_host_value(DEFAULT_GAIN),
         flags: ParameterFlags {
-            // false にすると DAW で automation できなくなる。
+            // Setting this false prevents automation in the DAW.
             is_automatable: true,
             ..ParameterFlags::default()
         },
@@ -133,8 +133,8 @@ pub(crate) fn gain_parameter_info() -> ParameterInfo {
 }
 
 pub(crate) fn bypass_parameter_info() -> ParameterInfo {
-    // 一部の host は bypass parameter が無いと generic editor に他の parameter も
-    // 出さない。テンプレートでも実際に効く bypass を 1 つ持たせておく。
+    // Some hosts suppress all parameters in their generic editor if there is no bypass
+    // parameter. Include a working bypass even in the template.
     ParameterInfo {
         id: PARAM_BYPASS_ID,
         name: "Bypass",
@@ -145,8 +145,8 @@ pub(crate) fn bypass_parameter_info() -> ParameterInfo {
         flags: ParameterFlags {
             is_automatable: true,
             is_stepped: true,
-            // 選択肢型は enum も立てる。wrapper が host ネイティブの list
-            // metadata に変換し、一部の generic editor がそれに依存する。
+            // Also set the enum flag for stepped choice parameters. The wrapper converts
+            // this to the host's native list metadata, which some generic editors rely on.
             is_enum: true,
             is_bypass: true,
             ..ParameterFlags::default()
@@ -154,8 +154,8 @@ pub(crate) fn bypass_parameter_info() -> ParameterInfo {
     }
 }
 
-/// plain value → 表示文字列。GUI payload の `text` もこれを通すので、host UI と
-/// plugin GUI の表示が必ず揃う。新しい parameter は match に追加する。
+/// Converts a plain value to a display string. GUI payloads route through here too, so
+/// the host UI and plugin GUI always show the same text. Add new parameters to the match arm.
 pub(crate) fn parameter_value_text(parameter_id: u32, value: f64) -> PluginResult<String> {
     match parameter_id {
         PARAM_GAIN_ID => Ok(gain_db_text(clamp_gain(value as f32) as f64)),
@@ -164,8 +164,8 @@ pub(crate) fn parameter_value_text(parameter_id: u32, value: f64) -> PluginResul
     }
 }
 
-/// parameter の default 値 (plain value)。reset 機能などが使う。
-/// 新しい parameter は match に追加する。
+/// Default value (plain value) for a parameter. Used by reset features, etc.
+/// Add new parameters to the match arm.
 pub(crate) fn parameter_default_value(parameter_id: u32) -> PluginResult<f64> {
     match parameter_id {
         PARAM_GAIN_ID => Ok(DEFAULT_GAIN as f64),
@@ -182,7 +182,7 @@ pub(crate) fn parameter_text_value(parameter_id: u32, text: &str) -> PluginResul
             let db = text
                 .parse::<f64>()
                 .map_err(|_| PluginError::InvalidParameter)?;
-            // dB → 線形 amplitude に変換してから clamp。
+            // Convert dB to linear amplitude, then clamp.
             Ok(clamp_gain(10.0_f64.powf(db / 20.0) as f32) as f64)
         }
         PARAM_BYPASS_ID => match text.trim().to_ascii_lowercase().as_str() {
@@ -215,7 +215,7 @@ pub(crate) fn host_value_to_gain(value: f64) -> f64 {
     (MIN_GAIN + value * (MAX_GAIN - MIN_GAIN)) as f64
 }
 
-/// 線形 amplitude を dB 表示の文字列に変換する。0 以下は "-inf dB"。
+/// Converts a linear amplitude to a dB display string. Values ≤ 0 return "-inf dB".
 pub(crate) fn gain_db_text(gain: f64) -> String {
     if gain <= 0.0 {
         "-inf dB".to_string()

--- a/src-plugin/src/plugin/state_support.rs
+++ b/src-plugin/src/plugin/state_support.rs
@@ -9,10 +9,10 @@ use crate::state::{
     EditorPage, ParameterStateSnapshot, ProjectState, ProjectStateStore, SharedState,
 };
 
-/// DAW project に保存する plugin state の serialize 形式 (JSON)。
+/// Serialisation format (JSON) for the plugin state saved in a DAW project.
 ///
-/// realtime parameter は [`SharedState`] から、editor-only state は
-/// [`ProjectStateStore`] から snapshot し、この 1 形式に合成して host へ渡す。
+/// Realtime parameters are snapshotted from [`SharedState`] and editor-only state from
+/// [`ProjectStateStore`]; both are merged into this single format before passing to the host.
 #[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct SavedPluginState {
     pub(crate) gain: f32,
@@ -42,8 +42,8 @@ impl WracGainStateSupport {
     }
 }
 
-// project 保存で `save_state`、復元で `restore_state`。bytes 形式は自由なので、
-// デバッグしやすい JSON にしている。
+// `save_state` is called on project save, `restore_state` on load. The byte format is
+// unrestricted, so JSON is used here for ease of debugging.
 impl PluginStateSupport for WracGainStateSupport {
     fn save_state(&self) -> PluginResult<PluginState> {
         let project = self.project_state.snapshot();

--- a/src-plugin/src/state.rs
+++ b/src-plugin/src/state.rs
@@ -1,7 +1,8 @@
-//! audio / GUI / host が共有する plugin state。
+//! Plugin state shared by the audio thread, GUI, and host.
 //!
-//! ここは「値の SoT」と「不整合を防ぐ最小限の操作」だけを持つ。GUI への配送や
-//! host への edit 通知は `gui.rs` / `commands.rs` の責務。
+//! This module holds only the source of truth for values and the minimal operations
+//! needed to prevent inconsistency. Delivering changes to the GUI and notifying the host
+//! of edits are the responsibility of `gui.rs` and `commands.rs`.
 
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -11,8 +12,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::plugin::{DEFAULT_GAIN, PARAM_BYPASS_ID, PARAM_GAIN_ID, clamp_gain};
 
-/// project に保存するが audio thread からは読まない editor state の例。
-/// 製品では IR path、track color、editor-only preference などがこの系統。
+/// Example of editor state that is saved with the project but never read from the audio thread.
+/// In a real product this category includes things like IR paths, track colours, and
+/// editor-only preferences.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub(crate) enum EditorPage {
@@ -43,16 +45,16 @@ impl EditorPage {
     }
 }
 
-/// project に保存する non-realtime state。
+/// Non-realtime state saved with the project.
 #[derive(Debug, Clone, Copy, Default)]
 pub(crate) struct ProjectState {
     pub(crate) editor_page: EditorPage,
 }
 
-/// [`ProjectState`] の SoT。audio thread はこの lock を触らない。
+/// Source of truth for [`ProjectState`]. The audio thread never touches this lock.
 ///
-/// lock は snapshot / commit だけに使い、lock 中に serialize・host callback・
-/// GUI dispatch・file IO を挟まないこと (lock 保持時間を最短に保つため)。
+/// The lock is used only for snapshot and commit operations. Do not perform serialisation,
+/// host callbacks, GUI dispatch, or file I/O while holding it (to minimise lock duration).
 pub(crate) struct ProjectStateStore {
     state: RwLock<ProjectState>,
 }
@@ -87,15 +89,15 @@ pub(crate) struct ParameterStateSnapshot {
     pub(crate) bypass: bool,
 }
 
-/// realtime parameter の現在値。3 つの thread から並行に触られる:
-/// - audio thread: `process()` で gain を読んで音に掛ける
-/// - GUI thread  : slider 操作で書き換える
-/// - host thread : `parameter_value()` などで host が問い合わせる
+/// Current values of realtime parameters, accessed concurrently from three threads:
+/// - audio thread: reads gain in `process()` and applies it to audio
+/// - GUI thread  : writes values on slider interaction
+/// - host thread : queries values via `parameter_value()` etc.
 ///
-/// audio thread が lock を待たないよう、lock ではなく atomic を使う。
-/// project にだけ残す non-realtime state は [`ProjectStateStore`] 側に分離する。
+/// Atomics are used instead of a lock so the audio thread never has to wait.
+/// Non-realtime state that belongs only in the project is separated into [`ProjectStateStore`].
 pub(crate) struct SharedState {
-    // 線形 amplitude。
+    // Linear amplitude.
     gain: AtomicF32,
     bypass: AtomicBool,
 }
@@ -117,9 +119,9 @@ impl SharedState {
     }
 
     pub(crate) fn snapshot_parameters(&self) -> ParameterStateSnapshot {
-        // gain/bypass 間に transaction 境界が無いので単純な atomic load で十分。
-        // 複数 field の完全一貫 snapshot が要る製品では、ここに seqlock 風の
-        // generation check を閉じ込める。
+        // No transaction boundary is needed between gain and bypass, so plain atomic
+        // loads are sufficient. Products requiring a fully consistent multi-field snapshot
+        // should add a seqlock-style generation check here.
         ParameterStateSnapshot {
             gain: self.gain(),
             bypass: self.bypass(),
@@ -132,8 +134,8 @@ impl SharedState {
         self.bypass.store(snapshot.bypass, Ordering::Release);
     }
 
-    /// parameter の現在値。新しい parameter は match に追加する
-    /// (GUI command は id だけを見るので command 名は増えない)。
+    /// Returns the current value of a parameter. Add new parameters to the match arm
+    /// (GUI commands look up parameters by ID, so command names do not need to change).
     pub(crate) fn parameter_value(&self, parameter_id: u32) -> Option<f32> {
         match parameter_id {
             PARAM_GAIN_ID => Some(self.gain()),
@@ -142,12 +144,13 @@ impl SharedState {
         }
     }
 
-    /// 外部から来た値を範囲に収めて SoT に保存する。各 parameter の clamp /
-    /// normalization はここで完結させる。新しい parameter は match に追加する。
+    /// Clamps an externally supplied value to the valid range and stores it as the source
+    /// of truth. All per-parameter clamping and normalisation is centralised here.
+    /// Add new parameters to the match arm.
     pub(crate) fn set_parameter_value(&self, parameter_id: u32, value: f64) -> Option<f32> {
         match parameter_id {
             PARAM_GAIN_ID => {
-                // automation/UI から範囲外が来ても安全なよう必ず clamp。
+                // Always clamp so out-of-range values from automation or the UI are safe.
                 let gain = clamp_gain(value as f32);
                 self.gain.store(gain, Ordering::Release);
                 Some(gain)

--- a/xtask/src/commands.rs
+++ b/xtask/src/commands.rs
@@ -23,8 +23,9 @@ pub(crate) fn build(ctx: &Context, args: BuildArgs) -> Result<()> {
     let profile = BuildProfile::from_release(args.release);
     let targets = resolve_build_targets(ctx.platform, &args.target)?;
 
-    // wrapper 系の不足は npm/cargo のビルド後に CMake エラーとして出ると原因が追いにくい。
-    // 対象が wrapper を必要とする時だけ、先にサブモジュールの実体まで確認する。
+    // Missing wrapper inputs surface as CMake errors after npm/cargo have already run,
+    // making the root cause hard to diagnose. Check submodule contents upfront only
+    // when the selected targets require a wrapper.
     if targets.iter().any(|target| target.is_wrapper()) || targets.contains(&Target::Standalone) {
         ensure_wrapper_inputs(
             ctx,
@@ -47,10 +48,11 @@ pub(crate) fn build(ctx: &Context, args: BuildArgs) -> Result<()> {
     }
 
     if targets.iter().any(|target| target.is_wrapper()) {
-        // 旧 WRY_OBJC_SUFFIX 時代は macOS の ObjC class 名を format ごとに変えるため、
-        // VST3/AU で別々の Rust staticlib を作っていた。現在の wxp/wry は wry source id を
-        // objc2 の自動 class 名へ含めるため、同じ製品 build の VST3/AU は同じ staticlib を
-        // 共有できる。format ごとの compile-time 入力を再導入しない限り、ここで分けない。
+        // In the old WRY_OBJC_SUFFIX era, VST3 and AU each required a separate Rust
+        // staticlib so their Objective-C class names could differ per format. The current
+        // wxp/wry embeds the wry source ID into objc2's auto-generated class names, so a
+        // single staticlib can be shared by both VST3 and AU in the same product build.
+        // Do not split again unless per-format compile-time inputs are reintroduced.
         if !default_rust_plugin_built {
             build_rust_plugin(ctx, profile, RustPluginBuild::Default)?;
         }
@@ -75,8 +77,8 @@ pub(crate) fn build(ctx: &Context, args: BuildArgs) -> Result<()> {
 
 fn build_gui(ctx: &Context) -> Result<()> {
     println!("Building GUI...");
-    // Rust 側の build.rs が src-gui/dist を埋め込むため、ここで先に frontend を確定させる。
-    // 順序を逆にすると古い dist や空の dist を plugin に含める可能性がある。
+    // build.rs embeds src-gui/dist into the plugin binary, so the frontend must be
+    // finalized here first. Reversing the order risks bundling a stale or empty dist.
     run(Command::new(npm_command(ctx.platform))
         .arg("install")
         .current_dir(ctx.gui_dir()))?;
@@ -141,7 +143,7 @@ fn build_rust_plugin(ctx: &Context, profile: BuildProfile, build: RustPluginBuil
         command.arg(flag);
     }
     if ctx.platform == Platform::Macos {
-        // CI や利用者環境の env を尊重しつつ、未指定時だけ template の安全な既定値を入れる。
+        // Respect CI and user environment variables; inject the template's safe default only when unset.
         command.env(
             "MACOSX_DEPLOYMENT_TARGET",
             env_value_or("MACOSX_DEPLOYMENT_TARGET", "11.0"),
@@ -154,8 +156,8 @@ fn build_rust_plugin(ctx: &Context, profile: BuildProfile, build: RustPluginBuil
         "dynamic plugin library",
     )?;
     if ctx.platform.supports_wrappers() {
-        // clap-wrapper は CLAP bundle ではなく Rust staticlib を直接 link する。
-        // CLAP だけの platform では不要なので、wrapper 対応 OS の時だけ確認する。
+        // clap-wrapper links the Rust staticlib directly rather than consuming a CLAP bundle.
+        // Not needed on CLAP-only platforms, so check only on OS targets that support wrappers.
         ensure_exists(&build.static_library(ctx, profile), "static plugin library")?;
     }
     Ok(())
@@ -170,9 +172,9 @@ fn package_clap(ctx: &Context, profile: BuildProfile) -> Result<()> {
 
     match ctx.platform {
         Platform::Macos => {
-            // macOS の CLAP は裸の dylib ではなく bundle として配布される。
-            // host が bundle metadata を読むため、plugin id と Info.plist をここで一致させる。
-            // install_name も bundle 内相対にして、install 先を変えてもロードできるようにする。
+            // macOS distributes CLAP plugins as bundles, not bare dylibs.
+            // The host reads bundle metadata, so the plugin ID must match Info.plist.
+            // Set install_name to a bundle-relative path so the plugin loads regardless of install location.
             let contents = bundle.join("Contents");
             let macos = contents.join("MacOS");
             fs::create_dir_all(&macos)?;
@@ -193,8 +195,8 @@ fn package_clap(ctx: &Context, profile: BuildProfile) -> Result<()> {
             codesign(&bundle)?;
         }
         Platform::Windows | Platform::Linux => {
-            // Windows/Linux では CLAP artifact は拡張子が .clap の dynamic library として扱う。
-            // bundle 構造を作らないことで各 OS の既存 host 探索規約に合わせる。
+            // On Windows/Linux the CLAP artifact is a dynamic library with the .clap extension.
+            // Skipping the bundle structure keeps it compatible with each OS's existing host scan conventions.
             fs::copy(ctx.dynamic_library(profile), &bundle)?;
         }
     }
@@ -239,9 +241,9 @@ fn build_wrapper_set(ctx: &Context, profile: BuildProfile, build: WrapperBuild) 
     fs::create_dir_all(&stage_dir)?;
 
     let mut configure = Command::new("cmake");
-    // wrapper は Rust staticlib から直接作る。既に生成済みの CLAP bundle を探す方式にすると、
-    // clean/install の順序や古い artifact に依存して再現性が落ちるため。
-    // stage 先も xtask が後続で検証する path と同じ値を CMake に渡す。
+    // Build the wrapper directly from the Rust staticlib. Locating a pre-built CLAP bundle
+    // instead would tie reproducibility to clean/install ordering and stale artifacts.
+    // Pass the same stage path that xtask uses for downstream validation checks.
     configure
         .arg("-S")
         .arg(&ctx.wrapper_dir)
@@ -280,8 +282,9 @@ fn build_wrapper_set(ctx: &Context, profile: BuildProfile, build: WrapperBuild) 
                 .arg("-DCLAP_WRAPPER_BUILDER_BUILD_STANDALONE=OFF");
         }
         WrapperBuild::Standalone => {
-            // standalone は plugin wrapper と違い、アプリ側の補助依存が必要になる。
-            // clap-wrapper 側の取得ロジックに任せ、plugin wrapper では依存 download を無効のまま保つ。
+            // standalone requires additional app-side dependencies that plugin wrappers do not.
+            // Delegate fetching to clap-wrapper's own download logic while keeping downloads
+            // disabled for plugin wrapper builds.
             configure
                 .arg("-DCLAP_WRAPPER_BUILDER_BUILD_VST3=OFF")
                 .arg("-DCLAP_WRAPPER_BUILDER_BUILD_AUV2=OFF")
@@ -299,8 +302,8 @@ fn build_wrapper_set(ctx: &Context, profile: BuildProfile, build: WrapperBuild) 
     }
 
     if ctx.platform == Platform::Macos {
-        // AUv2 は type/manufacturer/subtype の 4 文字コードが host discovery の key になる。
-        // Rust 側の descriptor から推測させず、template の constants を単一の入力にする。
+        // AUv2 uses 4-character type/manufacturer/subtype codes as the host discovery key.
+        // Drive them from the template's constants rather than inferring from the Rust descriptor.
         configure
             .arg(format!(
                 "-DAUDIOUNIT_SDK_ROOT={}",
@@ -338,8 +341,8 @@ fn build_wrapper_set(ctx: &Context, profile: BuildProfile, build: WrapperBuild) 
         .arg(profile.cmake_config());
 
     if ctx.platform == Platform::Macos {
-        // AudioUnitSDK は Xcode で warning-only な GNU statement-expression / narrowing を出す。
-        // template 利用者が wrapper SDK の warning に引きずられず build できるよう、ここだけ抑制する。
+        // AudioUnitSDK emits GNU statement-expression and narrowing warnings in Xcode.
+        // Suppress them here so template users are not pulled into wrapper SDK warnings.
         build_cmd.args([
             "--",
             "OTHER_CPLUSPLUSFLAGS=$(inherited) -Wno-unknown-warning-option -Wno-gnu-statement-expression-from-macro-expansion -Wno-shorten-64-to-32 -Wno-perf-constraint-implies-noexcept",
@@ -353,20 +356,20 @@ fn build_wrapper_set(ctx: &Context, profile: BuildProfile, build: WrapperBuild) 
             if vst3 {
                 ensure_exists(&ctx.vst3_bundle(profile), "VST3 artifact")?;
                 if ctx.platform == Platform::Macos {
-                    // macOS host は未署名 bundle を拒否することがあるため、開発用に ad-hoc 署名する。
+                    // macOS hosts may reject unsigned bundles; apply an ad-hoc signature for development.
                     codesign_nested_macos_bundle(ctx, &ctx.vst3_bundle(profile))?;
                 }
             }
             if au {
                 ensure_exists(&ctx.au_bundle(profile), "AU artifact")?;
-                // AU は AudioComponentRegistrar 経由で読むため、local build でも署名済みにしておく。
+                // AU components are loaded via AudioComponentRegistrar, so they must be signed even for local builds.
                 codesign_nested_macos_bundle(ctx, &ctx.au_bundle(profile))?;
             }
         }
         WrapperBuild::Standalone => {
             ensure_exists(&ctx.standalone_artifact(profile), "standalone artifact")?;
             if ctx.platform == Platform::Macos {
-                // standalone app も Gatekeeper/loader の扱いを plugin bundle と揃える。
+                // Apply the same Gatekeeper/loader treatment to the standalone app as to plugin bundles.
                 codesign_nested_macos_bundle(ctx, &ctx.standalone_artifact(profile))?;
             }
         }
@@ -513,8 +516,8 @@ fn install_artifact(artifact: &Path, destination_dir: &Path) -> Result<()> {
             .file_name()
             .ok_or_else(|| format!("artifact has no file name: {}", artifact.display()))?,
     );
-    // bundle の中身を上書き merge すると古い binary/resource が残り得る。
-    // 一度消してから丸ごとコピーし、install 結果を build artifact と一致させる。
+    // Merging over an existing bundle can leave behind stale binaries or resources.
+    // Remove the destination first, then copy the whole artifact so the installed result matches the build output exactly.
     remove_if_exists(&destination)?;
     copy_path(artifact, &destination)?;
     println!("Installed: {}", destination.display());
@@ -560,8 +563,8 @@ pub(crate) fn validate(
 ) -> Result<()> {
     let targets = resolve_validate_targets(ctx.platform, requested)?;
     if targets.contains(&ValidateTarget::Vst3) {
-        // validator は VST3 SDK からその場で build するため、artifact 確認より先に SDK を検証する。
-        // 空のサブモジュール directory だけで CMake まで進むと、利用者に原因が伝わりにくい。
+        // The validator is built on-demand from the VST3 SDK, so verify the SDK before checking
+        // the artifact. Proceeding to CMake with an empty submodule directory produces an opaque error.
         ensure_vst3_sdk_input(ctx)?;
     }
     validate_targets(ctx, profile, &targets)
@@ -600,13 +603,13 @@ fn validate_targets(
         ensure_exists(&au, "AU artifact")?;
         ensure_no_system_au_conflict(ctx)?;
 
-        // auval は path 指定ではなく AudioComponentRegistrar から対象を解決する。
-        // そのため freshly built な AU を user-local に置いてから validation する。
+        // auval resolves its target via AudioComponentRegistrar rather than a direct path,
+        // so the freshly built AU must be installed user-locally before running validation.
         let install_dir = install_dir(ctx, InstallScope::User, PluginFormat::Au)?;
         install_artifact(&au, &install_dir)?;
 
-        // registrar は component 情報を cache するため、直前に置いた AU を見せるには再起動が必要。
-        // killall が失敗しても auval 側で検出できる可能性があるので、ここでは best-effort にする。
+        // The registrar caches component metadata, so it must be restarted to expose the newly placed AU.
+        // If killall fails, auval may still detect the component, so treat this as best-effort.
         let _ = Command::new("killall")
             .args(["-9", "AudioComponentRegistrar"])
             .status();
@@ -725,8 +728,8 @@ fn ensure_vst3_validator(ctx: &Context) -> Result<PathBuf> {
         return Ok(validator_without_config);
     }
 
-    // validator は出荷 artifact ではなく検証用 tool。
-    // plugin の release/debug とは独立なので、Debug の 1 build を両 profile で使い回す。
+    // The validator is a verification tool, not a shipping artifact.
+    // It is independent of the plugin's release/debug profile, so a single Debug build is reused for both profiles.
     let build_dir = ctx.target_dir.join("vst3sdk-validator");
     let mut configure = Command::new("cmake");
     configure
@@ -765,8 +768,8 @@ pub(crate) fn clean(ctx: &Context) -> Result<()> {
 }
 
 fn ensure_wrapper_inputs(ctx: &Context, needs_vst3: bool, needs_au: bool) -> Result<()> {
-    // git submodule が未 init の場合、directory だけ存在して中身が空のことがある。
-    // CMake の抽象的な失敗に進ませず、wrapper が実際に読む sentinel file を見る。
+    // An uninitialized git submodule may leave only an empty directory in place.
+    // Rather than letting CMake fail with an opaque error, check the sentinel files the wrapper actually reads.
     ensure_exists(&ctx.wrapper_dir, "clap_wrapper_builder directory")?;
     ensure_exists(
         &ctx.wrapper_dir.join("clap-wrapper").join("CMakeLists.txt"),

--- a/xtask/src/context.rs
+++ b/xtask/src/context.rs
@@ -16,25 +16,25 @@ pub(crate) struct Context {
 
 impl Context {
     pub(crate) fn new() -> Result<Self> {
-        // cargo xtask は xtask crate の manifest から起動されるため、親 directory を repo root とする。
-        // current_dir に依存すると、別 directory から実行した時に artifact path がずれる。
+        // cargo xtask is invoked from the xtask crate's manifest, so the parent directory is the repo root.
+        // Relying on current_dir would misalign artifact paths when invoked from a different directory.
         let root = Path::new(env!("CARGO_MANIFEST_DIR"))
             .ancestors()
             .nth(1)
             .ok_or("failed to locate repository root")?
             .to_path_buf();
-        // CARGO_TARGET_DIR は workspace や CI で共有 cache に向けられることがある。
-        // xtask が cargo と同じ target root を見ることで、build 後の library 検出を一致させる。
+        // CARGO_TARGET_DIR may be redirected to a shared cache in workspaces or CI.
+        // Using the same target root as cargo keeps post-build library detection consistent.
         let target_dir = env::var_os("CARGO_TARGET_DIR")
             .map(PathBuf::from)
             .unwrap_or_else(|| root.join("target"));
-        // wrapper の fork/patch を最小限に保つため、通常は repo 内 submodule を使う。
-        // CLAP_WRAPPER_DIR は SDK 検証や一時的な外部 checkout を試すための escape hatch。
+        // The in-repo submodule is used by default to keep wrapper forks and patches minimal.
+        // CLAP_WRAPPER_DIR is an escape hatch for testing SDK changes or a temporary external checkout.
         let wrapper_dir = env::var_os("CLAP_WRAPPER_DIR")
             .map(PathBuf::from)
             .unwrap_or_else(|| root.join("clap_wrapper_builder"));
-        // Plugin identity は src-plugin/Cargo.toml の [package.metadata.wrac] を SoT にする。
-        // xtask が bundle 名や wrapper 引数を別に持つと、rename 時に build artifact だけ古い名前になる。
+        // Plugin identity is sourced from [package.metadata.wrac] in src-plugin/Cargo.toml.
+        // Maintaining separate bundle names or wrapper arguments in xtask risks stale build artifacts on rename.
         let metadata = PluginMetadata::read(&root.join("src-plugin").join("Cargo.toml"))?;
 
         Ok(Self {
@@ -67,8 +67,8 @@ impl Context {
     }
 
     pub(crate) fn cmake_dir(&self, purpose: &str, profile: BuildProfile) -> PathBuf {
-        // wrapper build directory は短く固定する。
-        // 旧 script の hash path は Windows path limit 回避には有効だが、launch.json や調査時の再現性が落ちる。
+        // Keep the wrapper build directory short and stable.
+        // The old hash-based path helped avoid Windows path length limits but hurt reproducibility in launch.json and investigations.
         self.wrac_dir()
             .join("cmake")
             .join(format!("{purpose}-{}", profile.cmake_suffix()))

--- a/xtask/src/targets.rs
+++ b/xtask/src/targets.rs
@@ -117,7 +117,7 @@ impl Platform {
     }
 
     pub(crate) fn default_build_targets(self) -> Vec<Target> {
-        // 無指定 build は「その OS で開発者が期待する全部」を作る。
+        // An unspecified build produces everything a developer would expect for that OS.
         match self {
             Self::Macos => vec![Target::Clap, Target::Vst3, Target::Au, Target::Standalone],
             Self::Windows => vec![Target::Clap, Target::Vst3, Target::Standalone],
@@ -134,7 +134,7 @@ impl Platform {
     }
 
     pub(crate) fn default_validate_targets(self) -> Vec<ValidateTarget> {
-        // validate は既に build 済みの plugin artifact を外部 validator で確認する command。
+        // validate runs external validators against already-built plugin artifacts.
         match self {
             Self::Macos => vec![
                 ValidateTarget::Clap,
@@ -240,8 +240,8 @@ pub(crate) fn resolve_validate_targets(
 }
 
 fn dedup<T: Copy + PartialEq>(targets: Vec<T>) -> Vec<T> {
-    // CLI では `--target=vst3,vst3` のような重複入力を許す。
-    // エラーにせず順序だけ保って重複排除し、script からの呼び出しを寛容にする。
+    // Allow duplicate inputs such as `--target=vst3,vst3` from the CLI.
+    // Deduplicate while preserving order rather than erroring, to be lenient toward script callers.
     let mut unique = Vec::new();
     for target in targets {
         if !unique.contains(&target) {

--- a/xtask/src/util.rs
+++ b/xtask/src/util.rs
@@ -39,8 +39,8 @@ pub(crate) fn ensure_exists(path: &Path, description: &str) -> Result<()> {
 }
 
 pub(crate) fn run(command: &mut Command) -> Result<()> {
-    // xtask は build orchestration なので、失敗時に実際の外部 command が見えることが重要。
-    // shell を経由せず Command で実行しつつ、人間が再実行しやすい形だけを表示する。
+    // xtask is a build orchestrator, so seeing the exact external command on failure is important.
+    // Run directly via Command without a shell, but print in a form that humans can re-run easily.
     println!();
     println!("========== Running command ==========");
     println!("$ {}", format_command(command));
@@ -72,8 +72,8 @@ fn shell_display(value: &OsStr) -> String {
 }
 
 pub(crate) fn remove_if_exists(path: &Path) -> Result<()> {
-    // clean/install は何度実行しても同じ結果にしたい。
-    // missing を正常系にすることで、途中失敗後の再実行や dry な環境を扱いやすくする。
+    // clean/install should be idempotent regardless of how many times they are run.
+    // Treating a missing path as success makes re-runs after partial failures and dry environments straightforward.
     if !path.exists() {
         return Ok(());
     }


### PR DESCRIPTION
## Summary
- Translate Japanese documentation and code comments into English
- Refresh setup and README guidance for supported build and validation targets

## Verification
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace --all-targets