### PR TITLE
Document GUI thread safety contracts

### DIFF
--- a/crates/wrac_clap_adapter/src/api.rs
+++ b/crates/wrac_clap_adapter/src/api.rs
@@ -69,6 +69,9 @@ pub struct PluginCoreContext {
 /// This is not an API to update the source of truth. The product updates its own store
 /// first, then calls this to report the edit back to the host
 /// (begin → update → end forms one undo unit).
+///
+/// `Send + Sync` allows GUI or control callbacks to share the notifier. It is not
+/// realtime-safe; do not call it from `Processor::process()`.
 pub trait HostParameterEditNotifier: Send + Sync {
     fn begin_edit(&self, parameter_id: u32);
     fn update_edit(&self, parameter_id: u32, value: f64);
@@ -76,6 +79,11 @@ pub trait HostParameterEditNotifier: Send + Sync {
 }
 
 /// Requests the host to resize the GUI client area on behalf of the product (e.g., from the GUI).
+///
+/// This trait is `Send + Sync` because it is stored inside the shared plugin context, not because
+/// every method is meaningful from every thread. Call `request_resize` only from the product's GUI
+/// event path. Do not call it from the audio thread, and do not assume arbitrary background threads
+/// may enter the host's GUI extension safely.
 pub trait HostGuiResizeRequester: Send + Sync {
     fn request_resize(&self, size: GuiSize) -> PluginResult<()>;
 }
@@ -365,7 +373,8 @@ pub trait PluginNotePorts: Send + Sync + 'static {
 /// CLAP params extension. Design assuming the host reads schema and current values from
 /// any thread. In particular, `parameter_value` / `apply_parameter_value` sit close to
 /// the automation/flush and audio processing boundary, so keep them in a store that does
-/// not share locks the audio thread waits on.
+/// not share locks the audio thread waits on. Do not do GUI dispatch, file IO, or host
+/// callbacks from these methods.
 pub trait PluginParameters: Send + Sync + 'static {
     fn parameter_count(&self) -> u32;
     fn parameter_info(&self, index: u32) -> Option<ParameterInfo>;
@@ -402,6 +411,7 @@ pub trait PluginStateSupport: Send + Sync + 'static {
 
 /// CLAP gui extension. GUI backend thread affinity must be enforced within this trait
 /// (the adapter does not marshal callbacks to the UI thread).
+/// This is not a realtime-safe API and must never be called from `Processor::process()`.
 ///
 /// `get_size`/`can_resize`/`resize_hints` may be re-entered during host layout
 /// computation. Answer from cached size or static hints without entering heavy mutations.
@@ -458,6 +468,9 @@ pub trait PluginLatency: Send + Sync + 'static {
 /// lock and from GUI/project state. State passed in must be either an immutable snapshot
 /// copied at activate time, or atomic/lock-free shared state the audio thread never
 /// waits on (even when passing `Arc<Mutex<_>>`, design it so process() never locks).
+///
+/// `Send` lets the adapter move the processor to the audio owner. `Sync` is intentionally
+/// not required because the adapter calls it through exclusive `&mut self` access.
 pub trait Processor: Send {
     fn reset(&mut self) {}
     fn process(&mut self, context: ProcessContext<'_>) -> PluginResult<ProcessStatus>;

--- a/crates/wrac_clap_adapter/src/host_gui.rs
+++ b/crates/wrac_clap_adapter/src/host_gui.rs
@@ -39,8 +39,8 @@ struct HostGuiRequestResize {
 }
 
 // The instance lifetime of the host pointer is the minimal unavoidable assumption of the
-// CLAP ABI. Use is limited to request_resize from the GUI thread; the raw pointer is
-// not exposed to product code.
+// CLAP ABI. This handle is Send/Sync only so it can live in shared plugin context; callers
+// must still use request_resize from the GUI event path, not from audio/background work.
 unsafe impl Send for HostGuiRequestResize {}
 unsafe impl Sync for HostGuiRequestResize {}
 

--- a/crates/wrac_wxp_gui/src/controller.rs
+++ b/crates/wrac_wxp_gui/src/controller.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
-use novonotes_run_loop::RunLoop;
 use parking_lot::Mutex;
 use wrac_clap_adapter::{
     ClapWindow, GuiApi, GuiConfiguration, GuiResizeHints, GuiSize, HostGuiResizeRequester,
@@ -27,6 +26,9 @@ pub struct GuiSizeLimits {
 /// The actual runtime lives in TLS on the UI thread; this type receives GUI lifecycle
 /// callbacks as the [`PluginGui`] handle shared across CLAP instances. Only embedded GUI
 /// (attached as a child view to the host parent) is supported; floating windows are rejected.
+/// Methods may be entered from host callback threads; GUI runtime work is serialized through the
+/// GUI run loop once a parent has established the owning GUI thread.
+/// This controller is not realtime-safe; do not call it from the audio callback.
 pub struct WxpGuiController {
     factory: Arc<dyn WxpGuiFactory>,
     layout: Arc<HostGuiLayout>,
@@ -87,6 +89,15 @@ pub struct WxpGuiResizeHandle {
     layout: Arc<HostGuiLayout>,
     scale: Arc<Mutex<f64>>,
 }
+
+const _: () = {
+    fn assert_send_sync<T: Send + Sync>() {}
+
+    // These handles are intentionally shared with host callbacks and product command handlers.
+    // Thread-affine native GUI objects remain behind run-loop dispatch/TLS.
+    let _ = assert_send_sync::<WxpGuiController>;
+    let _ = assert_send_sync::<WxpGuiResizeHandle>;
+};
 
 impl WxpGuiController {
     pub fn new_with_resize_handle(
@@ -156,7 +167,7 @@ fn schedule_runtime_creation(
     // makes host lifecycle re-entry more likely. Posting to the run loop centralizes
     // creation serialization, pending visibility/size application, and stale-generation
     // teardown in one place.
-    let (configuration, parent) = {
+    let (configuration, parent, sender) = {
         let mut state = runtime.lock();
         if state.is_creating_runtime {
             log::debug!(
@@ -176,19 +187,24 @@ fn schedule_runtime_creation(
             return Ok(());
         }
         let parent = session.parent.ok_or(PluginError::InvalidState)?;
+        let sender = session
+            .parent_lease
+            .as_ref()
+            .ok_or(PluginError::InvalidState)?
+            .sender();
         let configuration = session.configuration;
         state.is_creating_runtime = true;
         state.creating_generation = Some(generation);
         state.pending_creation_generation = None;
         state.destroy_requested_while_creating = false;
-        (configuration, parent)
+        (configuration, parent, sender)
     };
 
     log::debug!("wxp controller: posting runtime creation: generation={generation}");
     let factory_for_callback = factory.clone();
     let runtime_for_callback = runtime.clone();
     let layout_for_callback = layout.clone();
-    RunLoop::sender().send(move || {
+    sender.send(move || {
             log::debug!("wxp controller: posted runtime creation started: generation={generation}");
             let result = create_runtime_on_gui_thread(
                 factory_for_callback.as_ref(),
@@ -564,12 +580,19 @@ impl WxpGuiResizeHandle {
         }
     }
 
+    /// Requests a host-approved resize from the GUI event path and mirrors accepted bounds to wxp.
+    ///
+    /// `WxpGuiResizeHandle` is `Send + Sync` so command registration can share it, but this method
+    /// should be called by GUI commands/events. It is not suitable for audio-thread or generic
+    /// background-thread use because it enters the host GUI resize extension.
     pub fn request_resize(
         &self,
         requested: LogicalSize<f64>,
         web_view: &WebViewDispatch,
         host_gui_resize_requester: &dyn HostGuiResizeRequester,
     ) -> PluginResult<GuiSize> {
+        // This method is intended for GUI command handlers. `HostGuiResizeRequester` is stored in
+        // Send/Sync context, but host GUI resize calls are not real-time or arbitrary-thread APIs.
         let logical_size = self.layout.clamp_logical_size(requested);
         let gui_size = GuiSize {
             width: logical_size.width as u32,

--- a/crates/wrac_wxp_gui/src/runtime.rs
+++ b/crates/wrac_wxp_gui/src/runtime.rs
@@ -40,17 +40,25 @@ struct GuiRuntimeEntry {
 
 /// RAII token representing a reference to the GUI thread's run loop.
 ///
+/// The token is `Send + Sync` because `WxpGuiController` is shared with host callbacks,
+/// but the run-loop reference itself is released on the GUI thread captured at acquisition.
+/// Dropping this token from another host thread blocks until `RunLoop::deinit()` has run
+/// on the owning GUI thread.
+///
 /// TODO: once `novonotes_run_loop` gains a transactional guard API, this type should
 /// become a thin wrapper around it. The current `RunLoop::init()` does not guarantee
 /// full rollback on failure, so the local state is not advanced beyond what can be
 /// safely undone.
-pub(crate) struct GuiThreadLease;
+pub(crate) struct GuiThreadLease {
+    owner: ThreadId,
+    sender: RunLoopSender,
+}
 
 /// The actual WebView runtime owned by the UI thread.
 ///
-/// Not requiring `Send` / `Sync` is intentional: native GUI objects are bound to the
-/// thread that created them, so operations are dispatched back through the run loop via
-/// `GuiRuntimeHandle`.
+/// `Send` / `Sync` are intentionally not required: implementations may hold
+/// GUI-thread-owned toolkit state such as native WebViews, `Rc`, or `RefCell`.
+/// Host-facing thread defense belongs in [`WxpGuiController`](crate::WxpGuiController).
 pub trait WxpGuiRuntime: 'static {
     fn set_scale(&mut self, scale: f64) -> PluginResult<()>;
     fn set_size(&mut self, size: GuiSize) -> PluginResult<()>;
@@ -66,6 +74,7 @@ pub trait WxpGuiRuntime: 'static {
 ///
 /// The factory itself is `Send + Sync` because it is held inside `PluginCore`, but the
 /// runtime it returns does not need to be `Send` — it lives in the UI thread's TLS.
+/// Runtime creation may allocate and touch native GUI APIs; it is not realtime-safe.
 pub trait WxpGuiFactory: Send + Sync + 'static {
     fn create_gui_runtime(
         &self,
@@ -234,13 +243,21 @@ impl GuiThreadLease {
         // Advance the owner only after `RunLoop::init()` succeeds. The dependency's init
         // does not guarantee full rollback on failure, so at least keep our own source of
         // truth clean.
+        let sender = RunLoop::sender();
         gui_thread.owner = Some(current_thread);
         gui_thread.ref_count += 1;
         log::debug!(
             "wxp GUI thread lease: acquired on thread {current_thread:?}; ref_count={}",
             gui_thread.ref_count
         );
-        Ok(Self)
+        Ok(Self {
+            owner: current_thread,
+            sender,
+        })
+    }
+
+    pub(crate) fn sender(&self) -> RunLoopSender {
+        self.sender.clone()
     }
 }
 
@@ -248,7 +265,15 @@ impl Drop for GuiThreadLease {
     fn drop(&mut self) {
         let current_thread = std::thread::current().id();
         log::debug!("wxp GUI thread lease: dropping on thread {current_thread:?}");
-        RunLoop::deinit();
+        if current_thread == self.owner {
+            RunLoop::deinit();
+        } else {
+            log::debug!(
+                "wxp GUI thread lease: dispatching deinit from thread {current_thread:?} to owner {:?}",
+                self.owner
+            );
+            self.sender.send_and_wait(RunLoop::deinit);
+        }
         let mut gui_thread = GUI_THREAD_STATE.lock();
         debug_assert!(gui_thread.ref_count > 0);
         gui_thread.ref_count = gui_thread.ref_count.saturating_sub(1);


### PR DESCRIPTION
## Summary
- Document GUI and host callback thread-safety contracts in adapter traits
- Make WxpGuiController use the captured GUI run-loop sender for runtime creation
- Ensure GuiThreadLease deinitializes the run loop on the owning GUI thread

## Verification
- cargo fmt --all -- --check
- cargo check -p wrac_clap_adapter -p wrac_wxp_gui
- cargo clippy -p wrac_clap_adapter -p wrac_wxp_gui --all-targets --all-features -- -D warnings
- cargo test -p wrac_clap_adapter -p wrac_wxp_gui --all-features