### PR TITLE
Expose host state dirty notifications

### DIFF
--- a/crates/wrac_clap_adapter/src/abi.rs
+++ b/crates/wrac_clap_adapter/src/abi.rs
@@ -49,6 +49,7 @@ use crate::descriptor::{
     auv2_factory_ptr, auv2_factory_state, clap_factory_state, factory_ptr,
 };
 use crate::host_gui::HostGuiResizeRequest;
+use crate::host_state::HostStateDirtyNotification;
 use crate::params::ParameterEditQueue;
 use crate::{
     ActivateContext, PluginAudioPorts, PluginConfigurableAudioPorts, PluginCore, PluginCoreContext,
@@ -123,6 +124,7 @@ impl PluginInstance {
         // host pointers or CLAP event lifetimes.
         let context = PluginCoreContext {
             host_parameter_edit_notifier: parameter_edits.clone(),
+            host_state_dirty_notifier: Arc::new(HostStateDirtyNotification::new(host)),
             host_gui_resize_requester: Arc::new(HostGuiResizeRequest::new(host)),
         };
         let core = (registration.create)(context);

--- a/crates/wrac_clap_adapter/src/api.rs
+++ b/crates/wrac_clap_adapter/src/api.rs
@@ -60,6 +60,7 @@ impl From<AudioBufferError> for PluginError {
 #[derive(Clone)]
 pub struct PluginCoreContext {
     pub host_parameter_edit_notifier: Arc<dyn HostParameterEditNotifier>,
+    pub host_state_dirty_notifier: Arc<dyn HostStateDirtyNotifier>,
     pub host_gui_resize_requester: Arc<dyn HostGuiResizeRequester>,
 }
 
@@ -73,6 +74,14 @@ pub trait HostParameterEditNotifier: Send + Sync {
     fn begin_edit(&self, parameter_id: u32);
     fn update_edit(&self, parameter_id: u32, value: f64);
     fn end_edit(&self, parameter_id: u32);
+}
+
+/// Notifies the host that non-parameter project state changed and should be saved.
+///
+/// This maps to CLAP `clap_host_state.mark_dirty()`. Use it for plugin-owned document
+/// state, not for parameter automation gestures.
+pub trait HostStateDirtyNotifier: Send + Sync {
+    fn mark_dirty(&self);
 }
 
 /// Requests the host to resize the GUI client area on behalf of the product (e.g., from the GUI).

--- a/crates/wrac_clap_adapter/src/host_state.rs
+++ b/crates/wrac_clap_adapter/src/host_state.rs
@@ -1,0 +1,56 @@
+use clap_sys::ext::state::{CLAP_EXT_STATE, clap_host_state};
+use clap_sys::host::clap_host;
+
+use crate::HostStateDirtyNotifier;
+
+pub(crate) struct HostStateDirtyNotification {
+    host_state: Option<HostStateMarkDirty>,
+}
+
+impl HostStateDirtyNotification {
+    pub(crate) fn new(host: *const clap_host) -> Self {
+        Self {
+            host_state: host_state_mark_dirty(host),
+        }
+    }
+}
+
+impl HostStateDirtyNotifier for HostStateDirtyNotification {
+    fn mark_dirty(&self) {
+        let Some(host_state) = self.host_state else {
+            log::debug!("host_state.mark_dirty: host state extension unavailable");
+            return;
+        };
+
+        unsafe {
+            (host_state.mark_dirty)(host_state.host);
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct HostStateMarkDirty {
+    host: *const clap_host,
+    mark_dirty: unsafe extern "C" fn(host: *const clap_host),
+}
+
+// The instance lifetime of the host pointer is the minimal unavoidable assumption of the
+// CLAP ABI. Products only receive the safe notifier, not the raw pointer.
+unsafe impl Send for HostStateMarkDirty {}
+unsafe impl Sync for HostStateMarkDirty {}
+
+fn host_state_mark_dirty(host: *const clap_host) -> Option<HostStateMarkDirty> {
+    if host.is_null() {
+        return None;
+    }
+
+    unsafe {
+        let get_extension = (*host).get_extension?;
+        let state = get_extension(host, CLAP_EXT_STATE.as_ptr()) as *const clap_host_state;
+        if state.is_null() {
+            return None;
+        }
+        let mark_dirty = (*state).mark_dirty?;
+        Some(HostStateMarkDirty { host, mark_dirty })
+    }
+}

--- a/crates/wrac_clap_adapter/src/lib.rs
+++ b/crates/wrac_clap_adapter/src/lib.rs
@@ -10,14 +10,15 @@ mod api;
 mod descriptor;
 mod events;
 mod host_gui;
+mod host_state;
 mod params;
 mod process_buffer;
 
 pub use api::{
     ActivateContext, AudioPortConfigurationRequest, AudioPortFlags, AudioPortInfo, AudioPortType,
     ClapWindow, GuiApi, GuiConfiguration, GuiResizeHints, GuiSize, HostGuiResizeRequester,
-    HostParameterEditNotifier, NoteDialects, NotePortInfo, ParameterFlags, ParameterInfo,
-    ParameterValueEvent, PluginAudioPorts, PluginConfigurableAudioPorts, PluginCore,
+    HostParameterEditNotifier, HostStateDirtyNotifier, NoteDialects, NotePortInfo, ParameterFlags,
+    ParameterInfo, ParameterValueEvent, PluginAudioPorts, PluginConfigurableAudioPorts, PluginCore,
     PluginCoreContext, PluginError, PluginGui, PluginLatency, PluginNotePorts, PluginParameters,
     PluginRender, PluginResult, PluginState, PluginStateSupport, PluginTail, ProcessContext,
     ProcessStatus, Processor, RenderMode,


### PR DESCRIPTION
## Summary
- Add a safe HostStateDirtyNotifier adapter API for CLAP host state dirty notifications
- Query clap_host_state.mark_dirty from the host and expose it through PluginCoreContext
- Keep non-parameter document dirty reporting separate from parameter automation edits

## Verification
- cargo fmt --check
- cargo test -p wrac_clap_adapter
- cargo clippy -p wrac_clap_adapter -- -D warnings