### PR TITLE
Update wxp dependency pin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1330,7 +1330,7 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 [[package]]
 name = "novonotes_run_loop"
 version = "0.6.0"
-source = "git+https://github.com/novonotes/wxp.git?rev=6a55e6d83cb07ecc5d56cd3a5f8418e027320dd6#6a55e6d83cb07ecc5d56cd3a5f8418e027320dd6"
+source = "git+https://github.com/novonotes/wxp.git?rev=a7494eb35d661df355217be5ed75ab832cfbcd44#a7494eb35d661df355217be5ed75ab832cfbcd44"
 dependencies = [
  "core-foundation",
  "futures",
@@ -1837,7 +1837,7 @@ dependencies = [
 [[package]]
 name = "run_loop_timer"
 version = "0.1.0"
-source = "git+https://github.com/novonotes/wxp.git?rev=6a55e6d83cb07ecc5d56cd3a5f8418e027320dd6#6a55e6d83cb07ecc5d56cd3a5f8418e027320dd6"
+source = "git+https://github.com/novonotes/wxp.git?rev=a7494eb35d661df355217be5ed75ab832cfbcd44#a7494eb35d661df355217be5ed75ab832cfbcd44"
 dependencies = [
  "novonotes_run_loop",
 ]
@@ -2858,7 +2858,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 [[package]]
 name = "wry"
 version = "0.55.1"
-source = "git+https://github.com/novonotes/wxp.git?rev=6a55e6d83cb07ecc5d56cd3a5f8418e027320dd6#6a55e6d83cb07ecc5d56cd3a5f8418e027320dd6"
+source = "git+https://github.com/novonotes/wxp.git?rev=a7494eb35d661df355217be5ed75ab832cfbcd44#a7494eb35d661df355217be5ed75ab832cfbcd44"
 dependencies = [
  "base64",
  "block2 0.6.2",
@@ -2901,7 +2901,7 @@ dependencies = [
 [[package]]
 name = "wxp"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/novonotes/wxp.git?rev=6a55e6d83cb07ecc5d56cd3a5f8418e027320dd6#6a55e6d83cb07ecc5d56cd3a5f8418e027320dd6"
+source = "git+https://github.com/novonotes/wxp.git?rev=a7494eb35d661df355217be5ed75ab832cfbcd44#a7494eb35d661df355217be5ed75ab832cfbcd44"
 dependencies = [
  "async-trait",
  "directories",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-novonotes_run_loop = { git = "https://github.com/novonotes/wxp.git", package = "novonotes_run_loop", rev = "6a55e6d83cb07ecc5d56cd3a5f8418e027320dd6" }
-run_loop_timer = { git = "https://github.com/novonotes/wxp.git", package = "run_loop_timer", rev = "6a55e6d83cb07ecc5d56cd3a5f8418e027320dd6" }
+novonotes_run_loop = { git = "https://github.com/novonotes/wxp.git", package = "novonotes_run_loop", rev = "a7494eb35d661df355217be5ed75ab832cfbcd44" }
+run_loop_timer = { git = "https://github.com/novonotes/wxp.git", package = "run_loop_timer", rev = "a7494eb35d661df355217be5ed75ab832cfbcd44" }
 wrac_clap_adapter = { path = "crates/wrac_clap_adapter" }
 wrac_wxp_gui = { path = "crates/wrac_wxp_gui" }
-wxp = { git = "https://github.com/novonotes/wxp.git", rev = "6a55e6d83cb07ecc5d56cd3a5f8418e027320dd6" }
+wxp = { git = "https://github.com/novonotes/wxp.git", rev = "a7494eb35d661df355217be5ed75ab832cfbcd44" }

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -143,9 +143,3 @@ In VS Code, select the "Debug gain plugin standalone" configuration and run it.
 
 Debug build logs are written to `.log/<plugin_name> Latest.log`.
 To follow the log, use `tail -f ".log/<plugin_name> Latest.log"` on macOS/Linux, or `Get-Content ".log\<plugin_name> Latest.log" -Wait` in Windows PowerShell.
-
-## Next Steps
-
-Read [architecture.md](architecture.md) to learn about the thread model, communication flow, and parameter change flow.
-
-For wxp usage, see the [wxp README](https://github.com/novonotes/wxp/tree/main/crates/wxp).


### PR DESCRIPTION
## Summary
- Update wxp dependency revisions to the latest main commit.
- Update Cargo.lock git sources to the same revision.
- Remove obsolete setup next steps from the setup guide.

## Verification
- cargo metadata --locked --format-version 1