### PR TITLE
Handle raw MIDI input in standalone

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -22,20 +22,11 @@
 		{
 			"label": "open-wrac-gain-standalone",
 			"type": "process",
-			"command": "open",
+			"command": "cargo",
 			"args": [
-				"${workspaceFolder}/target/wrac/standalone/debug/WRAC Gain Standalone.app"
+				"xtask",
+				"launch"
 			],
-			"osx": {
-				"command": "open",
-				"args": [
-					"${workspaceFolder}/target/wrac/standalone/debug/WRAC Gain Standalone.app"
-				]
-			},
-			"windows": {
-				"command": "${workspaceFolder}/target/wrac/standalone/debug/WRAC Gain Standalone.exe",
-				"args": []
-			},
 			"presentation": {
 				"reveal": "always",
 				"panel": "new",

--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ cargo xtask validate
 cargo xtask install
 ```
 
+Launch the standalone app after building it:
+
+```bash
+cargo xtask build --target=standalone
+cargo xtask launch
+```
+
 Supported formats:
 
 | OS | `cargo xtask build` targets | `cargo xtask validate` targets |

--- a/README_JA.md
+++ b/README_JA.md
@@ -44,6 +44,13 @@ cargo xtask validate
 cargo xtask install
 ```
 
+Standalone app はビルド後に起動できます:
+
+```bash
+cargo xtask build --target=standalone
+cargo xtask launch
+```
+
 対応フォーマット:
 
 | OS | `cargo xtask build` の対象 | `cargo xtask validate` の対象 |

--- a/crates/wrac_clap_adapter/src/events.rs
+++ b/crates/wrac_clap_adapter/src/events.rs
@@ -3,11 +3,11 @@ use std::mem::size_of;
 use std::ptr;
 
 use clap_sys::events::{
-    CLAP_CORE_EVENT_SPACE_ID, CLAP_EVENT_NOTE_CHOKE, CLAP_EVENT_NOTE_END,
+    CLAP_CORE_EVENT_SPACE_ID, CLAP_EVENT_MIDI, CLAP_EVENT_NOTE_CHOKE, CLAP_EVENT_NOTE_END,
     CLAP_EVENT_NOTE_EXPRESSION, CLAP_EVENT_NOTE_OFF, CLAP_EVENT_NOTE_ON,
     CLAP_EVENT_PARAM_GESTURE_BEGIN, CLAP_EVENT_PARAM_GESTURE_END, CLAP_EVENT_PARAM_MOD,
-    CLAP_EVENT_PARAM_VALUE, CLAP_EVENT_TRANSPORT, clap_event_header, clap_event_note,
-    clap_event_note_expression, clap_event_param_gesture, clap_event_param_mod,
+    CLAP_EVENT_PARAM_VALUE, CLAP_EVENT_TRANSPORT, clap_event_header, clap_event_midi,
+    clap_event_note, clap_event_note_expression, clap_event_param_gesture, clap_event_param_mod,
     clap_event_param_value, clap_event_transport, clap_input_events, clap_note_expression,
     clap_output_events, clap_transport_flags,
 };
@@ -249,6 +249,12 @@ impl InputEvent {
             CLAP_EVENT_NOTE_EXPRESSION if has_size::<clap_event_note_expression>(header) => Some(
                 Self::NoteExpression(NoteExpressionEvent::from_raw(unsafe { cast_event(header) })),
             ),
+            CLAP_EVENT_MIDI if has_size::<clap_event_midi>(header) => {
+                // Some wrappers and hosts deliver MIDI dialect input as raw MIDI events even when
+                // the plugin's audio code only cares about note semantics. Convert the channel note
+                // messages here so processors can handle CLAP notes and MIDI notes uniformly.
+                midi_note_event_from_raw(unsafe { cast_event(header) })
+            }
             CLAP_EVENT_PARAM_VALUE if has_size::<clap_event_param_value>(header) => {
                 Some(Self::ParamValue(parameter_value_from_raw(unsafe {
                     cast_event(header)
@@ -291,6 +297,28 @@ impl InputEvent {
             Self::Transport(event) => event.time,
             Self::Unknown(event) => event.time,
         }
+    }
+}
+
+fn midi_note_event_from_raw(raw: &clap_event_midi) -> Option<InputEvent> {
+    let status = raw.data[0] & 0xF0;
+    let channel = raw.data[0] & 0x0F;
+    let key = raw.data[1];
+    let velocity = raw.data[2];
+    let note = NoteEvent {
+        time: raw.header.time,
+        note_id: -1,
+        port_index: raw.port_index as i16,
+        channel: channel as i16,
+        key: key as i16,
+        velocity: f64::from(velocity) / 127.0,
+    };
+
+    match status {
+        0x80 => Some(InputEvent::NoteOff(note)),
+        0x90 if velocity == 0 => Some(InputEvent::NoteOff(note)),
+        0x90 => Some(InputEvent::NoteOn(note)),
+        _ => Some(InputEvent::Unknown(UnknownEvent::from_header(&raw.header))),
     }
 }
 
@@ -545,8 +573,9 @@ mod tests {
     use std::ffi::c_void;
 
     use clap_sys::events::{
-        CLAP_CORE_EVENT_SPACE_ID, CLAP_EVENT_NOTE_ON, CLAP_EVENT_PARAM_VALUE, clap_event_header,
-        clap_event_note, clap_event_param_value, clap_input_events,
+        CLAP_CORE_EVENT_SPACE_ID, CLAP_EVENT_MIDI, CLAP_EVENT_NOTE_ON, CLAP_EVENT_PARAM_VALUE,
+        clap_event_header, clap_event_midi, clap_event_note, clap_event_param_value,
+        clap_input_events,
     };
 
     use super::{InputEvent, InputEvents};
@@ -627,6 +656,80 @@ mod tests {
                 assert_eq!(event.velocity, 0.5);
             }
             _ => panic!("expected note on"),
+        }
+    }
+
+    #[test]
+    fn input_events_convert_midi_note_messages() {
+        let note_on = clap_event_midi {
+            header: clap_event_header {
+                size: std::mem::size_of::<clap_event_midi>() as u32,
+                time: 10,
+                space_id: CLAP_CORE_EVENT_SPACE_ID,
+                type_: CLAP_EVENT_MIDI,
+                flags: 0,
+            },
+            port_index: 0,
+            data: [0x91, 64, 100],
+        };
+        let note_off = clap_event_midi {
+            header: clap_event_header {
+                size: std::mem::size_of::<clap_event_midi>() as u32,
+                time: 20,
+                space_id: CLAP_CORE_EVENT_SPACE_ID,
+                type_: CLAP_EVENT_MIDI,
+                flags: 0,
+            },
+            port_index: 0,
+            data: [0x80, 64, 0],
+        };
+        let zero_velocity_note_on = clap_event_midi {
+            header: clap_event_header {
+                size: std::mem::size_of::<clap_event_midi>() as u32,
+                time: 30,
+                space_id: CLAP_CORE_EVENT_SPACE_ID,
+                type_: CLAP_EVENT_MIDI,
+                flags: 0,
+            },
+            port_index: 0,
+            data: [0x91, 67, 0],
+        };
+        let mut list_data = EventList {
+            events: vec![
+                &note_on.header,
+                &note_off.header,
+                &zero_velocity_note_on.header,
+            ],
+        };
+        let raw = clap_input_events {
+            ctx: (&mut list_data as *mut EventList).cast::<c_void>(),
+            size: Some(event_count),
+            get: Some(event_get),
+        };
+        let events = unsafe { InputEvents::from_raw(&raw) };
+
+        match events.get(0).unwrap() {
+            InputEvent::NoteOn(event) => {
+                assert_eq!(event.time, 10);
+                assert_eq!(event.channel, 1);
+                assert_eq!(event.key, 64);
+                assert_eq!(event.velocity, 100.0 / 127.0);
+            }
+            _ => panic!("expected midi note on"),
+        }
+        match events.get(1).unwrap() {
+            InputEvent::NoteOff(event) => {
+                assert_eq!(event.time, 20);
+                assert_eq!(event.key, 64);
+            }
+            _ => panic!("expected midi note off"),
+        }
+        match events.get(2).unwrap() {
+            InputEvent::NoteOff(event) => {
+                assert_eq!(event.time, 30);
+                assert_eq!(event.key, 67);
+            }
+            _ => panic!("expected zero-velocity note on as note off"),
         }
     }
 

--- a/src-plugin/Cargo.toml
+++ b/src-plugin/Cargo.toml
@@ -8,16 +8,22 @@ repository = "https://github.com/novonotes/wrac-plugin-template"
 publish = false
 build = "build.rs"
 
-# Plugin identity lives here so descriptors, GUI metadata, bundle names,
-# wrapper arguments, AUv2 codes, WebView data dirs, and log names all move
-# together when this template is renamed.
+# WRAC metadata is the single source of truth for descriptors, GUI metadata,
+# bundle names, wrapper arguments, AUv2 registration, WebView data dirs, and logs.
 [package.metadata.wrac]
+# Reverse-DNS identifier. Use your own domain or another namespace you control.
 plugin_id = "com.your-company.wrac-gain"
+# User-visible plugin name shown by hosts and the template GUI.
 plugin_name = "WRAC Gain"
+# User-visible vendor name shown by hosts and the template GUI.
 company_name = "Your Company"
+# AUv2 component type. Audio effects usually use "aufx"; instruments usually use "aumu".
 auv2_type = "aufx"
+# AUv2 subtype. Pick a unique 4-byte ASCII code for each plugin from the same vendor.
 auv2_subtype = "WtGn"
+# AUv2 manufacturer code. Use the same 4-byte ASCII code across your plugin catalog.
 auv2_manufacturer_code = "YrCo"
+# User-visible standalone app name.
 standalone_name = "WRAC Gain Standalone"
 
 [lib]

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -85,6 +85,15 @@ Notes:
   AU validation is available only on macOS and installs the built AU before running auval.
   AU validation fails if the same AU bundle exists under /Library/Audio/Plug-Ins/Components.";
 
+const LAUNCH_AFTER_HELP: &str = "\
+Examples:
+  cargo xtask launch
+  cargo xtask launch --release
+
+Notes:
+  launch starts a previously built standalone artifact.
+  Run `cargo xtask build --target=standalone` first.";
+
 #[derive(Debug, Parser)]
 #[command(
     name = "xtask",
@@ -118,6 +127,11 @@ pub(crate) enum Commands {
         after_help = VALIDATE_AFTER_HELP
     )]
     Validate(ValidateArgs),
+    #[command(
+        about = "Launch a previously built standalone artifact.",
+        after_help = LAUNCH_AFTER_HELP
+    )]
+    Launch(LaunchArgs),
     #[command(about = "Remove generated build artifacts managed by xtask.")]
     Clean,
 }
@@ -131,6 +145,7 @@ pub(crate) struct BuildArgs {
     pub(crate) clean: bool,
 
     #[arg(
+        short_alias = 't',
         long,
         value_enum,
         value_delimiter = ',',
@@ -155,6 +170,7 @@ pub(crate) struct InstallArgs {
     pub(crate) scope: InstallScope,
 
     #[arg(
+        short_alias = 't',
         long,
         value_enum,
         value_delimiter = ',',
@@ -189,6 +205,7 @@ pub(crate) struct UninstallArgs {
     pub(crate) scope: UninstallScope,
 
     #[arg(
+        short_alias = 't',
         long,
         value_enum,
         value_delimiter = ',',
@@ -211,6 +228,7 @@ pub(crate) struct ValidateArgs {
     pub(crate) release: bool,
 
     #[arg(
+        short_alias = 't',
         long,
         value_enum,
         value_delimiter = ',',
@@ -219,4 +237,10 @@ pub(crate) struct ValidateArgs {
         long_help = "Targets to validate, comma-separated. Supported values are clap, vst3, and au. Defaults to every validation target supported by the current OS."
     )]
     pub(crate) target: Vec<ValidateTarget>,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct LaunchArgs {
+    #[arg(long, help = "Launch release artifact.")]
+    pub(crate) release: bool,
 }

--- a/xtask/src/commands.rs
+++ b/xtask/src/commands.rs
@@ -388,6 +388,29 @@ pub(crate) fn install(
     install_plugin_targets(ctx, profile, scope, &targets)
 }
 
+pub(crate) fn launch(ctx: &Context, profile: BuildProfile) -> Result<()> {
+    let artifact = ctx.standalone_artifact(profile);
+    if !artifact.exists() {
+        let release = if profile == BuildProfile::Release {
+            " --release"
+        } else {
+            ""
+        };
+        return Err(format!(
+            "standalone artifact not found: {}\nRun `cargo xtask build --target=standalone{release}` first.",
+            artifact.display()
+        )
+        .into());
+    }
+
+    println!("Launching standalone artifact: {}", artifact.display());
+    match ctx.platform {
+        Platform::Macos => run(Command::new("open").arg("-W").arg("-n").arg(&artifact))?,
+        Platform::Windows | Platform::Linux => run(&mut Command::new(&artifact))?,
+    }
+    Ok(())
+}
+
 fn install_plugin_targets(
     ctx: &Context,
     profile: BuildProfile,

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -12,7 +12,7 @@ mod targets;
 mod util;
 
 use cli::{Cli, Commands};
-use commands::{build, clean, install, uninstall, validate};
+use commands::{build, clean, install, launch, uninstall, validate};
 use context::Context;
 use profile::BuildProfile;
 
@@ -34,6 +34,7 @@ fn main() -> Result<()> {
         Commands::Validate(args) => {
             validate(&ctx, BuildProfile::from_release(args.release), &args.target)?
         }
+        Commands::Launch(args) => launch(&ctx, BuildProfile::from_release(args.release))?,
         Commands::Clean => clean(&ctx)?,
     }
 


### PR DESCRIPTION
## Summary
- Convert raw MIDI note on/off messages into InputEvent values in the CLAP adapter
- Treat zero-velocity note-on messages as note-off
- Add regression coverage for MIDI note conversion

## Verification
- cargo fmt --all -- --check
- cargo test --locked -p wrac_clap_adapter
- cargo test --locked -p wrac_sine_synth_plugin
- cargo xtask build --plugin=sine-synth --target=standalone