### PR TITLE
Add shared wxp GUI WebView helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2923,7 +2923,6 @@ version = "0.1.0"
 dependencies = [
  "assert_no_alloc",
  "atomic_float",
- "directories",
  "log",
  "novonotes_run_loop",
  "parking_lot",
@@ -2951,6 +2950,7 @@ dependencies = [
 name = "wrac_wxp_gui"
 version = "0.1.0"
 dependencies = [
+ "directories",
  "log",
  "novonotes_run_loop",
  "parking_lot",

--- a/crates/wrac_wxp_gui/Cargo.toml
+++ b/crates/wrac_wxp_gui/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 publish = false
 
 [dependencies]
+directories = "5"
 log = "0.4"
 novonotes_run_loop = { workspace = true }
 parking_lot = "0.12"

--- a/crates/wrac_wxp_gui/src/controller.rs
+++ b/crates/wrac_wxp_gui/src/controller.rs
@@ -541,6 +541,9 @@ impl HostGuiLayout {
 
     fn clamp_logical_size(&self, size: LogicalSize<f64>, scale: f64) -> LogicalSize<f64> {
         let dpi = DpiConverter::new(scale);
+        // Resize commands receive frontend logical pixels, while the host's min/max
+        // contract is physical pixels. Convert before clamping so limits mean the
+        // same thing at every DPI scale.
         let physical = dpi.logical_size_to_gui(size);
         let clamped = clamp_size_with_limits(physical, self.limits);
         dpi.gui_size_to_logical(clamped)
@@ -579,16 +582,16 @@ impl WxpGuiResizeHandle {
     /// Requests a host-approved resize from the GUI event path and mirrors accepted bounds to wxp.
     ///
     /// `WxpGuiResizeHandle` is `Send + Sync` so command registration can share it, but this method
-    /// should be called by GUI commands/events. It is not suitable for audio-thread or generic
-    /// background-thread use because it enters the host GUI resize extension.
+    /// enters the host GUI resize extension and must only be called from GUI commands/events.
     pub fn request_resize(
         &self,
         requested: LogicalSize<f64>,
         web_view: &WebViewDispatch,
         host_gui_resize_requester: &dyn HostGuiResizeRequester,
     ) -> PluginResult<LogicalSize<f64>> {
-        // This method is intended for GUI command handlers. `HostGuiResizeRequester` is stored in
-        // Send/Sync context, but host GUI resize calls are not real-time or arbitrary-thread APIs.
+        // `HostGuiResizeRequester` can be shared from Send/Sync product state, but the target
+        // API is a host GUI extension. Keep the "GUI command only" threading contract at the
+        // command registration boundary rather than making this a generic background-thread API.
         let scale = *self.scale.lock();
         let logical_size = self.layout.clamp_logical_size(requested, scale);
         let gui_size = DpiConverter::new(scale).logical_size_to_gui(logical_size);
@@ -990,5 +993,36 @@ fn default_gui_configuration() -> GuiConfiguration {
     GuiConfiguration {
         api: default_gui_api(),
         is_floating: false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clamps_logical_resize_request_in_physical_pixels() {
+        let layout = HostGuiLayout::new(
+            GuiSize {
+                width: 600,
+                height: 400,
+            },
+            GuiSizeLimits {
+                min: GuiSize {
+                    width: 300,
+                    height: 200,
+                },
+                max: GuiSize {
+                    width: 900,
+                    height: 600,
+                },
+            },
+            GuiResizePolicy::RESIZABLE,
+        );
+
+        let clamped = layout.clamp_logical_size(LogicalSize::new(700.0, 100.0), 1.5);
+
+        assert_eq!(clamped.width, 600.0);
+        assert_eq!(clamped.height, 200.0 / 1.5);
     }
 }

--- a/crates/wrac_wxp_gui/src/dpi.rs
+++ b/crates/wrac_wxp_gui/src/dpi.rs
@@ -3,45 +3,43 @@ use wxp::dpi::{LogicalPosition, LogicalSize, Size};
 
 /// Conversion between CLAP GUI sizes and wxp bounds.
 ///
-/// [`GuiSize`] values exchanged with the CLAP host are always in **physical pixels**.
-/// The WebView expects **logical** coordinates on macOS/Windows and **physical**
-/// coordinates on Linux. This converter centralises the DPI branch so that
-/// product code never has to deal with per-platform pixel arithmetic.
-pub struct DpiConverter {
+/// [`GuiSize`] values exchanged with the CLAP host are always physical pixels.
+/// WebView bounds are logical on macOS/Windows and physical on Linux, so keep
+/// platform-specific pixel arithmetic out of product code.
+pub(crate) struct DpiConverter {
     scale_factor: f64,
     uses_logical: bool,
 }
 
 impl DpiConverter {
-    pub fn new(scale_factor: f64) -> Self {
+    pub(crate) fn new(scale_factor: f64) -> Self {
         Self {
             scale_factor,
             uses_logical: cfg!(any(target_os = "macos", target_os = "windows")),
         }
     }
 
-    pub fn set_scale(&mut self, scale_factor: f64) {
+    pub(crate) fn set_scale(&mut self, scale_factor: f64) {
         self.scale_factor = scale_factor;
     }
 
-    /// Converts a physical-pixel [`GuiSize`] from the host into a logical size
-    /// suitable for internal layout calculations.
-    pub fn gui_size_to_logical(&self, size: GuiSize) -> LogicalSize<f64> {
+    /// Converts a host physical-pixel [`GuiSize`] into a logical size for internal layout.
+    pub(crate) fn gui_size_to_logical(&self, size: GuiSize) -> LogicalSize<f64> {
         LogicalSize::new(
             size.width as f64 / self.scale_factor,
             size.height as f64 / self.scale_factor,
         )
     }
 
-    /// Converts a logical size back to a physical-pixel [`GuiSize`] for the host.
-    pub fn logical_size_to_gui(&self, size: LogicalSize<f64>) -> GuiSize {
+    /// Converts a logical size back into a host physical-pixel [`GuiSize`].
+    pub(crate) fn logical_size_to_gui(&self, size: LogicalSize<f64>) -> GuiSize {
         GuiSize {
             width: (size.width * self.scale_factor).round() as u32,
             height: (size.height * self.scale_factor).round() as u32,
         }
     }
 
-    pub fn create_webview_bounds(&self, size: LogicalSize<f64>) -> wxp::Rect {
+    pub(crate) fn create_webview_bounds(&self, size: LogicalSize<f64>) -> wxp::Rect {
         wxp::Rect {
             position: LogicalPosition::new(0, 0).into(),
             size: if self.uses_logical {
@@ -50,5 +48,31 @@ impl DpiConverter {
                 Size::Physical(size.to_physical(self.scale_factor))
             },
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn converts_host_physical_size_to_logical_size() {
+        let dpi = DpiConverter::new(1.5);
+        let logical = dpi.gui_size_to_logical(GuiSize {
+            width: 900,
+            height: 600,
+        });
+
+        assert_eq!(logical.width, 600.0);
+        assert_eq!(logical.height, 400.0);
+    }
+
+    #[test]
+    fn converts_logical_size_to_host_physical_size() {
+        let dpi = DpiConverter::new(1.5);
+        let physical = dpi.logical_size_to_gui(LogicalSize::new(600.0, 400.0));
+
+        assert_eq!(physical.width, 900);
+        assert_eq!(physical.height, 600);
     }
 }

--- a/crates/wrac_wxp_gui/src/lib.rs
+++ b/crates/wrac_wxp_gui/src/lib.rs
@@ -1,17 +1,19 @@
-//! Helper that exposes the wxp WebView GUI as a `wrac_clap_adapter::PluginGui`.
+//! Shared building blocks for using wxp WebViews in WRAC plugin GUIs.
 //!
-//! Parts that need to know about the CLAP ABI remain in `wrac_clap_adapter`. This crate
-//! is responsible only for toolkit conversion of window handles and the thread affinity
-//! of the GUI runtime.
+//! Code that needs to understand the CLAP ABI stays in `wrac_clap_adapter`. This crate
+//! owns only the toolkit boundary shared by product GUI runtimes: window-handle conversion,
+//! GUI thread affinity, and WebView DPI/bounds management.
 
 mod controller;
 mod dpi;
 mod pointer;
+mod resize_drag;
 mod runtime;
+mod session;
 mod window;
 
 pub use controller::{GuiSizeLimits, WxpGuiController, WxpGuiResizeHandle};
-pub use dpi::DpiConverter;
-pub use pointer::{GlobalPointerPosition, global_pointer_position};
+pub use resize_drag::WxpNativeResizeDrag;
 pub use runtime::{WxpGuiFactory, WxpGuiRuntime};
+pub use session::{WxpFrontendSource, WxpWebViewConfig, WxpWebViewSession};
 pub use window::ParentWindowHandle;

--- a/crates/wrac_wxp_gui/src/pointer.rs
+++ b/crates/wrac_wxp_gui/src/pointer.rs
@@ -2,9 +2,9 @@
 use std::ffi::c_void;
 
 #[derive(Debug, Clone, Copy)]
-pub struct GlobalPointerPosition {
-    pub x: f64,
-    pub y: f64,
+pub(crate) struct GlobalPointerPosition {
+    pub(crate) x: f64,
+    pub(crate) y: f64,
 }
 
 #[cfg(target_os = "macos")]
@@ -28,11 +28,11 @@ unsafe extern "C" {
     fn CFRelease(cf: *const c_void);
 }
 
-pub fn global_pointer_position() -> Option<GlobalPointerPosition> {
+pub(crate) fn global_pointer_position() -> Option<GlobalPointerPosition> {
     #[cfg(target_os = "macos")]
     {
-        // WebView coordinates can shift during a host-owned editor resize. Reading the
-        // desktop cursor keeps resize gestures independent of child-view relayout.
+        // WebView coordinates can move during a host-owned editor resize, so read the
+        // desktop cursor to keep drag math independent of child-view relayout.
         let event = unsafe { CGEventCreate(std::ptr::null()) };
         if event.is_null() {
             return None;

--- a/crates/wrac_wxp_gui/src/resize_drag.rs
+++ b/crates/wrac_wxp_gui/src/resize_drag.rs
@@ -1,0 +1,75 @@
+use std::cell::RefCell;
+
+use wxp::dpi::LogicalSize;
+
+use crate::pointer::global_pointer_position;
+
+#[derive(Debug, Clone, Copy)]
+struct NativeResizeDrag {
+    drag_id: u64,
+    start_mouse_x: f64,
+    start_mouse_y: f64,
+    start_width: f64,
+    start_height: f64,
+}
+
+/// Native pointer correction for host-owned editor resizing.
+///
+/// Command names and JSON schemas stay in product code. This type only absorbs the
+/// case where WebView-relative coordinates move during resize, so product commands can
+/// pass and return logical sizes.
+#[derive(Debug, Default)]
+pub struct WxpNativeResizeDrag {
+    current: RefCell<Option<NativeResizeDrag>>,
+}
+
+impl WxpNativeResizeDrag {
+    pub fn begin(&self, drag_id: u64, size: LogicalSize<f64>) -> bool {
+        let Some(pointer) = global_pointer_position() else {
+            return false;
+        };
+
+        // Some hosts move the child WebView during resize. Computing each delta from the
+        // starting desktop cursor avoids accumulating WebView-relative coordinate error.
+        *self.current.borrow_mut() = Some(NativeResizeDrag {
+            drag_id,
+            start_mouse_x: pointer.x,
+            start_mouse_y: pointer.y,
+            start_width: size.width,
+            start_height: size.height,
+        });
+        true
+    }
+
+    pub fn end(&self, drag_id: u64) {
+        let mut current = self.current.borrow_mut();
+        // Do not let a stale end event clear a newer drag that has already started.
+        if current.as_ref().is_some_and(|drag| drag.drag_id == drag_id) {
+            *current = None;
+        }
+    }
+
+    pub fn resolve_size(
+        &self,
+        drag_id: Option<u64>,
+        fallback: LogicalSize<f64>,
+    ) -> LogicalSize<f64> {
+        let Some(drag_id) = drag_id else {
+            return fallback;
+        };
+        let current = self.current.borrow();
+        let Some(drag) = current.as_ref().filter(|drag| drag.drag_id == drag_id) else {
+            return fallback;
+        };
+        let Some(pointer) = global_pointer_position() else {
+            return fallback;
+        };
+
+        // Return frontend-facing logical pixels. `WxpGuiResizeHandle::request_resize`
+        // owns the only logical-to-physical conversion at the host boundary.
+        LogicalSize::new(
+            drag.start_width + (pointer.x - drag.start_mouse_x),
+            drag.start_height + (pointer.y - drag.start_mouse_y),
+        )
+    }
+}

--- a/crates/wrac_wxp_gui/src/runtime.rs
+++ b/crates/wrac_wxp_gui/src/runtime.rs
@@ -45,10 +45,9 @@ struct GuiRuntimeEntry {
 /// Dropping this token from another host thread blocks until `RunLoop::deinit()` has run
 /// on the owning GUI thread.
 ///
-/// TODO: once `novonotes_run_loop` gains a transactional guard API, this type should
-/// become a thin wrapper around it. The current `RunLoop::init()` does not guarantee
-/// full rollback on failure, so the local state is not advanced beyond what can be
-/// safely undone.
+/// `novonotes_run_loop` does not provide a transactional guard API, so failed
+/// `RunLoop::init()` calls cannot be treated as fully rolled back. Local state is
+/// advanced only after the part we can safely undo has succeeded.
 pub(crate) struct GuiThreadLease {
     owner: ThreadId,
     sender: RunLoopSender,

--- a/crates/wrac_wxp_gui/src/session.rs
+++ b/crates/wrac_wxp_gui/src/session.rs
@@ -1,0 +1,261 @@
+use std::path::PathBuf;
+use std::rc::Rc;
+
+use directories::ProjectDirs;
+use wrac_clap_adapter::{GuiSize, PluginError, PluginResult};
+use wxp::{WebContext, WxpCommandHandler, WxpWebView, WxpWebViewBuilder, dpi::LogicalSize};
+
+use crate::controller::GuiSizeLimits;
+use crate::dpi::DpiConverter;
+use crate::window::ParentWindowHandle;
+
+/// Frontend source loaded by the WebView.
+///
+/// Product crates decide how to switch debug/release sources. `wrac_wxp_gui` only
+/// knows how to open a URL or serve a zip under a custom scheme; frontend structure
+/// and command contracts remain product code.
+pub enum WxpFrontendSource {
+    Url {
+        url: &'static str,
+    },
+    Zip {
+        scheme: &'static str,
+        url: &'static str,
+        bytes: &'static [u8],
+    },
+}
+
+/// Configuration needed to create a native WebView session.
+///
+/// `plugin_id` is also used to isolate WebView user-data directories, so pass the same
+/// reverse-DNS ID used by the host descriptor. Size limits are interpreted as physical
+/// pixels because that is the CLAP host boundary.
+pub struct WxpWebViewConfig {
+    pub plugin_id: &'static str,
+    pub initial_size: GuiSize,
+    pub limits: GuiSizeLimits,
+    pub parent: ParentWindowHandle,
+    pub frontend: WxpFrontendSource,
+    pub devtools: bool,
+}
+
+/// WebView ownership component embedded by product runtimes.
+///
+/// This type owns only native WebView state, DPI/bounds application, show/hide, and
+/// WebContext drop ordering. Timers, state sync, command registration, and parameter
+/// notification stay in product runtimes so each GUI can choose its own sync strategy.
+pub struct WxpWebViewSession {
+    // WebView teardown can touch the context, so Drop sequences these fields explicitly.
+    web_view: Option<WxpWebView>,
+    wxp_context: Option<WebContext>,
+    // wxp expects the command handler to be owned externally, so keep it alive with the WebView.
+    command_handler: Rc<WxpCommandHandler>,
+    host_size: GuiSize,
+    logical_size: LogicalSize<f64>,
+    limits: GuiSizeLimits,
+    dpi_converter: DpiConverter,
+}
+
+impl WxpWebViewSession {
+    pub fn create(
+        config: WxpWebViewConfig,
+        command_handler: Rc<WxpCommandHandler>,
+    ) -> PluginResult<Self> {
+        log::debug!(
+            "creating wxp WebView session: plugin_id={}, width={}, height={}",
+            config.plugin_id,
+            config.initial_size.width,
+            config.initial_size.height
+        );
+
+        let data_dir = webview_data_dir(config.plugin_id);
+        std::fs::create_dir_all(&data_dir)
+            .map_err(|_| PluginError::Message("failed to create GUI data directory"))?;
+        log::debug!("using GUI data directory: {}", data_dir.display());
+
+        let mut wxp_context = WebContext::new(data_dir);
+        let dpi_converter = DpiConverter::new(1.0);
+        // The host contract is physical pixels. Convert initial bounds here so product
+        // runtimes never need platform-specific DPI branches.
+        let host_size = clamp_size(config.initial_size, config.limits);
+        let logical_size = dpi_converter.gui_size_to_logical(host_size);
+        let bounds = dpi_converter.create_webview_bounds(logical_size);
+
+        let builder = match config.frontend {
+            WxpFrontendSource::Url { url } => {
+                log::debug!("configuring wxp WebView session URL frontend: url={url}");
+                WxpWebViewBuilder::new(&mut wxp_context)
+                    .with_command_handler(command_handler.clone())
+                    .with_devtools(config.devtools)
+                    .with_visible(true)
+                    .with_bounds(bounds)
+                    .with_url(url)
+            }
+            WxpFrontendSource::Zip { scheme, url, bytes } => {
+                log::debug!("configuring wxp WebView session zip frontend: url={url}");
+                WxpWebViewBuilder::new(&mut wxp_context)
+                    .with_command_handler(command_handler.clone())
+                    .with_devtools(config.devtools)
+                    .with_visible(true)
+                    .with_bounds(bounds)
+                    .with_serve_zip(scheme, bytes)
+                    .map_err(|_| PluginError::Message("failed to serve GUI assets"))?
+                    .with_url(url)
+            }
+        };
+
+        let web_view = builder
+            .build_as_child(&config.parent)
+            .map_err(|_| PluginError::Message("failed to build webview"))?;
+
+        log::debug!("creating wxp WebView session completed");
+        Ok(Self {
+            web_view: Some(web_view),
+            wxp_context: Some(wxp_context),
+            command_handler,
+            host_size,
+            logical_size,
+            limits: config.limits,
+            dpi_converter,
+        })
+    }
+
+    pub fn set_scale(&mut self, scale: f64) -> PluginResult<()> {
+        log::debug!("setting wxp WebView scale: scale={scale}");
+        self.dpi_converter.set_scale(scale);
+        // Hosts may not resend set_size after a scale change. Reapply bounds immediately
+        // so Linux physical bounds and macOS/Windows logical bounds do not keep stale scale.
+        self.logical_size = self.dpi_converter.gui_size_to_logical(self.host_size);
+        self.apply_bounds()
+    }
+
+    pub fn set_size(&mut self, size: GuiSize) -> PluginResult<()> {
+        self.host_size = clamp_size(size, self.limits);
+        self.logical_size = self.dpi_converter.gui_size_to_logical(self.host_size);
+        log::debug!(
+            "setting wxp WebView size: requested_width={}, requested_height={}, applied_width={}, applied_height={}",
+            size.width,
+            size.height,
+            self.logical_size.width,
+            self.logical_size.height
+        );
+        self.apply_bounds()
+    }
+
+    pub fn show(&mut self) -> PluginResult<()> {
+        log::debug!("showing wxp WebView session");
+        if let Some(web_view) = &self.web_view {
+            web_view
+                .dispatch()
+                .post_set_visible(true)
+                .map_err(|_| PluginError::Message("failed to show webview"))?;
+        }
+        Ok(())
+    }
+
+    pub fn hide(&mut self) -> PluginResult<()> {
+        log::debug!("hiding wxp WebView session");
+        if let Some(web_view) = &self.web_view {
+            web_view
+                .dispatch()
+                .post_set_visible(false)
+                .map_err(|_| PluginError::Message("failed to hide webview"))?;
+        }
+        Ok(())
+    }
+
+    fn apply_bounds(&self) -> PluginResult<()> {
+        if let Some(web_view) = &self.web_view {
+            // Use the same dispatch path as command handlers and close handling so a closing
+            // WebView's native owner is not kept alive by direct access.
+            web_view
+                .dispatch()
+                .post_set_bounds(self.dpi_converter.create_webview_bounds(self.logical_size))
+                .map_err(|_| PluginError::Message("failed to resize webview"))?;
+        }
+        Ok(())
+    }
+}
+
+impl Drop for WxpWebViewSession {
+    fn drop(&mut self) {
+        log::debug!("dropping wxp WebView session");
+        self.web_view = None;
+        log::debug!("dropping wxp WebView session: webview dropped");
+        self.wxp_context = None;
+        log::debug!("dropping wxp WebView session: web context dropped");
+        let _ = Rc::strong_count(&self.command_handler);
+    }
+}
+
+fn clamp_size(size: GuiSize, limits: GuiSizeLimits) -> GuiSize {
+    GuiSize {
+        width: size.width.clamp(limits.min.width, limits.max.width),
+        height: size.height.clamp(limits.min.height, limits.max.height),
+    }
+}
+
+fn webview_data_dir(plugin_id: &str) -> PathBuf {
+    let plugin_dir = sanitize_plugin_data_dir(plugin_id);
+    // Derive the user-data path from plugin_id so a plugin created from the template
+    // does not share cookies, cache, or storage with the original template plugin.
+    match project_dirs_from_plugin_id(plugin_id) {
+        Some(dirs) => dirs.data_dir().join("webview").join(plugin_dir),
+        None => std::env::temp_dir()
+            .join(plugin_dir)
+            .join("webview")
+            .join("data"),
+    }
+}
+
+fn project_dirs_from_plugin_id(plugin_id: &str) -> Option<ProjectDirs> {
+    let mut parts = plugin_id.split('.');
+    let qualifier = parts.next()?;
+    let organization = parts.next()?;
+    let application = parts.collect::<Vec<_>>().join("-");
+    if application.is_empty() {
+        return None;
+    }
+    ProjectDirs::from(qualifier, organization, &application)
+}
+
+fn sanitize_plugin_data_dir(plugin_id: &str) -> String {
+    plugin_id
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || matches!(character, '.' | '-') {
+                character
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clamps_host_size_with_physical_limits() {
+        let clamped = clamp_size(
+            GuiSize {
+                width: 100,
+                height: 900,
+            },
+            GuiSizeLimits {
+                min: GuiSize {
+                    width: 320,
+                    height: 240,
+                },
+                max: GuiSize {
+                    width: 640,
+                    height: 480,
+                },
+            },
+        );
+
+        assert_eq!(clamped.width, 320);
+        assert_eq!(clamped.height, 480);
+    }
+}

--- a/src-plugin/Cargo.toml
+++ b/src-plugin/Cargo.toml
@@ -36,7 +36,6 @@ crate-type = ["rlib", "staticlib", "cdylib"]
 [dependencies]
 assert_no_alloc = { git = "https://github.com/Windfisch/rust-assert-no-alloc.git", rev = "d31f2d5f550ce339d1c2f0c1ab7da951224b20df", features = ["backtrace"] }
 atomic_float = "1.1.0"
-directories = "5"
 log = "0.4"
 novonotes_run_loop = { workspace = true }
 parking_lot = "0.12"

--- a/src-plugin/src/commands/resize.rs
+++ b/src-plugin/src/commands/resize.rs
@@ -1,12 +1,11 @@
-use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::Arc;
 
 use serde::Deserialize;
 use serde_json::json;
 use wrac_clap_adapter::HostGuiResizeRequester;
-use wrac_wxp_gui::{WxpGuiResizeHandle, global_pointer_position};
-use wxp::WxpCommandHandler;
+use wrac_wxp_gui::{WxpGuiResizeHandle, WxpNativeResizeDrag};
+use wxp::{WxpCommandHandler, dpi::LogicalSize};
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -30,27 +29,14 @@ struct EndGuiResizeDragRequest {
     drag_id: u64,
 }
 
-#[derive(Debug, Clone, Copy)]
-struct NativeResizeDrag {
-    drag_id: u64,
-    start_mouse_x: f64,
-    start_mouse_y: f64,
-    start_width: f64,
-    start_height: f64,
-}
-
 pub(super) fn register_resize_commands(
     command_handler: &Rc<WxpCommandHandler>,
     host_gui_resize_requester: Arc<dyn HostGuiResizeRequester>,
     gui_resize_handle: WxpGuiResizeHandle,
 ) {
-    // Split resize dragging between two responsibilities. JS owns the gesture lifetime
-    // (pointer capture/release are browser concepts). Rust owns the macOS coordinates
-    // (because the browser coordinate space is exactly the surface the host is moving).
-    // The drag ID links the browser-side trigger to this native snapshot so that every
-    // resize request can be recomputed from the original desktop cursor position,
-    // avoiding accumulated error from WebView-relative coordinates.
-    let native_resize_drag = Rc::new(RefCell::new(None::<NativeResizeDrag>));
+    // Command names and JSON contracts are the frontend/product boundary, so registration
+    // stays here. Only native drag correction and DPI-aware resize requests are delegated.
+    let native_resize_drag = Rc::new(WxpNativeResizeDrag::default());
 
     {
         let native_resize_drag = native_resize_drag.clone();
@@ -58,18 +44,11 @@ pub(super) fn register_resize_commands(
             let request = ctx
                 .arg::<BeginGuiResizeDragRequest>("request")
                 .map_err(|e| e.to_string())?;
-            let Some(mouse) = global_pointer_position() else {
-                return Ok::<_, String>(json!({ "ok": false }));
-            };
-
-            *native_resize_drag.borrow_mut() = Some(NativeResizeDrag {
-                drag_id: request.drag_id,
-                start_mouse_x: mouse.x,
-                start_mouse_y: mouse.y,
-                start_width: request.width,
-                start_height: request.height,
-            });
-            Ok::<_, String>(json!({ "ok": true }))
+            let ok = native_resize_drag.begin(
+                request.drag_id,
+                LogicalSize::new(request.width, request.height),
+            );
+            Ok::<_, String>(json!({ "ok": ok }))
         });
     }
 
@@ -79,13 +58,7 @@ pub(super) fn register_resize_commands(
             let request = ctx
                 .arg::<EndGuiResizeDragRequest>("request")
                 .map_err(|e| e.to_string())?;
-            let mut drag = native_resize_drag.borrow_mut();
-            if drag
-                .as_ref()
-                .is_some_and(|drag| drag.drag_id == request.drag_id)
-            {
-                *drag = None;
-            }
+            native_resize_drag.end(request.drag_id);
             Ok::<_, String>(json!({ "ok": true }))
         });
     }
@@ -97,23 +70,12 @@ pub(super) fn register_resize_commands(
                 .arg::<RequestGuiResizeRequest>("request")
                 .map_err(|e| e.to_string())?;
 
-            let native_request = request.drag_id.and_then(|drag_id| {
-                let drag = native_resize_drag.borrow();
-                let drag = drag.as_ref().filter(|drag| drag.drag_id == drag_id)?;
-                let mouse = global_pointer_position()?;
-                Some((
-                    drag.start_width + (mouse.x - drag.start_mouse_x),
-                    drag.start_height + (mouse.y - drag.start_mouse_y),
-                ))
-            });
-
-            let (width, height) = native_request.unwrap_or((request.width, request.height));
+            let requested = native_resize_drag.resolve_size(
+                request.drag_id,
+                LogicalSize::new(request.width, request.height),
+            );
             let size = gui_resize_handle
-                .request_resize(
-                    wxp::dpi::LogicalSize::new(width, height),
-                    ctx.webview(),
-                    host_gui_resize_requester.as_ref(),
-                )
+                .request_resize(requested, ctx.webview(), host_gui_resize_requester.as_ref())
                 .map_err(|e| e.to_string())?;
             Ok::<_, String>(json!({
                 "ok": true,

--- a/src-plugin/src/gui/runtime.rs
+++ b/src-plugin/src/gui/runtime.rs
@@ -1,16 +1,17 @@
-use std::path::PathBuf;
 use std::rc::Rc;
 use std::sync::Arc;
 use std::time::Duration;
 
-use directories::ProjectDirs;
 use run_loop_timer::Timer;
 use wrac_clap_adapter::{
     GuiConfiguration, GuiSize, HostGuiResizeRequester, HostParameterEditNotifier, PluginError,
     PluginResult,
 };
-use wrac_wxp_gui::{DpiConverter, ParentWindowHandle, WxpGuiResizeHandle, WxpGuiRuntime};
-use wxp::{WebContext, WxpCommandHandler, WxpWebView, WxpWebViewBuilder, dpi::LogicalSize};
+use wrac_wxp_gui::{
+    GuiSizeLimits, ParentWindowHandle, WxpFrontendSource, WxpGuiResizeHandle, WxpGuiRuntime,
+    WxpWebViewConfig, WxpWebViewSession,
+};
+use wxp::WxpCommandHandler;
 
 use crate::commands::register_commands;
 use crate::gui::GuiStateNotifier;
@@ -48,16 +49,12 @@ pub(super) struct GuiRuntimeDependencies {
 /// Runtime for one GUI window. Created each time the host opens the GUI; dropped when closed.
 pub(crate) struct WracGainGuiRuntime {
     gui_notifier: Arc<GuiStateNotifier>,
-    // !Send + !Sync token owning the native WebView. Stored as Option to control drop order.
-    web_view: Option<WxpWebView>,
-    // Kept alive longer than the WebView (see the Drop impl below for ordering).
-    wxp_context: Option<WebContext>,
-    command_handler: Rc<WxpCommandHandler>,
-    // Timer that periodically pushes the current shared state to the GUI.
+    // WebView ownership and DPI/bounds live in the shared component; product runtime
+    // remains responsible for choosing its state sync strategy.
+    webview: WxpWebViewSession,
+    // Host callbacks can be delayed by wrapper behavior, so this product chooses periodic
+    // sync on the GUI run loop.
     gui_update_timer: Timer,
-    gui_size: LogicalSize<f64>,
-    // Used for bounds conversion that accounts for DPI scaling.
-    dpi_converter: DpiConverter,
 }
 
 impl WracGainGuiRuntime {
@@ -96,61 +93,20 @@ impl WracGainGuiRuntime {
         );
         log::debug!("creating GUI runtime: commands registered");
 
-        // WebView2 can fail to initialise when two instances share the same user data folder
-        // with different Environment options, so isolate each plugin by ID under the
-        // OS standard app-data directory.
-        let data_dir = webview_data_dir(PLUGIN_ID);
-        std::fs::create_dir_all(&data_dir)
-            .map_err(|_| PluginError::Message("failed to create GUI data directory"))?;
-        log::debug!("using GUI data directory: {}", data_dir.display());
-
-        log::debug!("creating GUI runtime: creating WebContext");
-        let mut wxp_context = WebContext::new(data_dir);
-        // Initial scale is 1.0; the host will override it via `set_scale` later.
-        let dpi_converter = DpiConverter::new(1.0);
-        let gui_size = dpi_converter.gui_size_to_logical(initial_size);
-        let bounds = dpi_converter.create_webview_bounds(gui_size);
-        log::debug!(
-            "creating GUI runtime: computed logical size: width={}, height={}",
-            gui_size.width,
-            gui_size.height
-        );
-
-        // Debug builds point to the Vite dev server (no native rebuild needed on frontend changes).
-        // Release builds cannot depend on a dev server, so the zip bundled by build.rs is served.
-        #[cfg(debug_assertions)]
-        let builder = {
-            let url = "http://127.0.0.1:5173/";
-            log::debug!("creating GUI runtime: configuring debug WebView builder: url={url}");
-            WxpWebViewBuilder::new(&mut wxp_context)
-                .with_command_handler(command_handler.clone())
-                .with_devtools(cfg!(debug_assertions))
-                .with_visible(true)
-                .with_bounds(bounds)
-                .with_url(url)
-        };
-
-        #[cfg(not(debug_assertions))]
-        let builder = {
-            let url = "wxp-plugin://localhost/";
-            log::debug!("creating GUI runtime: configuring release WebView builder: url={url}");
-            WxpWebViewBuilder::new(&mut wxp_context)
-                .with_command_handler(command_handler.clone())
-                .with_devtools(cfg!(debug_assertions))
-                .with_visible(true)
-                .with_bounds(bounds)
-                // Serve the embedded zip under the `wxp-plugin://` scheme.
-                .with_serve_zip("wxp-plugin", FRONTEND_ZIP)
-                .map_err(|_| PluginError::Message("failed to serve GUI assets"))?
-                .with_url(url)
-        };
-
-        // Create the WebView as a child of the parent window, embedding it in the host UI.
-        log::debug!("creating GUI runtime: build_as_child start");
-        let web_view = builder
-            .build_as_child(&parent)
-            .map_err(|_| PluginError::Message("failed to build webview"))?;
-        log::debug!("creating GUI runtime: build_as_child completed");
+        let webview = WxpWebViewSession::create(
+            WxpWebViewConfig {
+                plugin_id: PLUGIN_ID,
+                initial_size,
+                limits: GuiSizeLimits {
+                    min: MIN_GUI_SIZE,
+                    max: MAX_GUI_SIZE,
+                },
+                parent,
+                frontend: frontend_source(),
+                devtools: cfg!(debug_assertions),
+            },
+            command_handler,
+        )?;
 
         // Push the current value to the GUI at ~30 Hz (33 ms). Reading shared state on
         // every tick is simpler than maintaining a dirty flag. CLAP's `request_callback()`
@@ -171,12 +127,8 @@ impl WracGainGuiRuntime {
         log::debug!("creating GUI runtime: completed");
         Ok(Self {
             gui_notifier: dependencies.gui_notifier,
-            web_view: Some(web_view),
-            wxp_context: Some(wxp_context),
-            command_handler,
+            webview,
             gui_update_timer,
-            gui_size,
-            dpi_converter,
         })
     }
 }
@@ -185,48 +137,17 @@ impl WracGainGuiRuntime {
 impl WxpGuiRuntime for WracGainGuiRuntime {
     /// Called when the host reports a display scale factor (e.g. HiDPI).
     fn set_scale(&mut self, scale: f64) -> PluginResult<()> {
-        log::debug!("setting GUI scale: scale={scale}");
-        self.dpi_converter.set_scale(scale);
-        Ok(())
+        self.webview.set_scale(scale)
     }
 
     /// Called when the host changes the window size. Clamps to the valid range before applying.
     fn set_size(&mut self, size: GuiSize) -> PluginResult<()> {
-        let clamped = GuiSize {
-            width: size.width.clamp(MIN_GUI_SIZE.width, MAX_GUI_SIZE.width),
-            height: size.height.clamp(MIN_GUI_SIZE.height, MAX_GUI_SIZE.height),
-        };
-        self.gui_size = self.dpi_converter.gui_size_to_logical(clamped);
-        log::debug!(
-            "setting GUI size: requested_width={}, requested_height={}, applied_width={}, applied_height={}",
-            size.width,
-            size.height,
-            self.gui_size.width,
-            self.gui_size.height
-        );
-
-        if let Some(web_view) = &self.web_view {
-            // wxp separates direct native WebView manipulation from the owner. Even though this
-            // is already on the GUI thread, dispatch is used to align with stale-close checks
-            // and the post/enqueue semantics used elsewhere.
-            web_view
-                .dispatch()
-                .post_set_bounds(self.dpi_converter.create_webview_bounds(self.gui_size))
-                .map_err(|_| PluginError::Message("failed to resize webview"))?;
-        }
-        Ok(())
+        self.webview.set_size(size)
     }
 
     fn show(&mut self) -> PluginResult<()> {
         log::debug!("showing GUI runtime");
-        if let Some(web_view) = &self.web_view {
-            // show/hide often races with host lifecycle events, so the close-aware dispatch
-            // path in wxp is used rather than touching the owner directly.
-            web_view
-                .dispatch()
-                .post_set_visible(true)
-                .map_err(|_| PluginError::Message("failed to show webview"))?;
-        }
+        self.webview.show()?;
         self.gui_update_timer.start();
         log::debug!("showing GUI runtime completed");
         Ok(())
@@ -235,78 +156,37 @@ impl WxpGuiRuntime for WracGainGuiRuntime {
     fn hide(&mut self) -> PluginResult<()> {
         log::debug!("hiding GUI runtime");
         self.gui_update_timer.stop();
-        if let Some(web_view) = &self.web_view {
-            // hide can be called just before destroy. If the WebView is already closed,
-            // dispatch returns WebViewClosed without extending the native object's lifetime.
-            web_view
-                .dispatch()
-                .post_set_visible(false)
-                .map_err(|_| PluginError::Message("failed to hide webview"))?;
-        }
+        self.webview.hide()?;
         log::debug!("hiding GUI runtime completed");
         Ok(())
     }
 }
 
-fn webview_data_dir(plugin_id: &str) -> PathBuf {
-    let plugin_dir = sanitize_plugin_data_dir(plugin_id);
-    // Derive the WebView user-data path from plugin_id too. Hard-coding the template name
-    // here would cause a renamed plugin to share cookies, cache, and storage with the original.
-    match project_dirs_from_plugin_id(plugin_id) {
-        Some(dirs) => dirs.data_dir().join("webview").join(plugin_dir),
-        None => std::env::temp_dir()
-            .join(plugin_dir)
-            .join("webview")
-            .join("data"),
+fn frontend_source() -> WxpFrontendSource {
+    #[cfg(debug_assertions)]
+    {
+        WxpFrontendSource::Url {
+            url: "http://127.0.0.1:5173/",
+        }
+    }
+
+    #[cfg(not(debug_assertions))]
+    {
+        WxpFrontendSource::Zip {
+            scheme: "wxp-plugin",
+            url: "wxp-plugin://localhost/",
+            bytes: FRONTEND_ZIP,
+        }
     }
 }
 
-fn project_dirs_from_plugin_id(plugin_id: &str) -> Option<ProjectDirs> {
-    let mut parts = plugin_id.split('.');
-    let qualifier = parts.next()?;
-    let organization = parts.next()?;
-    let application = parts.collect::<Vec<_>>().join("-");
-    if application.is_empty() {
-        return None;
-    }
-    ProjectDirs::from(qualifier, organization, &application)
-}
-
-fn sanitize_plugin_data_dir(plugin_id: &str) -> String {
-    plugin_id
-        .chars()
-        .map(|character| {
-            if character.is_ascii_alphanumeric() || matches!(character, '.' | '-') {
-                character
-            } else {
-                '_'
-            }
-        })
-        .collect()
-}
-
-// Override the field-declaration drop order and explicitly sequence:
-// disconnect → destroy WebView → destroy context.
-// This prevents callbacks from touching already-freed objects.
 impl Drop for WracGainGuiRuntime {
     fn drop(&mut self) {
         log::debug!("dropping GUI runtime");
-        // The timer callback depends on the run loop and GUI subscriptions. Stop it before
-        // dropping the native WebView so no tick can observe partially-destroyed GUI state.
         self.gui_update_timer.stop();
         log::debug!("dropping GUI runtime: timer stopped");
-        // The GUI is going away; clear channels from shared state as well.
         self.gui_notifier.clear_subscriptions();
         log::debug!("dropping GUI runtime: subscriptions cleared");
-        // Drop WebView before WebContext. The reverse order can cause wry to panic
-        // when the context is absent during WebView teardown.
-        self.web_view = None;
-        log::debug!("dropping GUI runtime: webview dropped");
-        self.wxp_context = None;
-        log::debug!("dropping GUI runtime: web context dropped");
-        // `command_handler` and `gui_update_timer` are left to field drop order.
-        // The two reads below make the intended "keep alive until here" explicit.
-        let _ = Rc::strong_count(&self.command_handler);
         let _ = self.gui_update_timer.is_running();
     }
 }


### PR DESCRIPTION
## Summary
- Add `WxpWebViewSession` to centralize WebView ownership, DPI-aware bounds, frontend loading, and storage setup in `wrac_wxp_gui`
- Add `WxpNativeResizeDrag` so product command handlers can reuse native resize drag correction without sharing command registration policy
- Keep product-side composition responsible for command names, JSON contracts, and state synchronization strategy
- Make low-level DPI and pointer helpers crate-private and update the template plugin to use the shared helpers

## Verification
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `git diff --check`