### PR TITLE
Update docs for xtask implicit builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ cd wrac-plugin-template
 
 # Build and install the plugin
 # Change the --target argument if you need AU or VST3
-cargo xtask build --target=clap
 cargo xtask install --target=clap
 
 # Debug builds load the GUI from the Vite dev server, so start it before launching your DAW
@@ -93,16 +92,15 @@ cargo xtask build --release
 cargo xtask build --target=vst3
 # Release build for AU and Standalone
 cargo xtask build --target=au,standalone --release
-# Validate built plugins
+# Build and validate plugins
 cargo xtask validate
-# Install built plugins
+# Build and install plugins
 cargo xtask install
 ```
 
-Launch the standalone app after building it:
+Build and launch the standalone app:
 
 ```bash
-cargo xtask build --target=standalone
 cargo xtask launch
 ```
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -44,7 +44,6 @@ cd wrac-plugin-template
 
 # プラグインをビルドしてインストール
 # AU や VST3 が必要な場合は、target 引数を変更してください。
-cargo xtask build --target=clap
 cargo xtask install --target=clap
 
 # デバッグビルドは Vite dev server から GUI を読み込むため、DAW を起動する前に立ち上げてください
@@ -90,16 +89,15 @@ cargo xtask build --release
 cargo xtask build --target=vst3
 # AU と スタンドアローンをリリースビルド
 cargo xtask build --target=au,standalone --release
-# ビルド済みプラグインを検証
+# プラグインをビルドして検証
 cargo xtask validate
-# ビルド済みプラグインをインストール
+# プラグインをビルドしてインストール
 cargo xtask install
 ```
 
-Standalone app はビルド後に起動できます:
+Standalone app をビルドして起動できます:
 
 ```bash
-cargo xtask build --target=standalone
 cargo xtask launch
 ```
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -110,10 +110,10 @@ Run the following from the repository root.
 
 ```sh
 cd /path/to/my_plugin
-cargo xtask build
 cargo xtask install
 ```
 
+`cargo xtask install` builds the selected plugin formats before installing them.
 `cargo xtask install` installs to user-local paths by default.
 Use `cargo xtask install --scope=system` for hosts that only scan system-wide plugin folders.
 The `--target` option accepts `clap`, `vst3`, and `au` as comma-separated values.

--- a/docs/setup_JA.md
+++ b/docs/setup_JA.md
@@ -110,10 +110,10 @@ rg --hidden 'repository = "https://github.com/novonotes/wrac-plugin-template"' -
 
 ```sh
 cd /path/to/my_plugin
-cargo xtask build
 cargo xtask install
 ```
 
+`cargo xtask install` は選択したプラグインフォーマットをビルドしてからインストールします。
 `cargo xtask install` は既定で user-local のパスにインストールします。
 system-wide のみをスキャンするホスト向けには `cargo xtask install --scope=system` を使います。
 `--target` オプションで `clap`、`vst3`、`au` をカンマ区切りで指定できます。


### PR DESCRIPTION
## Summary
- Update Quick Start and setup steps to reflect that `cargo xtask install` builds selected plugin formats before installing them.
- Update README command descriptions for `validate` and `launch`, which now build required artifacts implicitly.

## Verification
- `cargo xtask --help`
- `cargo xtask install --help`
- `cargo xtask validate --help`
- `cargo xtask launch --help`
- `git diff --check`