### PR TITLE
Clarify host thread contracts

### DIFF
--- a/crates/wrac_clap_adapter/src/api.rs
+++ b/crates/wrac_clap_adapter/src/api.rs
@@ -81,6 +81,10 @@ pub trait HostParameterEditNotifier: Send + Sync {
 ///
 /// This maps to CLAP `clap_host_state.mark_dirty()`. Use it for plugin-owned document
 /// state, not for parameter automation gestures.
+///
+/// CLAP requires this notification to be sent from the main thread. The adapter
+/// does not marshal calls, so call this from the product's GUI/control path, not
+/// directly from `Processor::process()` or a background worker.
 pub trait HostStateDirtyNotifier: Send + Sync {
     fn mark_dirty(&self);
 }

--- a/crates/wrac_clap_adapter/src/host_state.rs
+++ b/crates/wrac_clap_adapter/src/host_state.rs
@@ -35,7 +35,8 @@ struct HostStateMarkDirty {
 }
 
 // The instance lifetime of the host pointer is the minimal unavoidable assumption of the
-// CLAP ABI. Products only receive the safe notifier, not the raw pointer.
+// CLAP ABI. The public trait contract, not this proxy, carries the `mark_dirty`
+// main-thread constraint, so products never receive the raw pointer.
 unsafe impl Send for HostStateMarkDirty {}
 unsafe impl Sync for HostStateMarkDirty {}
 

--- a/crates/wrac_clap_adapter/src/params.rs
+++ b/crates/wrac_clap_adapter/src/params.rs
@@ -164,8 +164,9 @@ struct HostParams {
 }
 
 // The instance lifetime of the host pointer is the minimal unavoidable assumption of the
-// CLAP ABI. Wrapper-specific thread/order guarantees are not trusted; within the adapter
-// usage is limited to `request_flush()` only.
+// CLAP ABI. Product-facing usage is limited to `request_flush()`; adapter-internal
+// `rescan_values()` is called only after state load, where CLAP gives the callback a
+// main-thread contract.
 unsafe impl Send for HostParams {}
 unsafe impl Sync for HostParams {}
 


### PR DESCRIPTION
## Summary
- Document that host state dirty notifications must be made from the main thread.
- Clarify that the state dirty proxy relies on the public trait contract rather than exposing raw host pointers.
- Update the host params pointer comment to reflect adapter-internal rescan usage after state load.

## Verification
- cargo fmt
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-features