### PR TITLE
Refactor Entry/Factory and realtime logging foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2832,9 +2832,18 @@ dependencies = [
  "serde_json",
  "time",
  "wrac_clap_adapter",
+ "wrac_log",
  "wrac_wxp_gui",
  "wxp",
  "zip 2.4.2",
+]
+
+[[package]]
+name = "wrac_log"
+version = "0.1.0"
+dependencies = [
+ "log",
+ "time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "src-plugin",
     "xtask",
     "crates/wrac_clap_adapter",
+    "crates/wrac_log",
     "crates/wrac_wxp_gui",
 ]
 resolver = "2"
@@ -11,5 +12,6 @@ resolver = "2"
 novonotes_run_loop = { git = "https://github.com/novonotes/wxp.git", package = "novonotes_run_loop", rev = "a7494eb35d661df355217be5ed75ab832cfbcd44" }
 run_loop_timer = { git = "https://github.com/novonotes/wxp.git", package = "run_loop_timer", rev = "a7494eb35d661df355217be5ed75ab832cfbcd44" }
 wrac_clap_adapter = { path = "crates/wrac_clap_adapter" }
+wrac_log = { path = "crates/wrac_log" }
 wrac_wxp_gui = { path = "crates/wrac_wxp_gui" }
 wxp = { git = "https://github.com/novonotes/wxp.git", rev = "a7494eb35d661df355217be5ed75ab832cfbcd44" }

--- a/crates/wrac_clap_adapter/README.md
+++ b/crates/wrac_clap_adapter/README.md
@@ -1,7 +1,7 @@
 # wrac_clap_adapter
 
 Defines the traits that each product crate must implement,
-and provides an adapter that maps those trait implementations to the CLAP ABI so they can be used as a plugin.
+and provides an adapter that maps those trait implementations to the CLAP ABI so they can be used as plugins.
 
 Conversion to VST3 / AU / AAX is the responsibility of `clap-wrapper`. This crate focuses solely on implementing CLAP plugins and CLAP extensions on the Rust side.
 
@@ -23,6 +23,8 @@ This crate, on the other hand, also targets VST3/AU/AAX hosts via `clap-wrapper`
 
 ## Public API
 
+- `PluginEntry`: DSO-level lifecycle and typed factory provider
+- `PluginFactory`: CLAP `clap.plugin-factory`
 - `PluginCore`: instance lifecycle and declaration of supported extensions
 - `PluginAudioPorts`: CLAP `audio-ports`
 - `PluginConfigurableAudioPorts`: CLAP `configurable-audio-ports`
@@ -33,7 +35,7 @@ This crate, on the other hand, also targets VST3/AU/AAX hosts via `clap-wrapper`
 - `PluginRender`: CLAP `render`
 - `PluginTail`: CLAP `tail`
 - `PluginLatency`: CLAP `latency`
-- `export_clap_plugin!`: exports the CLAP entry point
+- `export_clap_entry!`: exports the CLAP entry point
 
 Each trait is a thin Rust representation of the corresponding CLAP C ABI. This crate is not designed as a general plugin framework.
 
