### PR TITLE
Document AAX and AUv3 status

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ No. This repository is an implementation example and starting point, not a gener
 
 Yes. This repository is licensed under the MIT License, which permits commercial use. Open-source, freeware, and commercial releases built from this template are all welcome.
 
+### What about AAX and AUv3 support?
+
+AAX and AUv3 support are ongoing. `clap-wrapper` already has AAX support on its `next` branch, and NovoNotes is using it for internal macOS AAX builds. AUv3 support also has open `clap-wrapper` pull requests, but NovoNotes has not verified it yet. This template still exposes only CLAP / VST3 / AU / Standalone as supported `xtask` targets.
+
 ## Build
 
 Common commands:

--- a/README_JA.md
+++ b/README_JA.md
@@ -73,6 +73,10 @@ npm run dev
 
 はい。このリポジトリは MIT License で公開されており、商用利用が可能です。このテンプレートを元にしたオープンソース、フリーウェア、商用リリースのいずれも歓迎です。
 
+### AAX / AUv3 対応はありますか
+
+AAX / AUv3 対応は進行中です。`clap-wrapper` の `next` ブランチにはすでに AAX 対応が入っており、NovoNotes 社内では macOS AAX ビルドに利用しています。AUv3 対応も `clap-wrapper` に PR はありますが、NovoNotes ではまだ検証していません。このテンプレートの `xtask` target としては、現時点では CLAP / VST3 / AU / Standalone のみを公開しています。
+
 ## ビルド
 
 代表的なコマンド:


### PR DESCRIPTION
## Summary
- Add FAQ entry for ongoing AAX and AUv3 support status
- Clarify that this template currently exposes CLAP / VST3 / AU / Standalone as supported xtask targets

## Verification
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-features