@@ -48,4 +50,4 @@ Additionally, full CLAP ABI coverage is not yet complete. Known limitations:
 - `params`: value rescan after state restore is supported, but a dynamic rescan API for the parameter schema itself is not provided
 - Output event batching helpers are minimal (sample-accurate event ordering is the product's responsibility)
 - The `audio-ports-activation` extension is not implemented
-- Exporting multiple plugins from a single binary is not supported
+- Typed factories other than plugin factory and AUv2 wrapper info are not implemented yet

--- a/crates/wrac_clap_adapter/src/abi.rs
+++ b/crates/wrac_clap_adapter/src/abi.rs
@@ -1,6 +1,6 @@
 //! Module that binds the CLAP ABI to `PluginCore` instances.
 //!
-//! The public API is surfaced through re-exports in `lib.rs` and `export_clap_plugin!`.
+//! The public API is surfaced through re-exports in `lib.rs` and `export_clap_entry!`.
 //! This module is responsible only for C ABI callbacks and owning the adapter state.
 
 use std::cell::UnsafeCell;
@@ -44,9 +44,13 @@ mod tail_extension;
 
 use self::audio_buffers::audio_buffers;
 use self::ffi::{ffi_bool, ffi_ptr, ffi_status, ffi_unit, four_char_code};
-use crate::descriptor::{
-    Auv2FactoryState, ClapPluginFactoryAsAuv2, ClapPluginInfoAsAuv2, PluginRegistration,
-    auv2_factory_ptr, auv2_factory_state, clap_factory_state, factory_ptr,
+use crate::entry::{
+    EntryContext, EntryRegistration, decrement_entry_init_count, entry_init_count,
+    increment_entry_init_count, reset_entry_init_count,
+};
+use crate::factory::{
+    Auv2FactoryState, ClapPluginFactoryAsAuv2, ClapPluginInfoAsAuv2, auv2_factory_ptr,
+    auv2_factory_state, clap_factory_state, factory_ptr,
 };
 use crate::host_gui::HostGuiResizeRequest;
 use crate::host_state::HostStateDirtyNotification;
@@ -118,7 +122,12 @@ unsafe impl Send for PluginInstance {}
 unsafe impl Sync for PluginInstance {}
 
 impl PluginInstance {
-    fn new(registration: &'static PluginRegistration, host: *const clap_host) -> Box<Self> {
+    fn new(
+        registration: &'static EntryRegistration,
+        descriptor_index: usize,
+        plugin_id: &CStr,
+        host: *const clap_host,
+    ) -> Option<Box<Self>> {
         let parameter_edits = Arc::new(ParameterEditQueue::new(host));
         // Pass as a safe proxy so product GUI code can hold it without knowing about
         // host pointers or CLAP event lifetimes.
@@ -127,7 +136,10 @@ impl PluginInstance {
             host_state_dirty_notifier: Arc::new(HostStateDirtyNotification::new(host)),
             host_gui_resize_requester: Arc::new(HostGuiResizeRequest::new(host)),
         };
-        let core = (registration.create)(context);
+        let core = registration
+            .entry
+            .plugin_factory()?
+            .create_plugin(plugin_id, context)?;
         // Freeze capabilities here, before callbacks begin. Waiting on the core lock
         // inside get_extension would make us dependent on host re-entry order. The Arc
         // is just an entry point; the source of truth remains in the plugin's store.
@@ -153,9 +165,9 @@ impl PluginInstance {
         };
         let storage = registration.storage();
 
-        Box::new(Self {
+        Some(Box::new(Self {
             plugin: clap_plugin {
-                desc: storage.descriptor.clap_descriptor(),
+                desc: storage.descriptors.get(descriptor_index)?.clap_descriptor(),
                 plugin_data: ptr::null_mut(),
                 init: Some(plugin_init),
                 destroy: Some(plugin_destroy),
@@ -184,7 +196,7 @@ impl PluginInstance {
             processor: UnsafeCell::new(None),
             processor_busy: AtomicBool::new(false),
             lifecycle_busy: AtomicBool::new(false),
-        })
+        }))
     }
 
     pub(crate) unsafe fn from_plugin<'a>(plugin: *const clap_plugin) -> Option<&'a Self> {
@@ -301,24 +313,52 @@ impl Drop for LifecycleGuard<'_> {
 /// `plugin_path` must be a valid CLAP string pointer when provided by the host.
 /// The registration must be the static registration generated for this binary.
 pub unsafe extern "C" fn entry_init(
-    _registration: &'static PluginRegistration,
-    _plugin_path: *const c_char,
+    registration: &'static EntryRegistration,
+    plugin_path: *const c_char,
 ) -> bool {
-    true
+    ffi_bool(|| {
+        let count = increment_entry_init_count(registration);
+        if count > 1 {
+            return true;
+        }
+
+        let plugin_path = if plugin_path.is_null() {
+            None
+        } else {
+            Some(unsafe { CStr::from_ptr(plugin_path) })
+        };
+        if let Err(error) = registration.entry.init(EntryContext { plugin_path }) {
+            log::warn!("entry.init: product init failed: {error}");
+            reset_entry_init_count(registration);
+            return false;
+        }
+        true
+    })
 }
 
 /// # Safety
 ///
 /// The registration must be the same static registration previously passed to
 /// `entry_init` for this binary.
-pub unsafe extern "C" fn entry_deinit(_registration: &'static PluginRegistration) {}
+pub unsafe extern "C" fn entry_deinit(registration: &'static EntryRegistration) {
+    ffi_unit(|| {
+        if entry_init_count(registration) == 0 {
+            log::warn!("entry.deinit: called while entry is not initialized");
+            return;
+        }
+        let count = decrement_entry_init_count(registration);
+        if count == 0 {
+            registration.entry.deinit();
+        }
+    })
+}
 
 /// # Safety
 ///
 /// `factory_id` must be null or point to a valid NUL-terminated CLAP factory id.
 /// The returned pointer is owned by the static plugin registration storage.
 pub unsafe extern "C" fn entry_get_factory(
-    registration: &'static PluginRegistration,
+    registration: &'static EntryRegistration,
     factory_id: *const c_char,
 ) -> *const c_void {
     ffi_ptr(|| {
@@ -330,7 +370,10 @@ pub unsafe extern "C" fn entry_get_factory(
         if factory_id == CLAP_PLUGIN_FACTORY_ID {
             factory_ptr(storage)
         } else if factory_id == CLAP_PLUGIN_FACTORY_INFO_AUV2
-            && registration.descriptor.auv2.is_some()
+            && storage
+                .descriptors
+                .iter()
+                .any(|descriptor| descriptor.descriptor().auv2.is_some())
         {
             auv2_factory_ptr(storage)
         } else {
@@ -345,7 +388,7 @@ pub(crate) unsafe extern "C" fn auv2_get_info(
     info: *mut ClapPluginInfoAsAuv2,
 ) -> bool {
     ffi_bool(|| {
-        if index != 0 || info.is_null() {
+        if info.is_null() {
             log::warn!(
                 "auv2.get_info: invalid arguments index={index} info_is_null={}",
                 info.is_null()
@@ -357,8 +400,12 @@ pub(crate) unsafe extern "C" fn auv2_get_info(
             log::warn!("auv2.get_info: invalid factory pointer");
             return false;
         };
-        let Some(auv2) = registration.descriptor.auv2 else {
-            log::warn!("auv2.get_info: registration has no AUv2 descriptor");
+        let Some(descriptor) = registration.storage().descriptors.get(index as usize) else {
+            log::warn!("auv2.get_info: descriptor not found index={index}");
+            return false;
+        };
+        let Some(auv2) = descriptor.descriptor().auv2 else {
+            log::warn!("auv2.get_info: descriptor has no AUv2 info index={index}");
             return false;
         };
 
@@ -371,25 +418,28 @@ pub(crate) unsafe extern "C" fn auv2_get_info(
 }
 
 pub(crate) unsafe extern "C" fn factory_get_plugin_count(
-    _factory: *const clap_plugin_factory,
+    factory: *const clap_plugin_factory,
 ) -> u32 {
-    1
+    let Some(state) = clap_factory_state(factory) else {
+        log::warn!("factory.get_plugin_count: invalid factory pointer");
+        return 0;
+    };
+    state.registration.storage().descriptors.len() as u32
 }
 
 pub(crate) unsafe extern "C" fn factory_get_plugin_descriptor(
     factory: *const clap_plugin_factory,
     index: u32,
 ) -> *const clap_plugin_descriptor {
-    if index != 0 {
-        log::warn!("factory.get_plugin_descriptor: invalid index={index}");
-        return ptr::null();
-    }
-
     let Some(state) = clap_factory_state(factory) else {
         log::warn!("factory.get_plugin_descriptor: invalid factory pointer");
         return ptr::null();
     };
-    state.registration.storage().descriptor.clap_descriptor()
+    let Some(descriptor) = state.registration.storage().descriptors.get(index as usize) else {
+        log::warn!("factory.get_plugin_descriptor: invalid index={index}");
+        return ptr::null();
+    };
+    descriptor.clap_descriptor()
 }
 
 pub(crate) unsafe extern "C" fn factory_create_plugin(
@@ -416,13 +466,24 @@ pub(crate) unsafe extern "C" fn factory_create_plugin(
             return ptr::null();
         };
         let registration = factory_state.registration;
-        if unsafe { CStr::from_ptr(plugin_id) }.to_bytes() != registration.descriptor.id.as_bytes()
-        {
+        let plugin_id = unsafe { CStr::from_ptr(plugin_id) };
+        let storage = registration.storage();
+        let Some((descriptor_index, _descriptor)) = storage
+            .descriptors
+            .iter()
+            .enumerate()
+            .find(|(_, descriptor)| descriptor.descriptor().id.as_bytes() == plugin_id.to_bytes())
+        else {
             log::warn!("factory.create_plugin: requested unknown plugin id");
             return ptr::null();
-        }
+        };
 
-        let mut instance = PluginInstance::new(registration, host);
+        let Some(mut instance) =
+            PluginInstance::new(registration, descriptor_index, plugin_id, host)
+        else {
+            log::warn!("factory.create_plugin: product factory returned no plugin core");
+            return ptr::null();
+        };
         let instance_ptr = (&mut *instance) as *mut PluginInstance;
         instance.plugin.plugin_data = instance_ptr.cast();
         let plugin_ptr = &instance.plugin as *const clap_plugin;

--- a/crates/wrac_clap_adapter/src/descriptor.rs
+++ b/crates/wrac_clap_adapter/src/descriptor.rs
@@ -1,8 +1,6 @@
-use std::ffi::{CStr, CString, c_char, c_void};
+use std::ffi::{CStr, CString, c_char};
 use std::ptr;
-use std::sync::OnceLock;
 
-use clap_sys::factory::plugin_factory::clap_plugin_factory;
 use clap_sys::plugin::clap_plugin_descriptor;
 use clap_sys::plugin_features::{
     CLAP_PLUGIN_FEATURE_AMBISONIC, CLAP_PLUGIN_FEATURE_ANALYZER, CLAP_PLUGIN_FEATURE_AUDIO_EFFECT,
@@ -21,10 +19,6 @@ use clap_sys::plugin_features::{
     CLAP_PLUGIN_FEATURE_TRANSIENT_SHAPER, CLAP_PLUGIN_FEATURE_TREMOLO, CLAP_PLUGIN_FEATURE_UTILITY,
 };
 use clap_sys::version::CLAP_VERSION;
-
-use crate::{PluginCore, PluginCoreContext};
-
-pub(crate) type CreatePluginCore = fn(PluginCoreContext) -> Box<dyn PluginCore>;
 
 #[derive(Debug, Clone, Copy)]
 pub struct PluginDescriptor {
@@ -137,121 +131,11 @@ pub struct Auv2Descriptor {
     pub plugin_subtype: [u8; 4],
 }
 
-/// Descriptor and factory function fixed for the plugin binary.
-///
-/// The factory callback may be called at any time, so it is stored statically. Being
-/// immutable allows it to be passed to the C ABI without relying on a global mutable
-/// registry or pointer leaks.
-pub struct PluginRegistration {
-    pub(crate) descriptor: PluginDescriptor,
-    pub(crate) create: CreatePluginCore,
-    storage: OnceLock<PluginRegistrationStorage>,
-}
-
-// Safety: `descriptor` and `create` are immutable data in the static registration;
-// mutable state is synchronized by `OnceLock`. Factory queries from multiple threads
-// via the C ABI return only shared references.
-unsafe impl Sync for PluginRegistration {}
-unsafe impl Send for PluginRegistration {}
-
-impl PluginRegistration {
-    pub const fn new(descriptor: PluginDescriptor, create: CreatePluginCore) -> Self {
-        Self {
-            descriptor,
-            create,
-            storage: OnceLock::new(),
-        }
-    }
-
-    pub(crate) fn storage(&'static self) -> &'static PluginRegistrationStorage {
-        self.storage
-            .get_or_init(|| PluginRegistrationStorage::new(self))
-    }
-}
-
-pub(crate) struct PluginRegistrationStorage {
-    pub clap_factory: ClapFactoryState,
-    pub auv2_factory: Auv2FactoryState,
-    pub descriptor: ClapDescriptorStorage,
-}
-
-// Safety: after creation the storage only reads out factory/descriptor pointers.
-// Internal pointers point to buffers owned by this same storage, and `OnceLock`
-// prevents initialization races.
-unsafe impl Sync for PluginRegistrationStorage {}
-unsafe impl Send for PluginRegistrationStorage {}
-
-impl PluginRegistrationStorage {
-    fn new(registration: &'static PluginRegistration) -> Self {
-        let descriptor = ClapDescriptorStorage::new(registration.descriptor);
-        Self {
-            clap_factory: ClapFactoryState {
-                factory: clap_plugin_factory {
-                    get_plugin_count: Some(crate::abi::factory_get_plugin_count),
-                    get_plugin_descriptor: Some(crate::abi::factory_get_plugin_descriptor),
-                    create_plugin: Some(crate::abi::factory_create_plugin),
-                },
-                registration,
-            },
-            auv2_factory: Auv2FactoryState {
-                factory: ClapPluginFactoryAsAuv2 {
-                    manufacturer_code: descriptor.auv2_manufacturer_code_ptr(),
-                    manufacturer_name: descriptor.auv2_manufacturer_name_ptr(),
-                    get_auv2_info: Some(crate::abi::auv2_get_info),
-                },
-                registration,
-            },
-            descriptor,
-        }
-    }
-}
-
-// CLAP factory callbacks receive only a factory pointer, so the C ABI struct is placed
-// as the first field and cast back to the state inside the callback.
-#[repr(C)]
-pub(crate) struct ClapFactoryState {
-    pub factory: clap_plugin_factory,
-    pub registration: &'static PluginRegistration,
-}
-
-unsafe impl Sync for ClapFactoryState {}
-unsafe impl Send for ClapFactoryState {}
-
-#[repr(C)]
-pub(crate) struct Auv2FactoryState {
-    pub factory: ClapPluginFactoryAsAuv2,
-    pub registration: &'static PluginRegistration,
-}
-
-unsafe impl Sync for Auv2FactoryState {}
-unsafe impl Send for Auv2FactoryState {}
-
-#[repr(C)]
-pub(crate) struct ClapPluginInfoAsAuv2 {
-    pub au_type: [c_char; 5],
-    pub au_subt: [c_char; 5],
-}
-
-#[repr(C)]
-pub(crate) struct ClapPluginFactoryAsAuv2 {
-    pub manufacturer_code: *const c_char,
-    pub manufacturer_name: *const c_char,
-    pub get_auv2_info: Option<
-        unsafe extern "C" fn(
-            factory: *const ClapPluginFactoryAsAuv2,
-            index: u32,
-            info: *mut ClapPluginInfoAsAuv2,
-        ) -> bool,
-    >,
-}
-
-unsafe impl Sync for ClapPluginFactoryAsAuv2 {}
-unsafe impl Send for ClapPluginFactoryAsAuv2 {}
-
 // `clap_plugin_descriptor` holds only C string pointers, so the owners of the CString
 // and feature pointer arrays are placed in the same storage to keep their lifetimes
 // aligned with the descriptor pointer.
 pub(crate) struct ClapDescriptorStorage {
+    descriptor: PluginDescriptor,
     _id: CString,
     _name: CString,
     _vendor: CString,
@@ -273,7 +157,7 @@ unsafe impl Sync for ClapDescriptorStorage {}
 unsafe impl Send for ClapDescriptorStorage {}
 
 impl ClapDescriptorStorage {
-    fn new(descriptor: PluginDescriptor) -> Self {
+    pub(crate) fn new(descriptor: PluginDescriptor) -> Self {
         let id = cstring(descriptor.id);
         let name = cstring(descriptor.name);
         let vendor = cstring(descriptor.vendor);
@@ -309,6 +193,7 @@ impl ClapDescriptorStorage {
         };
 
         Self {
+            descriptor,
             _id: id,
             _name: name,
             _vendor: vendor,
@@ -328,45 +213,23 @@ impl ClapDescriptorStorage {
         &self.clap_descriptor
     }
 
-    fn auv2_manufacturer_code_ptr(&self) -> *const c_char {
+    pub(crate) fn auv2_manufacturer_code_ptr(&self) -> Option<*const c_char> {
         self.auv2_manufacturer_code
             .as_ref()
-            .map_or(ptr::null(), |value| value.as_ptr())
+            .map(|value| value.as_ptr())
     }
 
-    fn auv2_manufacturer_name_ptr(&self) -> *const c_char {
+    pub(crate) fn auv2_manufacturer_name_ptr(&self) -> Option<*const c_char> {
         self.auv2_manufacturer_name
             .as_ref()
-            .map_or(ptr::null(), |value| value.as_ptr())
+            .map(|value| value.as_ptr())
+    }
+
+    pub(crate) fn descriptor(&self) -> PluginDescriptor {
+        self.descriptor
     }
 }
 
 fn cstring(value: &'static str) -> CString {
     CString::new(value).expect("plugin descriptor strings must not contain NUL bytes")
-}
-
-pub(crate) fn clap_factory_state(
-    factory: *const clap_plugin_factory,
-) -> Option<&'static ClapFactoryState> {
-    if factory.is_null() {
-        return None;
-    }
-    Some(unsafe { &*(factory as *const ClapFactoryState) })
-}
-
-pub(crate) fn auv2_factory_state(
-    factory: *const ClapPluginFactoryAsAuv2,
-) -> Option<&'static Auv2FactoryState> {
-    if factory.is_null() {
-        return None;
-    }
-    Some(unsafe { &*(factory as *const Auv2FactoryState) })
-}
-
-pub(crate) fn factory_ptr(storage: &'static PluginRegistrationStorage) -> *const c_void {
-    &storage.clap_factory.factory as *const clap_plugin_factory as *const c_void
-}
-
-pub(crate) fn auv2_factory_ptr(storage: &'static PluginRegistrationStorage) -> *const c_void {
-    &storage.auv2_factory.factory as *const ClapPluginFactoryAsAuv2 as *const c_void
 }

--- a/crates/wrac_clap_adapter/src/entry.rs
+++ b/crates/wrac_clap_adapter/src/entry.rs
@@ -1,0 +1,95 @@
+use std::ffi::CStr;
+use std::sync::{Mutex, OnceLock};
+
+use crate::factory::PluginRegistrationStorage;
+use crate::{PluginCore, PluginCoreContext, PluginDescriptor, PluginResult};
+
+pub struct EntryContext<'a> {
+    pub plugin_path: Option<&'a CStr>,
+}
+
+pub trait PluginEntry: Send + Sync + 'static {
+    fn init(&self, _context: EntryContext<'_>) -> PluginResult<()> {
+        Ok(())
+    }
+
+    fn deinit(&self) {}
+
+    fn plugin_factory(&self) -> Option<&dyn PluginFactory>;
+}
+
+pub trait PluginFactory: Send + Sync + 'static {
+    fn plugin_count(&self) -> u32;
+    fn plugin_descriptor(&self, index: u32) -> Option<PluginDescriptor>;
+    fn create_plugin(
+        &self,
+        plugin_id: &CStr,
+        context: PluginCoreContext,
+    ) -> Option<Box<dyn PluginCore>>;
+}
+
+/// Static owner for the safe Rust entry and ABI-facing factory storage.
+pub struct EntryRegistration {
+    pub(crate) entry: &'static dyn PluginEntry,
+    storage: OnceLock<PluginRegistrationStorage>,
+    init_state: Mutex<EntryInitState>,
+}
+
+#[derive(Debug, Default)]
+struct EntryInitState {
+    count: u32,
+}
+
+// Safety: `entry` is immutable and all mutable state is synchronized. Factory queries
+// return shared references to storage owned by this registration.
+unsafe impl Sync for EntryRegistration {}
+unsafe impl Send for EntryRegistration {}
+
+impl EntryRegistration {
+    pub const fn new(entry: &'static dyn PluginEntry) -> Self {
+        Self {
+            entry,
+            storage: OnceLock::new(),
+            init_state: Mutex::new(EntryInitState { count: 0 }),
+        }
+    }
+
+    pub(crate) fn storage(&'static self) -> &'static PluginRegistrationStorage {
+        self.storage
+            .get_or_init(|| PluginRegistrationStorage::new(self))
+    }
+}
+
+pub(crate) fn entry_init_count(registration: &'static EntryRegistration) -> u32 {
+    registration
+        .init_state
+        .lock()
+        .map(|state| state.count)
+        .unwrap_or(0)
+}
+
+pub(crate) fn increment_entry_init_count(registration: &'static EntryRegistration) -> u32 {
+    let mut state = registration
+        .init_state
+        .lock()
+        .expect("entry init state mutex poisoned");
+    state.count = state.count.saturating_add(1);
+    state.count
+}
+
+pub(crate) fn decrement_entry_init_count(registration: &'static EntryRegistration) -> u32 {
+    let mut state = registration
+        .init_state
+        .lock()
+        .expect("entry init state mutex poisoned");
+    state.count = state.count.saturating_sub(1);
+    state.count
+}
+
+pub(crate) fn reset_entry_init_count(registration: &'static EntryRegistration) {
+    let mut state = registration
+        .init_state
+        .lock()
+        .expect("entry init state mutex poisoned");
+    state.count = 0;
+}

--- a/crates/wrac_clap_adapter/src/factory.rs
+++ b/crates/wrac_clap_adapter/src/factory.rs
@@ -1,0 +1,127 @@
+use std::ffi::{c_char, c_void};
+use std::ptr;
+
+use clap_sys::factory::plugin_factory::clap_plugin_factory;
+
+use crate::descriptor::ClapDescriptorStorage;
+use crate::entry::EntryRegistration;
+
+pub(crate) struct PluginRegistrationStorage {
+    pub clap_factory: ClapFactoryState,
+    pub auv2_factory: Auv2FactoryState,
+    pub descriptors: Vec<ClapDescriptorStorage>,
+}
+
+// Safety: after creation the storage only reads out factory/descriptor pointers.
+// Internal pointers point to buffers owned by this same storage, and `OnceLock`
+// prevents initialization races.
+unsafe impl Sync for PluginRegistrationStorage {}
+unsafe impl Send for PluginRegistrationStorage {}
+
+impl PluginRegistrationStorage {
+    pub(crate) fn new(registration: &'static EntryRegistration) -> Self {
+        let descriptors = registration
+            .entry
+            .plugin_factory()
+            .map(|factory| {
+                (0..factory.plugin_count())
+                    .filter_map(|index| factory.plugin_descriptor(index))
+                    .map(ClapDescriptorStorage::new)
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        Self {
+            clap_factory: ClapFactoryState {
+                factory: clap_plugin_factory {
+                    get_plugin_count: Some(crate::abi::factory_get_plugin_count),
+                    get_plugin_descriptor: Some(crate::abi::factory_get_plugin_descriptor),
+                    create_plugin: Some(crate::abi::factory_create_plugin),
+                },
+                registration,
+            },
+            auv2_factory: Auv2FactoryState {
+                factory: ClapPluginFactoryAsAuv2 {
+                    manufacturer_code: descriptors
+                        .iter()
+                        .find_map(ClapDescriptorStorage::auv2_manufacturer_code_ptr)
+                        .unwrap_or(ptr::null()),
+                    manufacturer_name: descriptors
+                        .iter()
+                        .find_map(ClapDescriptorStorage::auv2_manufacturer_name_ptr)
+                        .unwrap_or(ptr::null()),
+                    get_auv2_info: Some(crate::abi::auv2_get_info),
+                },
+                registration,
+            },
+            descriptors,
+        }
+    }
+}
+
+// CLAP factory callbacks receive only a factory pointer, so the C ABI struct is placed
+// as the first field and cast back to the state inside the callback.
+#[repr(C)]
+pub(crate) struct ClapFactoryState {
+    pub factory: clap_plugin_factory,
+    pub registration: &'static EntryRegistration,
+}
+
+unsafe impl Sync for ClapFactoryState {}
+unsafe impl Send for ClapFactoryState {}
+
+#[repr(C)]
+pub(crate) struct Auv2FactoryState {
+    pub factory: ClapPluginFactoryAsAuv2,
+    pub registration: &'static EntryRegistration,
+}
+
+unsafe impl Sync for Auv2FactoryState {}
+unsafe impl Send for Auv2FactoryState {}
+
+#[repr(C)]
+pub(crate) struct ClapPluginInfoAsAuv2 {
+    pub au_type: [c_char; 5],
+    pub au_subt: [c_char; 5],
+}
+
+#[repr(C)]
+pub(crate) struct ClapPluginFactoryAsAuv2 {
+    pub manufacturer_code: *const c_char,
+    pub manufacturer_name: *const c_char,
+    pub get_auv2_info: Option<
+        unsafe extern "C" fn(
+            factory: *const ClapPluginFactoryAsAuv2,
+            index: u32,
+            info: *mut ClapPluginInfoAsAuv2,
+        ) -> bool,
+    >,
+}
+
+unsafe impl Sync for ClapPluginFactoryAsAuv2 {}
+unsafe impl Send for ClapPluginFactoryAsAuv2 {}
+
+pub(crate) fn clap_factory_state(
+    factory: *const clap_plugin_factory,
+) -> Option<&'static ClapFactoryState> {
+    if factory.is_null() {
+        return None;
+    }
+    Some(unsafe { &*(factory as *const ClapFactoryState) })
+}
+
+pub(crate) fn auv2_factory_state(
+    factory: *const ClapPluginFactoryAsAuv2,
+) -> Option<&'static Auv2FactoryState> {
+    if factory.is_null() {
+        return None;
+    }
+    Some(unsafe { &*(factory as *const Auv2FactoryState) })
+}
+
+pub(crate) fn factory_ptr(storage: &'static PluginRegistrationStorage) -> *const c_void {
+    &storage.clap_factory.factory as *const clap_plugin_factory as *const c_void
+}
+
+pub(crate) fn auv2_factory_ptr(storage: &'static PluginRegistrationStorage) -> *const c_void {
+    &storage.auv2_factory.factory as *const ClapPluginFactoryAsAuv2 as *const c_void
+}

--- a/crates/wrac_clap_adapter/src/lib.rs
+++ b/crates/wrac_clap_adapter/src/lib.rs
@@ -1,14 +1,16 @@
 //! Adapter crate that connects the CLAP ABI to the plugin core.
 //!
 //! Product crates only need to implement the safe traits in [`api`] and declare
-//! the CLAP entry with [`export_clap_plugin!`]. `clap-sys`, raw pointers, event
+//! the CLAP entry with [`export_clap_entry!`]. `clap-sys`, raw pointers, event
 //! conversion, and host callbacks are all encapsulated inside the adapter.
 //! See `api.rs` for the trait contracts.
 
 mod abi;
 mod api;
 mod descriptor;
+mod entry;
 mod events;
+mod factory;
 mod host_gui;
 mod host_state;
 mod params;
@@ -24,6 +26,7 @@ pub use api::{
     ProcessStatus, Processor, RenderMode,
 };
 pub use descriptor::{Auv2Descriptor, PluginDescriptor, PluginFeature};
+pub use entry::{EntryContext, PluginEntry, PluginFactory};
 pub use events::{
     InputEvent, InputEvents, Midi2Event, MidiEvent, MidiSysexEvent, NoteEvent, NoteExpressionEvent,
     OutputEvent, OutputEvents, ParameterGestureEvent, ParameterModEvent, ProcessEvents,
@@ -41,35 +44,35 @@ pub mod __private {
     pub use std::ffi::{c_char, c_void};
 
     pub use crate::abi::{entry_deinit, entry_get_factory, entry_init};
-    pub use crate::descriptor::PluginRegistration;
+    pub use crate::entry::EntryRegistration;
 }
 
 #[macro_export]
-macro_rules! export_clap_plugin {
-    (descriptor: $descriptor:expr, create: $create:path $(,)?) => {
+macro_rules! export_clap_entry {
+    (entry: $entry:expr $(,)?) => {
         #[allow(non_snake_case)]
         mod __wrac_clap_export {
             // The CLAP entry symbol must appear exactly once per binary, so this macro
             // expands in the product crate rather than in the adapter. The adapter
-            // stays reusable while the static lifetimes of descriptor and factory are
-            // confined to the binary.
-            static WRAC_CLAP_PLUGIN_REGISTRATION: $crate::__private::PluginRegistration =
-                $crate::__private::PluginRegistration::new($descriptor, $create);
+            // stays reusable while entry and factory storage lifetimes are confined to
+            // the binary.
+            static WRAC_CLAP_ENTRY_REGISTRATION: $crate::__private::EntryRegistration =
+                $crate::__private::EntryRegistration::new($entry);
 
             unsafe extern "C" fn wrac_clap_entry_init(
                 plugin_path: *const $crate::__private::c_char,
             ) -> bool {
-                $crate::__private::entry_init(&WRAC_CLAP_PLUGIN_REGISTRATION, plugin_path)
+                $crate::__private::entry_init(&WRAC_CLAP_ENTRY_REGISTRATION, plugin_path)
             }
 
             unsafe extern "C" fn wrac_clap_entry_deinit() {
-                $crate::__private::entry_deinit(&WRAC_CLAP_PLUGIN_REGISTRATION)
+                $crate::__private::entry_deinit(&WRAC_CLAP_ENTRY_REGISTRATION)
             }
 
             unsafe extern "C" fn wrac_clap_entry_get_factory(
                 factory_id: *const $crate::__private::c_char,
             ) -> *const $crate::__private::c_void {
-                $crate::__private::entry_get_factory(&WRAC_CLAP_PLUGIN_REGISTRATION, factory_id)
+                $crate::__private::entry_get_factory(&WRAC_CLAP_ENTRY_REGISTRATION, factory_id)
             }
 
             #[allow(unreachable_pub)]

--- a/crates/wrac_log/Cargo.toml
+++ b/crates/wrac_log/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "wrac_log"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+log = "0.4"
+time = { version = "0.3", features = ["formatting", "local-offset", "macros"] }
+
+[lints.rust]
+unreachable_pub = "deny"

--- a/crates/wrac_log/src/lib.rs
+++ b/crates/wrac_log/src/lib.rs
@@ -301,6 +301,7 @@ impl RtLogInner {
             );
         }
 
+        let mut drained_until = start;
         for sequence in start..total {
             if let Some(record) = self.slots[sequence as usize % RT_LOG_CAPACITY].read(sequence) {
                 log::log!(
@@ -313,9 +314,15 @@ impl RtLogInner {
                     record.sample_time,
                     record.message.as_str(),
                 );
+                drained_until = sequence + 1;
+            } else {
+                // writer は sequence number を先に予約してから slot を publish する。
+                // ここで先へ進むと、直後に publish された record を永久に読み飛ばすため、
+                // drain_sequence は連続して読めた位置までしか進めない。
+                break;
             }
         }
-        self.drain_sequence.store(total, Ordering::Release);
+        self.drain_sequence.store(drained_until, Ordering::Release);
     }
 }
 
@@ -417,11 +424,22 @@ impl FixedMessage {
 impl fmt::Write for FixedMessage {
     fn write_str(&mut self, value: &str) -> fmt::Result {
         let remaining = RT_MESSAGE_CAPACITY.saturating_sub(self.len);
-        let count = remaining.min(value.len());
+        let count = utf8_boundary_len(value, remaining);
         self.bytes[self.len..self.len + count].copy_from_slice(&value.as_bytes()[..count]);
         self.len += count;
         Ok(())
     }
+}
+
+fn utf8_boundary_len(value: &str, limit: usize) -> usize {
+    if value.len() <= limit {
+        return value.len();
+    }
+    let mut count = limit.min(value.len());
+    while count > 0 && !value.is_char_boundary(count) {
+        count -= 1;
+    }
+    count
 }
 
 struct FixedString<const N: usize> {
@@ -586,5 +604,37 @@ fn u8_to_level(level: u8) -> Level {
         3 => Level::Info,
         5 => Level::Trace,
         _ => Level::Debug,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn drain_stops_before_unpublished_slot() {
+        let log = RtLogInner::new("test");
+        log.next_sequence.store(1, Ordering::Release);
+
+        log.drain_to_log();
+        assert_eq!(log.drain_sequence.load(Ordering::Acquire), 0);
+
+        log.slots[0].write(0, Level::Debug, "test", 10, 20, format_args!("published"));
+        log.drain_to_log();
+        assert_eq!(log.drain_sequence.load(Ordering::Acquire), 1);
+    }
+
+    #[test]
+    fn fixed_message_truncates_at_utf8_boundary() {
+        let mut message = FixedMessage::new();
+        let value = "a".repeat(RT_MESSAGE_CAPACITY - 1) + "あ";
+
+        message.write_str(&value).unwrap();
+
+        assert_eq!(message.len, RT_MESSAGE_CAPACITY - 1);
+        assert_eq!(
+            std::str::from_utf8(message.as_bytes()).unwrap().len(),
+            message.len
+        );
     }
 }

--- a/crates/wrac_log/src/lib.rs
+++ b/crates/wrac_log/src/lib.rs
@@ -1,0 +1,590 @@
+//! WRAC plugin 用の logging 基盤。
+//!
+//! 通常 logger は非 realtime thread 用の同期 file logger として実装する。
+//! realtime thread からは `rtdebug!` 系 macro で固定長 ring buffer へ書き込み、
+//! 非 realtime の drain worker が通常 logger へ流す。
+
+use std::array;
+use std::fmt::{self, Write as _};
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU8, AtomicU32, AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, Once, OnceLock, Weak};
+use std::thread;
+use std::time::Duration;
+
+use log::{Level, LevelFilter, Log, Metadata, Record};
+use time::{OffsetDateTime, macros::format_description};
+
+const RT_LOG_CAPACITY: usize = 4096;
+const RT_MESSAGE_CAPACITY: usize = 256;
+const RT_TARGET_CAPACITY: usize = 96;
+
+static FILE_LOGGER_INIT: Once = Once::new();
+static FILE_LOGGER: FileLogger = FileLogger {
+    file: Mutex::new(None),
+    level: Mutex::new(LevelFilter::Debug),
+};
+static RT_REGISTRY: OnceLock<RtRegistry> = OnceLock::new();
+static RT_DRAIN_WORKER: OnceLock<()> = OnceLock::new();
+
+pub struct FileLoggerConfig {
+    app_name: String,
+    log_file: PathBuf,
+    level: LevelFilter,
+    stderr_prefix: String,
+}
+
+impl FileLoggerConfig {
+    pub fn new(app_name: impl Into<String>, log_file: impl Into<PathBuf>) -> Self {
+        Self {
+            app_name: app_name.into(),
+            log_file: log_file.into(),
+            level: std::env::var("RUST_LOG")
+                .ok()
+                .and_then(|value| parse_level_filter(&value))
+                .unwrap_or(LevelFilter::Debug),
+            stderr_prefix: "wrac".to_string(),
+        }
+    }
+
+    pub fn with_stderr_prefix(mut self, stderr_prefix: impl Into<String>) -> Self {
+        self.stderr_prefix = stderr_prefix.into();
+        self
+    }
+
+    pub fn with_level(mut self, level: LevelFilter) -> Self {
+        self.level = level;
+        self
+    }
+}
+
+pub struct RtDrainConfig {
+    interval: Duration,
+}
+
+impl Default for RtDrainConfig {
+    fn default() -> Self {
+        Self {
+            interval: Duration::from_millis(100),
+        }
+    }
+}
+
+impl RtDrainConfig {
+    pub fn with_interval(mut self, interval: Duration) -> Self {
+        self.interval = interval;
+        self
+    }
+}
+
+pub fn init_file_logger_once(config: FileLoggerConfig) {
+    FILE_LOGGER_INIT.call_once(|| {
+        let file = open_log_file(&config.log_file, &config.stderr_prefix);
+
+        if let Ok(mut logger_file) = FILE_LOGGER.file.lock() {
+            *logger_file = file;
+        }
+        if let Ok(mut logger_level) = FILE_LOGGER.level.lock() {
+            *logger_level = config.level;
+        }
+
+        if log::set_logger(&FILE_LOGGER).is_ok() {
+            log::set_max_level(config.level);
+            eprintln!(
+                "[{}] debug log: {}",
+                config.stderr_prefix,
+                config.log_file.display()
+            );
+            FILE_LOGGER.write_session_header(&config.app_name);
+        }
+    });
+}
+
+pub fn init_rt_log_drain_once(config: RtDrainConfig) {
+    RT_DRAIN_WORKER.get_or_init(|| {
+        let interval = config.interval;
+        let _ = thread::Builder::new()
+            .name("wrac-rt-log-drain".to_string())
+            .spawn(move || {
+                loop {
+                    thread::sleep(interval);
+                    drain_rt_logs_once();
+                }
+            });
+    });
+}
+
+pub fn drain_rt_logs_once() {
+    rt_registry().drain_all();
+}
+
+pub struct RtLog {
+    inner: Arc<RtLogInner>,
+}
+
+impl RtLog {
+    pub fn new_registered(name: &'static str) -> Self {
+        let inner = Arc::new(RtLogInner::new(name));
+        rt_registry().register(&inner);
+        Self { inner }
+    }
+
+    pub fn writer(&self) -> RtLogWriter {
+        RtLogWriter {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+impl Drop for RtLog {
+    fn drop(&mut self) {
+        self.inner.drain_to_log();
+        rt_registry().unregister(&self.inner);
+    }
+}
+
+#[derive(Clone)]
+pub struct RtLogWriter {
+    inner: Arc<RtLogInner>,
+}
+
+impl RtLogWriter {
+    #[doc(hidden)]
+    pub fn write_fmt(
+        &self,
+        level: Level,
+        target: &'static str,
+        block_seq: u64,
+        sample_time: u32,
+        args: fmt::Arguments<'_>,
+    ) {
+        self.inner
+            .write_fmt(level, target, block_seq, sample_time, args);
+    }
+}
+
+#[macro_export]
+macro_rules! rttrace {
+    ($writer:expr, $block_seq:expr, $sample_time:expr, $($arg:tt)+) => {{
+        (&$writer).write_fmt(
+            log::Level::Trace,
+            module_path!(),
+            $block_seq,
+            $sample_time,
+            format_args!($($arg)+),
+        );
+    }};
+}
+
+#[macro_export]
+macro_rules! rtdebug {
+    ($writer:expr, $block_seq:expr, $sample_time:expr, $($arg:tt)+) => {{
+        (&$writer).write_fmt(
+            log::Level::Debug,
+            module_path!(),
+            $block_seq,
+            $sample_time,
+            format_args!($($arg)+),
+        );
+    }};
+}
+
+#[macro_export]
+macro_rules! rtwarn {
+    ($writer:expr, $block_seq:expr, $sample_time:expr, $($arg:tt)+) => {{
+        (&$writer).write_fmt(
+            log::Level::Warn,
+            module_path!(),
+            $block_seq,
+            $sample_time,
+            format_args!($($arg)+),
+        );
+    }};
+}
+
+struct RtRegistry {
+    logs: Mutex<Vec<Weak<RtLogInner>>>,
+}
+
+impl RtRegistry {
+    fn register(&self, log: &Arc<RtLogInner>) {
+        if let Ok(mut logs) = self.logs.lock() {
+            logs.push(Arc::downgrade(log));
+        }
+    }
+
+    fn unregister(&self, log: &Arc<RtLogInner>) {
+        if let Ok(mut logs) = self.logs.lock() {
+            logs.retain(|registered| {
+                registered
+                    .upgrade()
+                    .is_some_and(|inner| !Arc::ptr_eq(&inner, log))
+            });
+        }
+    }
+
+    fn drain_all(&self) {
+        if let Ok(mut logs) = self.logs.lock() {
+            logs.retain(|registered| {
+                let Some(log) = registered.upgrade() else {
+                    return false;
+                };
+                log.drain_to_log();
+                true
+            });
+        }
+    }
+}
+
+fn rt_registry() -> &'static RtRegistry {
+    RT_REGISTRY.get_or_init(|| RtRegistry {
+        logs: Mutex::new(Vec::new()),
+    })
+}
+
+struct RtLogInner {
+    name: &'static str,
+    next_sequence: AtomicU64,
+    drain_sequence: AtomicU64,
+    dropped: AtomicU64,
+    slots: Vec<RtLogSlot>,
+}
+
+impl RtLogInner {
+    fn new(name: &'static str) -> Self {
+        Self {
+            name,
+            next_sequence: AtomicU64::new(0),
+            drain_sequence: AtomicU64::new(0),
+            dropped: AtomicU64::new(0),
+            // 固定長 slot を heap に置き、plugin instance 作成時の stack overflow を避ける。
+            slots: (0..RT_LOG_CAPACITY).map(|_| RtLogSlot::new()).collect(),
+        }
+    }
+
+    fn write_fmt(
+        &self,
+        level: Level,
+        target: &'static str,
+        block_seq: u64,
+        sample_time: u32,
+        args: fmt::Arguments<'_>,
+    ) {
+        let sequence = self.next_sequence.fetch_add(1, Ordering::Relaxed);
+        let drain_sequence = self.drain_sequence.load(Ordering::Acquire);
+        if sequence.saturating_sub(drain_sequence) >= RT_LOG_CAPACITY as u64 {
+            self.dropped.fetch_add(1, Ordering::Relaxed);
+        }
+
+        let slot = &self.slots[sequence as usize % RT_LOG_CAPACITY];
+        slot.write(sequence, level, target, block_seq, sample_time, args);
+    }
+
+    fn drain_to_log(&self) {
+        let total = self.next_sequence.load(Ordering::Acquire);
+        let retained_start = total.saturating_sub(RT_LOG_CAPACITY as u64);
+        let start = self
+            .drain_sequence
+            .load(Ordering::Acquire)
+            .max(retained_start);
+
+        let dropped = self.dropped.swap(0, Ordering::AcqRel);
+        if dropped > 0 || start > self.drain_sequence.load(Ordering::Acquire) {
+            log::warn!(
+                target: "wrac_log::rt",
+                "[rt] name={} dropped={} skipped={}",
+                self.name,
+                dropped,
+                start.saturating_sub(self.drain_sequence.load(Ordering::Acquire)),
+            );
+        }
+
+        for sequence in start..total {
+            if let Some(record) = self.slots[sequence as usize % RT_LOG_CAPACITY].read(sequence) {
+                log::log!(
+                    target: record.target.as_str(),
+                    record.level,
+                    "[rt] name={} seq={} block={} sample={} {}",
+                    self.name,
+                    record.sequence,
+                    record.block_seq,
+                    record.sample_time,
+                    record.message.as_str(),
+                );
+            }
+        }
+        self.drain_sequence.store(total, Ordering::Release);
+    }
+}
+
+struct RtLogSlot {
+    sequence: AtomicU64,
+    level: AtomicU8,
+    block_seq: AtomicU64,
+    sample_time: AtomicU32,
+    target_len: AtomicUsize,
+    target: [AtomicU8; RT_TARGET_CAPACITY],
+    message_len: AtomicUsize,
+    message: [AtomicU8; RT_MESSAGE_CAPACITY],
+}
+
+impl RtLogSlot {
+    fn new() -> Self {
+        Self {
+            sequence: AtomicU64::new(0),
+            level: AtomicU8::new(level_to_u8(Level::Debug)),
+            block_seq: AtomicU64::new(0),
+            sample_time: AtomicU32::new(0),
+            target_len: AtomicUsize::new(0),
+            target: array::from_fn(|_| AtomicU8::new(0)),
+            message_len: AtomicUsize::new(0),
+            message: array::from_fn(|_| AtomicU8::new(0)),
+        }
+    }
+
+    fn write(
+        &self,
+        sequence: u64,
+        level: Level,
+        target: &str,
+        block_seq: u64,
+        sample_time: u32,
+        args: fmt::Arguments<'_>,
+    ) {
+        self.sequence.store(0, Ordering::Release);
+        self.level.store(level_to_u8(level), Ordering::Relaxed);
+        self.block_seq.store(block_seq, Ordering::Relaxed);
+        self.sample_time.store(sample_time, Ordering::Relaxed);
+        write_atomic_bytes(&self.target, &self.target_len, target.as_bytes());
+
+        let mut message = FixedMessage::new();
+        let _ = message.write_fmt(args);
+        write_atomic_bytes(&self.message, &self.message_len, message.as_bytes());
+        self.sequence.store(sequence + 1, Ordering::Release);
+    }
+
+    fn read(&self, sequence: u64) -> Option<RtLogRecord> {
+        if self.sequence.load(Ordering::Acquire) != sequence + 1 {
+            return None;
+        }
+
+        let record = RtLogRecord {
+            sequence,
+            level: u8_to_level(self.level.load(Ordering::Relaxed)),
+            block_seq: self.block_seq.load(Ordering::Relaxed),
+            sample_time: self.sample_time.load(Ordering::Relaxed),
+            target: read_atomic_string::<RT_TARGET_CAPACITY>(&self.target, &self.target_len),
+            message: read_atomic_string::<RT_MESSAGE_CAPACITY>(&self.message, &self.message_len),
+        };
+
+        if self.sequence.load(Ordering::Acquire) == sequence + 1 {
+            Some(record)
+        } else {
+            None
+        }
+    }
+}
+
+struct RtLogRecord {
+    sequence: u64,
+    level: Level,
+    block_seq: u64,
+    sample_time: u32,
+    target: FixedString<RT_TARGET_CAPACITY>,
+    message: FixedString<RT_MESSAGE_CAPACITY>,
+}
+
+struct FixedMessage {
+    bytes: [u8; RT_MESSAGE_CAPACITY],
+    len: usize,
+}
+
+impl FixedMessage {
+    fn new() -> Self {
+        Self {
+            bytes: [0; RT_MESSAGE_CAPACITY],
+            len: 0,
+        }
+    }
+
+    fn as_bytes(&self) -> &[u8] {
+        &self.bytes[..self.len]
+    }
+}
+
+impl fmt::Write for FixedMessage {
+    fn write_str(&mut self, value: &str) -> fmt::Result {
+        let remaining = RT_MESSAGE_CAPACITY.saturating_sub(self.len);
+        let count = remaining.min(value.len());
+        self.bytes[self.len..self.len + count].copy_from_slice(&value.as_bytes()[..count]);
+        self.len += count;
+        Ok(())
+    }
+}
+
+struct FixedString<const N: usize> {
+    bytes: [u8; N],
+    len: usize,
+}
+
+impl<const N: usize> FixedString<N> {
+    fn as_str(&self) -> &str {
+        std::str::from_utf8(&self.bytes[..self.len]).unwrap_or("<invalid utf8>")
+    }
+}
+
+fn write_atomic_bytes<const N: usize>(target: &[AtomicU8; N], len: &AtomicUsize, bytes: &[u8]) {
+    let count = N.min(bytes.len());
+    for index in 0..count {
+        target[index].store(bytes[index], Ordering::Relaxed);
+    }
+    len.store(count, Ordering::Relaxed);
+}
+
+fn read_atomic_string<const N: usize>(source: &[AtomicU8; N], len: &AtomicUsize) -> FixedString<N> {
+    let len = len.load(Ordering::Relaxed).min(N);
+    let mut bytes = [0; N];
+    for index in 0..len {
+        bytes[index] = source[index].load(Ordering::Relaxed);
+    }
+    FixedString { bytes, len }
+}
+
+struct FileLogger {
+    file: Mutex<Option<File>>,
+    level: Mutex<LevelFilter>,
+}
+
+impl Log for FileLogger {
+    fn enabled(&self, metadata: &Metadata<'_>) -> bool {
+        metadata.level() <= self.level()
+    }
+
+    fn log(&self, record: &Record<'_>) {
+        if !self.enabled(record.metadata()) {
+            return;
+        }
+
+        let line = format!(
+            "{} [{}] {} - {}\n",
+            local_timestamp_millis(),
+            record.level(),
+            record.target(),
+            record.args()
+        );
+        let _ = std::io::stderr().write_all(line.as_bytes());
+
+        if let Ok(mut file) = self.file.lock()
+            && let Some(file) = file.as_mut()
+        {
+            let _ = file.write_all(line.as_bytes());
+            let _ = file.flush();
+        }
+    }
+
+    fn flush(&self) {
+        let _ = std::io::stderr().flush();
+        if let Ok(mut file) = self.file.lock()
+            && let Some(file) = file.as_mut()
+        {
+            let _ = file.flush();
+        }
+    }
+}
+
+impl FileLogger {
+    fn level(&self) -> LevelFilter {
+        self.level
+            .lock()
+            .map(|level| *level)
+            .unwrap_or(LevelFilter::Off)
+    }
+
+    fn write_session_header(&self, app_name: &str) {
+        let line = format!(
+            "\n================ {} session started at {} ================\n",
+            app_name,
+            local_timestamp_millis()
+        );
+        let _ = std::io::stderr().write_all(line.as_bytes());
+
+        if let Ok(mut file) = self.file.lock()
+            && let Some(file) = file.as_mut()
+        {
+            let _ = file.write_all(line.as_bytes());
+            let _ = file.flush();
+        }
+    }
+}
+
+fn open_log_file(path: &Path, stderr_prefix: &str) -> Option<File> {
+    if let Some(parent) = path.parent()
+        && let Err(error) = std::fs::create_dir_all(parent)
+    {
+        eprintln!(
+            "[{stderr_prefix}] failed to create log directory '{}': {error}",
+            parent.display()
+        );
+        return None;
+    }
+
+    match OpenOptions::new().create(true).append(true).open(path) {
+        Ok(file) => Some(file),
+        Err(error) => {
+            eprintln!(
+                "[{stderr_prefix}] failed to open log file '{}': {error}",
+                path.display()
+            );
+            None
+        }
+    }
+}
+
+fn parse_level_filter(value: &str) -> Option<LevelFilter> {
+    let value = value
+        .rsplit(',')
+        .next()
+        .and_then(|directive| directive.rsplit('=').next())
+        .unwrap_or(value)
+        .trim();
+
+    match value.to_ascii_lowercase().as_str() {
+        "off" => Some(LevelFilter::Off),
+        "error" => Some(LevelFilter::Error),
+        "warn" => Some(LevelFilter::Warn),
+        "info" => Some(LevelFilter::Info),
+        "debug" => Some(LevelFilter::Debug),
+        "trace" => Some(LevelFilter::Trace),
+        _ => None,
+    }
+}
+
+fn local_timestamp_millis() -> String {
+    let now = OffsetDateTime::now_local().unwrap_or_else(|_| OffsetDateTime::now_utc());
+    let format =
+        format_description!("[year]-[month]-[day] [hour]:[minute]:[second].[subsecond digits:3]");
+    now.format(format)
+        .unwrap_or_else(|_| format!("{}.{:03}", now.unix_timestamp(), now.millisecond()))
+}
+
+const fn level_to_u8(level: Level) -> u8 {
+    match level {
+        Level::Error => 1,
+        Level::Warn => 2,
+        Level::Info => 3,
+        Level::Debug => 4,
+        Level::Trace => 5,
+    }
+}
+
+fn u8_to_level(level: u8) -> Level {
+    match level {
+        1 => Level::Error,
+        2 => Level::Warn,
+        3 => Level::Info,
+        5 => Level::Trace,
+        _ => Level::Debug,
+    }
+}

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -56,13 +56,16 @@ Edit `[package.metadata.wrac]` first.
 
 ```toml
 [package.metadata.wrac]
+company_name = "Your Company"
+auv2_manufacturer_code = "YrCo"
+bundle_name = "My Plugin"
+standalone_name = "My Plugin Standalone"
+
+[[package.metadata.wrac.plugins]]
 plugin_id = "com.your-company.my-plugin"
 plugin_name = "My Plugin"
-company_name = "Your Company"
 auv2_type = "aufx"
 auv2_subtype = "MyPl"
-auv2_manufacturer_code = "YrCo"
-standalone_name = "My Plugin Standalone"
 ```
 
 > **Important:** The plugin ID must be globally unique. It cannot be changed once published.

--- a/docs/setup_JA.md
+++ b/docs/setup_JA.md
@@ -56,13 +56,16 @@ VST3 / AU / Standalone、または VST3 / AU の検証を行う場合は clap-wr
 
 ```toml
 [package.metadata.wrac]
+company_name = "Your Company"
+auv2_manufacturer_code = "YrCo"
+bundle_name = "My Plugin"
+standalone_name = "My Plugin Standalone"
+
+[[package.metadata.wrac.plugins]]
 plugin_id = "com.your-company.my-plugin"
 plugin_name = "My Plugin"
-company_name = "Your Company"
 auv2_type = "aufx"
 auv2_subtype = "MyPl"
-auv2_manufacturer_code = "YrCo"
-standalone_name = "My Plugin Standalone"
 ```
 
 > **重要:** プラグイン ID はグローバルに一意である必要があります。一度公開したら変更できません。

--- a/src-gui/vite.config.ts
+++ b/src-gui/vite.config.ts
@@ -25,11 +25,32 @@ function readCargoMetadata(): PluginMetadata {
     );
   }
   return {
-    pluginId: readWracMetadataString(cargoToml, "plugin_id"),
-    pluginName: readWracMetadataString(cargoToml, "plugin_name"),
+    pluginId: readFirstPluginMetadataString(cargoToml, "plugin_id"),
+    pluginName: readFirstPluginMetadataString(cargoToml, "plugin_name"),
     companyName: readWracMetadataString(cargoToml, "company_name"),
     version: versionMatch[1],
   };
+}
+
+function readFirstPluginMetadataString(cargoToml: string, key: string): string {
+  let inSection = false;
+  for (const rawLine of cargoToml.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (line.startsWith("[") && line.endsWith("]")) {
+      inSection = line === "[[package.metadata.wrac.plugins]]";
+      continue;
+    }
+    if (!inSection) {
+      continue;
+    }
+    const match = line.match(new RegExp(`^${key}\\s*=\\s*"([^"]+)"\\s*$`));
+    if (match) {
+      return match[1];
+    }
+  }
+  throw new Error(
+    `Failed to read package.metadata.wrac.plugins.${key} from src-plugin/Cargo.toml`,
+  );
 }
 
 function readWracMetadataString(cargoToml: string, key: string): string {

--- a/src-plugin/Cargo.toml
+++ b/src-plugin/Cargo.toml
@@ -11,20 +11,24 @@ build = "build.rs"
 # WRAC metadata is the single source of truth for descriptors, GUI metadata,
 # bundle names, wrapper arguments, AUv2 registration, WebView data dirs, and logs.
 [package.metadata.wrac]
+# User-visible vendor name shown by hosts and the template GUI.
+company_name = "Your Company"
+# AUv2 manufacturer code. Use the same 4-byte ASCII code across your plugin catalog.
+auv2_manufacturer_code = "YrCo"
+# User-visible bundle name.
+bundle_name = "WRAC Gain"
+# User-visible standalone app name.
+standalone_name = "WRAC Gain Standalone"
+
+[[package.metadata.wrac.plugins]]
 # Reverse-DNS identifier. Use your own domain or another namespace you control.
 plugin_id = "com.your-company.wrac-gain"
 # User-visible plugin name shown by hosts and the template GUI.
 plugin_name = "WRAC Gain"
-# User-visible vendor name shown by hosts and the template GUI.
-company_name = "Your Company"
 # AUv2 component type. Audio effects usually use "aufx"; instruments usually use "aumu".
 auv2_type = "aufx"
 # AUv2 subtype. Pick a unique 4-byte ASCII code for each plugin from the same vendor.
 auv2_subtype = "WtGn"
-# AUv2 manufacturer code. Use the same 4-byte ASCII code across your plugin catalog.
-auv2_manufacturer_code = "YrCo"
-# User-visible standalone app name.
-standalone_name = "WRAC Gain Standalone"
 
 [lib]
 crate-type = ["rlib", "staticlib", "cdylib"]
@@ -41,6 +45,7 @@ serde_json = "1.0"
 time = { version = "0.3", features = ["formatting", "local-offset", "macros"] }
 run_loop_timer = { workspace = true }
 wrac_clap_adapter = { workspace = true }
+wrac_log = { workspace = true }
 wrac_wxp_gui = { workspace = true }
 wxp = { workspace = true }
 

--- a/src-plugin/build.rs
+++ b/src-plugin/build.rs
@@ -29,16 +29,27 @@ fn main() {
     // template rename could leave some artifacts with the old name, so pass them to Rust
     // as compile-time env vars.
     let metadata = read_wrac_metadata(&manifest_path).expect("failed to read WRAC metadata");
-    println!("cargo:rustc-env=WRAC_PLUGIN_ID={}", metadata.plugin_id);
-    println!("cargo:rustc-env=WRAC_PLUGIN_NAME={}", metadata.plugin_name);
+    for (index, plugin) in metadata.plugins.iter().enumerate() {
+        println!(
+            "cargo:rustc-env=WRAC_PLUGIN_{index}_ID={}",
+            plugin.plugin_id
+        );
+        println!(
+            "cargo:rustc-env=WRAC_PLUGIN_{index}_NAME={}",
+            plugin.plugin_name
+        );
+        println!(
+            "cargo:rustc-env=WRAC_PLUGIN_{index}_AUV2_TYPE={}",
+            plugin.auv2_type
+        );
+        println!(
+            "cargo:rustc-env=WRAC_PLUGIN_{index}_AUV2_SUBTYPE={}",
+            plugin.auv2_subtype
+        );
+    }
     println!(
         "cargo:rustc-env=WRAC_COMPANY_NAME={}",
         metadata.company_name
-    );
-    println!("cargo:rustc-env=WRAC_AUV2_TYPE={}", metadata.auv2_type);
-    println!(
-        "cargo:rustc-env=WRAC_AUV2_SUBTYPE={}",
-        metadata.auv2_subtype
     );
     println!(
         "cargo:rustc-env=WRAC_AUV2_MANUFACTURER_CODE={}",
@@ -70,39 +81,38 @@ fn main() {
 }
 
 struct WracMetadata {
+    company_name: String,
+    auv2_manufacturer_code: String,
+    plugins: Vec<WracPluginMetadata>,
+}
+
+struct WracPluginMetadata {
     plugin_id: String,
     plugin_name: String,
-    company_name: String,
     auv2_type: String,
     auv2_subtype: String,
-    auv2_manufacturer_code: String,
 }
 
 fn read_wrac_metadata(manifest_path: &Path) -> io::Result<WracMetadata> {
     let manifest = fs::read_to_string(manifest_path)?;
-    let plugin_id = read_toml_string(&manifest, "package.metadata.wrac", "plugin_id")
-        .ok_or_else(|| missing_metadata("plugin_id"))?;
-    let plugin_name = read_toml_string(&manifest, "package.metadata.wrac", "plugin_name")
-        .ok_or_else(|| missing_metadata("plugin_name"))?;
     let company_name = read_toml_string(&manifest, "package.metadata.wrac", "company_name")
         .ok_or_else(|| missing_metadata("company_name"))?;
-    let auv2_type = read_toml_string(&manifest, "package.metadata.wrac", "auv2_type")
-        .ok_or_else(|| missing_metadata("auv2_type"))?;
-    let auv2_subtype = read_toml_string(&manifest, "package.metadata.wrac", "auv2_subtype")
-        .ok_or_else(|| missing_metadata("auv2_subtype"))?;
     let auv2_manufacturer_code =
         read_toml_string(&manifest, "package.metadata.wrac", "auv2_manufacturer_code")
             .ok_or_else(|| missing_metadata("auv2_manufacturer_code"))?;
-    validate_four_ascii("auv2_type", &auv2_type)?;
-    validate_four_ascii("auv2_subtype", &auv2_subtype)?;
     validate_four_ascii("auv2_manufacturer_code", &auv2_manufacturer_code)?;
+    let plugins = read_plugin_metadata(&manifest)?;
+    if plugins.is_empty() {
+        return Err(missing_metadata("plugins"));
+    }
+    for plugin in &plugins {
+        validate_four_ascii("auv2_type", &plugin.auv2_type)?;
+        validate_four_ascii("auv2_subtype", &plugin.auv2_subtype)?;
+    }
     Ok(WracMetadata {
-        plugin_id,
-        plugin_name,
         company_name,
-        auv2_type,
-        auv2_subtype,
         auv2_manufacturer_code,
+        plugins,
     })
 }
 
@@ -133,6 +143,63 @@ fn read_toml_string(manifest: &str, section: &str, key: &str) -> Option<String> 
         return parse_toml_basic_string(value.trim());
     }
     None
+}
+
+fn read_plugin_metadata(manifest: &str) -> io::Result<Vec<WracPluginMetadata>> {
+    let mut plugins = Vec::new();
+    let mut current: Option<WracPluginMetadata> = None;
+    let mut in_plugins = false;
+
+    for line in manifest.lines() {
+        let line = line.trim();
+        if line.starts_with('[') && line.ends_with(']') {
+            if let Some(plugin) = current.take() {
+                plugins.push(plugin);
+            }
+            in_plugins = line == "[[package.metadata.wrac.plugins]]";
+            if in_plugins {
+                current = Some(WracPluginMetadata {
+                    plugin_id: String::new(),
+                    plugin_name: String::new(),
+                    auv2_type: String::new(),
+                    auv2_subtype: String::new(),
+                });
+            }
+            continue;
+        }
+        if !in_plugins {
+            continue;
+        }
+        let Some((line_key, value)) = line.split_once('=') else {
+            continue;
+        };
+        let Some(value) = parse_toml_basic_string(value.trim()) else {
+            continue;
+        };
+        let plugin = current
+            .as_mut()
+            .expect("plugin table must create current metadata");
+        match line_key.trim() {
+            "plugin_id" => plugin.plugin_id = value,
+            "plugin_name" => plugin.plugin_name = value,
+            "auv2_type" => plugin.auv2_type = value,
+            "auv2_subtype" => plugin.auv2_subtype = value,
+            _ => {}
+        }
+    }
+    if let Some(plugin) = current {
+        plugins.push(plugin);
+    }
+    for plugin in &plugins {
+        if plugin.plugin_id.is_empty()
+            || plugin.plugin_name.is_empty()
+            || plugin.auv2_type.is_empty()
+            || plugin.auv2_subtype.is_empty()
+        {
+            return Err(missing_metadata("plugins.*"));
+        }
+    }
+    Ok(plugins)
 }
 
 fn parse_toml_basic_string(value: &str) -> Option<String> {

--- a/src-plugin/src/lib.rs
+++ b/src-plugin/src/lib.rs
@@ -31,10 +31,7 @@ mod logging;
 mod plugin;
 mod state;
 
-// Export the CLAP entry point. The adapter generates the C ABI, factory, and lifecycle
-// machinery; here we only supply "what this plugin is" (descriptor) and "how to create
-// the core" (create).
-wrac_clap_adapter::export_clap_plugin! {
-    descriptor: crate::plugin::PLUGIN_DESCRIPTOR,
-    create: crate::plugin::create_plugin_core,
+// Export the CLAP entry point. The adapter owns the C ABI and calls the safe Rust entry.
+wrac_clap_adapter::export_clap_entry! {
+    entry: &crate::plugin::PLUGIN_ENTRY,
 }

--- a/src-plugin/src/logging.rs
+++ b/src-plugin/src/logging.rs
@@ -1,111 +1,17 @@
-//! Debug logger for the template.
-//!
-//! stderr is often hidden when developing inside a DAW, so this helper makes logs
-//! immediately accessible during development. Production plugins are expected to
-//! replace it with a custom logging backend.
+//! Product-specific wrapper around the shared WRAC logger.
 
-use std::fs::{File, OpenOptions};
-use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::sync::{Mutex, Once};
 
-use log::{LevelFilter, Log, Metadata, Record};
-use time::{OffsetDateTime, macros::format_description};
-
-static INIT: Once = Once::new();
-static LOGGER: DebugFileLogger = DebugFileLogger {
-    file: Mutex::new(None),
-    level: Mutex::new(LevelFilter::Debug),
-};
+use wrac_log::{FileLoggerConfig, RtDrainConfig};
 
 pub(crate) fn init_debug_logging_once(app_name: &str) {
-    INIT.call_once(|| {
-        let level = std::env::var("RUST_LOG")
-            .ok()
-            .and_then(|value| parse_level_filter(&value))
-            .unwrap_or(LevelFilter::Debug);
-        let log_file = default_log_file(app_name);
-        let file = open_log_file(&log_file);
+    let log_file = default_log_file(app_name);
+    wrac_log::init_file_logger_once(
+        FileLoggerConfig::new(app_name, log_file).with_stderr_prefix("wrac_gain_plugin"),
+    );
 
-        if let Ok(mut logger_file) = LOGGER.file.lock() {
-            *logger_file = file;
-        }
-        if let Ok(mut logger_level) = LOGGER.level.lock() {
-            *logger_level = level;
-        }
-
-        if log::set_logger(&LOGGER).is_ok() {
-            log::set_max_level(level);
-            eprintln!("[wrac_gain_plugin] debug log: {}", log_file.display());
-            LOGGER.write_session_header(app_name);
-        }
-    });
-}
-
-struct DebugFileLogger {
-    file: Mutex<Option<File>>,
-    level: Mutex<LevelFilter>,
-}
-
-impl Log for DebugFileLogger {
-    fn enabled(&self, metadata: &Metadata<'_>) -> bool {
-        metadata.level() <= self.level()
-    }
-
-    fn log(&self, record: &Record<'_>) {
-        if !self.enabled(record.metadata()) {
-            return;
-        }
-
-        let line = format!(
-            "{} [{}] {} - {}\n",
-            local_timestamp_millis(),
-            record.level(),
-            record.target(),
-            record.args()
-        );
-        let _ = std::io::stderr().write_all(line.as_bytes());
-
-        if let Ok(mut file) = self.file.lock() {
-            if let Some(file) = file.as_mut() {
-                let _ = file.write_all(line.as_bytes());
-                let _ = file.flush();
-            }
-        }
-    }
-
-    fn flush(&self) {
-        let _ = std::io::stderr().flush();
-        if let Ok(mut file) = self.file.lock() {
-            if let Some(file) = file.as_mut() {
-                let _ = file.flush();
-            }
-        }
-    }
-}
-
-impl DebugFileLogger {
-    fn level(&self) -> LevelFilter {
-        self.level
-            .lock()
-            .map(|level| *level)
-            .unwrap_or(LevelFilter::Off)
-    }
-
-    fn write_session_header(&self, app_name: &str) {
-        let line = format!(
-            "\n================ {} session started at {} ================\n",
-            app_name,
-            local_timestamp_millis()
-        );
-        let _ = std::io::stderr().write_all(line.as_bytes());
-
-        if let Ok(mut file) = self.file.lock() {
-            if let Some(file) = file.as_mut() {
-                let _ = file.write_all(line.as_bytes());
-                let _ = file.flush();
-            }
-        }
+    if cfg!(debug_assertions) || std::env::var_os("WRAC_RT_LOG").is_some() {
+        wrac_log::init_rt_log_drain_once(RtDrainConfig::default());
     }
 }
 
@@ -113,48 +19,6 @@ fn default_log_file(app_name: &str) -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("../.log")
         .join(format!("{} Latest.log", sanitize_file_stem(app_name)))
-}
-
-fn open_log_file(path: &Path) -> Option<File> {
-    if let Some(parent) = path.parent() {
-        if let Err(error) = std::fs::create_dir_all(parent) {
-            eprintln!(
-                "[wrac_gain_plugin] failed to create log directory '{}': {error}",
-                parent.display()
-            );
-            return None;
-        }
-    }
-
-    match OpenOptions::new().create(true).append(true).open(path) {
-        Ok(file) => Some(file),
-        Err(error) => {
-            eprintln!(
-                "[wrac_gain_plugin] failed to open log file '{}': {error}",
-                path.display()
-            );
-            None
-        }
-    }
-}
-
-fn parse_level_filter(value: &str) -> Option<LevelFilter> {
-    let value = value
-        .rsplit(',')
-        .next()
-        .and_then(|directive| directive.rsplit('=').next())
-        .unwrap_or(value)
-        .trim();
-
-    match value.to_ascii_lowercase().as_str() {
-        "off" => Some(LevelFilter::Off),
-        "error" => Some(LevelFilter::Error),
-        "warn" => Some(LevelFilter::Warn),
-        "info" => Some(LevelFilter::Info),
-        "debug" => Some(LevelFilter::Debug),
-        "trace" => Some(LevelFilter::Trace),
-        _ => None,
-    }
 }
 
 fn sanitize_file_stem(value: &str) -> String {
@@ -177,12 +41,4 @@ fn sanitize_file_stem(value: &str) -> String {
     } else {
         sanitized
     }
-}
-
-fn local_timestamp_millis() -> String {
-    let now = OffsetDateTime::now_local().unwrap_or_else(|_| OffsetDateTime::now_utc());
-    let format =
-        format_description!("[year]-[month]-[day] [hour]:[minute]:[second].[subsecond digits:3]");
-    now.format(format)
-        .unwrap_or_else(|_| format!("{}.{:03}", now.unix_timestamp(), now.millisecond()))
 }

--- a/src-plugin/src/plugin.rs
+++ b/src-plugin/src/plugin.rs
@@ -10,6 +10,7 @@
 //! Format differences between CLAP, VST3, and AU are absorbed by `wrac_clap_adapter`,
 //! so this module focuses solely on "which capabilities this plugin offers."
 
+use std::ffi::CStr;
 use std::sync::Arc;
 
 mod audio_ports;
@@ -27,8 +28,8 @@ use parameters::{WracGainParameters, bypass_parameter_info};
 use state_support::WracGainStateSupport;
 use wrac_clap_adapter::{
     ActivateContext, Auv2Descriptor, PluginAudioPorts, PluginConfigurableAudioPorts, PluginCore,
-    PluginCoreContext, PluginDescriptor, PluginFeature, PluginGui, PluginParameters, PluginResult,
-    PluginStateSupport, Processor,
+    PluginCoreContext, PluginDescriptor, PluginEntry, PluginFactory, PluginFeature, PluginGui,
+    PluginParameters, PluginResult, PluginStateSupport, Processor,
 };
 use wrac_wxp_gui::WxpGuiController;
 
@@ -40,11 +41,11 @@ use crate::state::{ProjectStateStore, SharedState};
 // src-plugin/Cargo.toml. The GUI, xtask, and wrapper build all read the same metadata,
 // so env! macros are used here instead of hard-coded strings to prevent mismatches
 // (mismatched bundle names or About-dialog text) when renaming the template.
-pub(crate) const PLUGIN_ID: &str = env!("WRAC_PLUGIN_ID");
-pub(crate) const PLUGIN_NAME: &str = env!("WRAC_PLUGIN_NAME");
+pub(crate) const PLUGIN_ID: &str = env!("WRAC_PLUGIN_0_ID");
+pub(crate) const PLUGIN_NAME: &str = env!("WRAC_PLUGIN_0_NAME");
 pub(crate) const COMPANY_NAME: &str = env!("WRAC_COMPANY_NAME");
-const AUV2_TYPE: [u8; 4] = four_char_code(env!("WRAC_AUV2_TYPE"));
-const AUV2_SUBTYPE: [u8; 4] = four_char_code(env!("WRAC_AUV2_SUBTYPE"));
+const AUV2_TYPE: [u8; 4] = four_char_code(env!("WRAC_PLUGIN_0_AUV2_TYPE"));
+const AUV2_SUBTYPE: [u8; 4] = four_char_code(env!("WRAC_PLUGIN_0_AUV2_SUBTYPE"));
 const AUV2_MANUFACTURER_CODE: [u8; 4] = four_char_code(env!("WRAC_AUV2_MANUFACTURER_CODE"));
 
 // Plugin self-description sent to the host. The adapter converts this into CLAP / AUv2 descriptors.
@@ -71,6 +72,38 @@ pub(crate) const PLUGIN_DESCRIPTOR: PluginDescriptor = PluginDescriptor {
         plugin_subtype: AUV2_SUBTYPE,
     }),
 };
+
+pub(crate) static PLUGIN_ENTRY: WracGainEntry = WracGainEntry;
+
+pub(crate) struct WracGainEntry;
+
+impl PluginEntry for WracGainEntry {
+    fn plugin_factory(&self) -> Option<&dyn PluginFactory> {
+        Some(&WRAC_GAIN_FACTORY)
+    }
+}
+
+static WRAC_GAIN_FACTORY: WracGainFactory = WracGainFactory;
+
+struct WracGainFactory;
+
+impl PluginFactory for WracGainFactory {
+    fn plugin_count(&self) -> u32 {
+        1
+    }
+
+    fn plugin_descriptor(&self, index: u32) -> Option<PluginDescriptor> {
+        (index == 0).then_some(PLUGIN_DESCRIPTOR)
+    }
+
+    fn create_plugin(
+        &self,
+        plugin_id: &CStr,
+        context: PluginCoreContext,
+    ) -> Option<Box<dyn PluginCore>> {
+        (plugin_id.to_bytes() == PLUGIN_ID.as_bytes()).then(|| create_plugin_core(context))
+    }
+}
 
 const fn four_char_code(value: &str) -> [u8; 4] {
     let bytes = value.as_bytes();
@@ -137,7 +170,7 @@ impl WracGainPlugin {
     }
 }
 
-/// Factory called by [`wrac_clap_adapter::export_clap_plugin!`].
+/// Called from this product's [`PluginFactory`] implementation.
 /// Called each time the host requests a new instance; returns a [`PluginCore`].
 pub(crate) fn create_plugin_core(context: PluginCoreContext) -> Box<dyn PluginCore> {
     crate::logging::init_debug_logging_once(PLUGIN_DESCRIPTOR.name);

--- a/xtask/src/commands.rs
+++ b/xtask/src/commands.rs
@@ -185,12 +185,12 @@ fn package_clap(ctx: &Context, profile: BuildProfile) -> Result<()> {
             fs::write(contents.join("PkgInfo"), "BNDL????")?;
             fs::copy(
                 ctx.dynamic_library(profile),
-                macos.join(&ctx.metadata.plugin_name),
+                macos.join(&ctx.metadata.bundle_name),
             )?;
             run(Command::new("install_name_tool")
                 .arg("-id")
-                .arg(format!("@loader_path/{}", ctx.metadata.plugin_name))
-                .arg(macos.join(&ctx.metadata.plugin_name))
+                .arg(format!("@loader_path/{}", ctx.metadata.bundle_name))
+                .arg(macos.join(&ctx.metadata.bundle_name))
                 .current_dir(&ctx.root))?;
             codesign(&bundle)?;
         }
@@ -255,7 +255,7 @@ fn build_wrapper_set(ctx: &Context, profile: BuildProfile, build: WrapperBuild) 
         ))
         .arg(format!(
             "-DCLAP_WRAPPER_BUILDER_OUTPUT_NAME={}",
-            ctx.metadata.plugin_name
+            ctx.metadata.bundle_name
         ))
         .arg(format!(
             "-DCLAP_WRAPPER_BUILDER_TARGET_NAME={CRATE_NAME}_{}",
@@ -291,7 +291,7 @@ fn build_wrapper_set(ctx: &Context, profile: BuildProfile, build: WrapperBuild) 
                 .arg("-DCLAP_WRAPPER_BUILDER_BUILD_STANDALONE=ON")
                 .arg(format!(
                     "-DCLAP_WRAPPER_BUILDER_STANDALONE_PLUGIN_ID={}",
-                    ctx.metadata.plugin_id
+                    ctx.metadata.primary_plugin().plugin_id
                 ))
                 .arg(format!(
                     "-DCLAP_WRAPPER_BUILDER_STANDALONE_OUTPUT_NAME={}",
@@ -311,7 +311,7 @@ fn build_wrapper_set(ctx: &Context, profile: BuildProfile, build: WrapperBuild) 
             ))
             .arg(format!(
                 "-DCLAP_WRAPPER_AUV2_INSTRUMENT_TYPE={}",
-                ctx.metadata.auv2_type
+                ctx.metadata.primary_plugin().auv2_type
             ))
             .arg(format!(
                 "-DCLAP_WRAPPER_AUV2_MANUFACTURER_NAME={}",
@@ -323,7 +323,7 @@ fn build_wrapper_set(ctx: &Context, profile: BuildProfile, build: WrapperBuild) 
             ))
             .arg(format!(
                 "-DCLAP_WRAPPER_AUV2_SUBTYPE_CODE={}",
-                ctx.metadata.auv2_subtype
+                ctx.metadata.primary_plugin().auv2_subtype
             ));
     }
 
@@ -640,8 +640,8 @@ fn validate_targets(
         run(Command::new("/usr/bin/auval")
             .args([
                 "-v",
-                &ctx.metadata.auv2_type,
-                &ctx.metadata.auv2_subtype,
+                &ctx.metadata.primary_plugin().auv2_type,
+                &ctx.metadata.primary_plugin().auv2_subtype,
                 &ctx.metadata.auv2_manufacturer_code,
             ])
             .current_dir(&ctx.root))?;
@@ -843,8 +843,8 @@ fn print_outputs(ctx: &Context, profile: BuildProfile, targets: &[Target]) {
 }
 
 fn macos_clap_info_plist(metadata: &PluginMetadata, version: &str) -> String {
-    let plugin_name = &metadata.plugin_name;
-    let plugin_id = &metadata.plugin_id;
+    let plugin_name = &metadata.bundle_name;
+    let plugin_id = &metadata.primary_plugin().plugin_id;
     format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">

--- a/xtask/src/metadata.rs
+++ b/xtask/src/metadata.rs
@@ -5,47 +5,62 @@ use crate::Result;
 
 #[derive(Debug, Clone)]
 pub(crate) struct PluginMetadata {
+    pub(crate) company_name: String,
+    pub(crate) auv2_manufacturer_code: String,
+    pub(crate) bundle_name: String,
+    pub(crate) standalone_name: String,
+    pub(crate) plugins: Vec<PluginProductMetadata>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct PluginProductMetadata {
     pub(crate) plugin_id: String,
     pub(crate) plugin_name: String,
-    pub(crate) company_name: String,
     pub(crate) auv2_type: String,
     pub(crate) auv2_subtype: String,
-    pub(crate) auv2_manufacturer_code: String,
-    pub(crate) standalone_name: String,
 }
 
 impl PluginMetadata {
     pub(crate) fn read(manifest_path: &Path) -> Result<Self> {
         let manifest = fs::read_to_string(manifest_path)?;
         let metadata = Self {
-            plugin_id: required_toml_string(&manifest, "plugin_id")?,
-            plugin_name: required_toml_string(&manifest, "plugin_name")?,
             company_name: required_toml_string(&manifest, "company_name")?,
-            auv2_type: required_toml_string(&manifest, "auv2_type")?,
-            auv2_subtype: required_toml_string(&manifest, "auv2_subtype")?,
             auv2_manufacturer_code: required_toml_string(&manifest, "auv2_manufacturer_code")?,
+            bundle_name: required_toml_string(&manifest, "bundle_name")?,
             standalone_name: required_toml_string(&manifest, "standalone_name")?,
+            plugins: read_plugin_products(&manifest)?,
         };
         metadata.validate()?;
         Ok(metadata)
     }
 
     pub(crate) fn clap_bundle_name(&self) -> String {
-        format!("{}.clap", self.plugin_name)
+        format!("{}.clap", self.bundle_name)
     }
 
     pub(crate) fn vst3_bundle_name(&self) -> String {
-        format!("{}.vst3", self.plugin_name)
+        format!("{}.vst3", self.bundle_name)
     }
 
     pub(crate) fn au_bundle_name(&self) -> String {
-        format!("{}.component", self.plugin_name)
+        format!("{}.component", self.bundle_name)
+    }
+
+    pub(crate) fn primary_plugin(&self) -> &PluginProductMetadata {
+        self.plugins
+            .first()
+            .expect("validated metadata must contain at least one plugin")
     }
 
     fn validate(&self) -> Result<()> {
-        validate_four_ascii("auv2_type", &self.auv2_type)?;
-        validate_four_ascii("auv2_subtype", &self.auv2_subtype)?;
+        if self.plugins.is_empty() {
+            return Err("package.metadata.wrac.plugins must contain at least one plugin".into());
+        }
         validate_four_ascii("auv2_manufacturer_code", &self.auv2_manufacturer_code)?;
+        for plugin in &self.plugins {
+            validate_four_ascii("auv2_type", &plugin.auv2_type)?;
+            validate_four_ascii("auv2_subtype", &plugin.auv2_subtype)?;
+        }
         Ok(())
     }
 }
@@ -54,6 +69,63 @@ fn required_toml_string(manifest: &str, key: &str) -> Result<String> {
     read_toml_string(manifest, "package.metadata.wrac", key).ok_or_else(|| {
         format!("missing package.metadata.wrac.{key} in src-plugin/Cargo.toml").into()
     })
+}
+
+fn read_plugin_products(manifest: &str) -> Result<Vec<PluginProductMetadata>> {
+    let mut plugins = Vec::new();
+    let mut current: Option<PluginProductMetadata> = None;
+    let mut in_plugins = false;
+
+    for line in manifest.lines() {
+        let line = line.trim();
+        if line.starts_with('[') && line.ends_with(']') {
+            if let Some(plugin) = current.take() {
+                plugins.push(plugin);
+            }
+            in_plugins = line == "[[package.metadata.wrac.plugins]]";
+            if in_plugins {
+                current = Some(PluginProductMetadata {
+                    plugin_id: String::new(),
+                    plugin_name: String::new(),
+                    auv2_type: String::new(),
+                    auv2_subtype: String::new(),
+                });
+            }
+            continue;
+        }
+        if !in_plugins {
+            continue;
+        }
+        let Some((line_key, value)) = line.split_once('=') else {
+            continue;
+        };
+        let Some(value) = parse_toml_basic_string(value.trim()) else {
+            continue;
+        };
+        let plugin = current
+            .as_mut()
+            .expect("plugin table must create current metadata");
+        match line_key.trim() {
+            "plugin_id" => plugin.plugin_id = value,
+            "plugin_name" => plugin.plugin_name = value,
+            "auv2_type" => plugin.auv2_type = value,
+            "auv2_subtype" => plugin.auv2_subtype = value,
+            _ => {}
+        }
+    }
+    if let Some(plugin) = current {
+        plugins.push(plugin);
+    }
+    for plugin in &plugins {
+        if plugin.plugin_id.is_empty()
+            || plugin.plugin_name.is_empty()
+            || plugin.auv2_type.is_empty()
+            || plugin.auv2_subtype.is_empty()
+        {
+            return Err("incomplete package.metadata.wrac.plugins entry".into());
+        }
+    }
+    Ok(plugins)
 }
 
 fn read_toml_string(manifest: &str, section: &str, key: &str) -> Option<String> {


### PR DESCRIPTION
## Summary
- Refactor `wrac_clap_adapter` around safe Rust `PluginEntry` / `PluginFactory` traits so one CLAP entry can expose multiple plugin descriptors.
- Add `wrac_log`, including a fixed-size realtime log buffer and async drain path for audio-thread diagnostics.
- Split WRAC metadata into bundle-level fields and plugin product entries, then update the template, xtask, and setup docs to match.

## Verification
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`