### PR TITLE
Update wxp revision and stabilize CI fetch

### DIFF
--- a/.github/scripts/retry.sh
+++ b/.github/scripts/retry.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+max_attempts=3
+
+for attempt in $(seq 1 "$max_attempts"); do
+  if "$@"; then
+    exit 0
+  else
+    status=$?
+  fi
+
+  if [ "$attempt" -eq "$max_attempts" ]; then
+    exit "$status"
+  fi
+
+  # GitHub-hosted runners can see transient registry/CDN failures, so retry only
+  # after the command has failed instead of hiding the first failure's output.
+  sleep $((attempt * 10))
+done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
   rust-test:
     name: Rust lint and test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    env:
+      CARGO_HTTP_MULTIPLEXING: false
 
     # Keep clippy and tests in one per-OS job so both checks share the same
     # checkout and compiled dependency graph. Splitting them would make the CI
@@ -69,6 +71,9 @@ jobs:
           rustc --version
           cargo --version
 
+      - name: Cargo fetch
+        run: bash .github/scripts/retry.sh cargo fetch --locked
+
       - name: Run Clippy
         run: cargo clippy --locked --workspace --all-targets -- -D warnings
 
@@ -78,6 +83,8 @@ jobs:
   plugin-build:
     name: Plugin artifact validation (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    env:
+      CARGO_HTTP_MULTIPLEXING: false
     needs:
       - rust-format
       - rust-test
@@ -139,6 +146,9 @@ jobs:
             xcodebuild -version
             /usr/bin/auval -h || true
           fi
+
+      - name: Cargo fetch
+        run: bash .github/scripts/retry.sh cargo fetch --locked
 
       - name: Build all supported artifacts
         run: cargo xtask build --release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1386,7 +1386,7 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 [[package]]
 name = "novonotes_run_loop"
 version = "0.6.0"
-source = "git+https://github.com/novonotes/wxp.git?rev=a7494eb35d661df355217be5ed75ab832cfbcd44#a7494eb35d661df355217be5ed75ab832cfbcd44"
+source = "git+https://github.com/novonotes/wxp.git?rev=e13c91e8effb625489d2487050226b75f1557a33#e13c91e8effb625489d2487050226b75f1557a33"
 dependencies = [
  "core-foundation",
  "futures",
@@ -1937,7 +1937,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 [[package]]
 name = "run_loop_timer"
 version = "0.1.0"
-source = "git+https://github.com/novonotes/wxp.git?rev=a7494eb35d661df355217be5ed75ab832cfbcd44#a7494eb35d661df355217be5ed75ab832cfbcd44"
+source = "git+https://github.com/novonotes/wxp.git?rev=e13c91e8effb625489d2487050226b75f1557a33#e13c91e8effb625489d2487050226b75f1557a33"
 dependencies = [
  "novonotes_run_loop",
 ]
@@ -2332,15 +2332,6 @@ checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
-]
-
-[[package]]
-name = "tokio"
-version = "1.52.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
-dependencies = [
- "pin-project-lite",
 ]
 
 [[package]]
@@ -2976,7 +2967,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 [[package]]
 name = "wry"
 version = "0.55.1"
-source = "git+https://github.com/novonotes/wxp.git?rev=a7494eb35d661df355217be5ed75ab832cfbcd44#a7494eb35d661df355217be5ed75ab832cfbcd44"
+source = "git+https://github.com/novonotes/wxp.git?rev=e13c91e8effb625489d2487050226b75f1557a33#e13c91e8effb625489d2487050226b75f1557a33"
 dependencies = [
  "base64",
  "block2 0.6.2",
@@ -3019,7 +3010,7 @@ dependencies = [
 [[package]]
 name = "wxp"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/novonotes/wxp.git?rev=a7494eb35d661df355217be5ed75ab832cfbcd44#a7494eb35d661df355217be5ed75ab832cfbcd44"
+source = "git+https://github.com/novonotes/wxp.git?rev=e13c91e8effb625489d2487050226b75f1557a33#e13c91e8effb625489d2487050226b75f1557a33"
 dependencies = [
  "async-trait",
  "directories",
@@ -3032,7 +3023,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "tokio",
  "wry",
  "zip 7.2.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,9 @@ resolver = "2"
 
 [workspace.dependencies]
 clap-sys = "0.5.0"
-novonotes_run_loop = { git = "https://github.com/novonotes/wxp.git", package = "novonotes_run_loop", rev = "a7494eb35d661df355217be5ed75ab832cfbcd44" }
-run_loop_timer = { git = "https://github.com/novonotes/wxp.git", package = "run_loop_timer", rev = "a7494eb35d661df355217be5ed75ab832cfbcd44" }
+novonotes_run_loop = { git = "https://github.com/novonotes/wxp.git", package = "novonotes_run_loop", rev = "e13c91e8effb625489d2487050226b75f1557a33" }
+run_loop_timer = { git = "https://github.com/novonotes/wxp.git", package = "run_loop_timer", rev = "e13c91e8effb625489d2487050226b75f1557a33" }
 wrac_clap_adapter = { path = "crates/wrac_clap_adapter" }
 wrac_log = { path = "crates/wrac_log" }
 wrac_wxp_gui = { path = "crates/wrac_wxp_gui" }
-wxp = { git = "https://github.com/novonotes/wxp.git", rev = "a7494eb35d661df355217be5ed75ab832cfbcd44" }
+wxp = { git = "https://github.com/novonotes/wxp.git", rev = "e13c91e8effb625489d2487050226b75f1557a33" }


### PR DESCRIPTION
## Summary
- Update wxp-related git dependencies to novonotes/wxp@e13c91e8effb625489d2487050226b75f1557a33
- Add retry-backed cargo fetch --locked steps before Rust CI jobs that compile or build artifacts
- Disable Cargo HTTP multiplexing in Rust CI jobs to reduce transient registry/CDN failures

## Tests
- cargo fmt --all -- --check
- cargo clippy --locked --workspace --all-targets -- -D warnings
- cargo test --locked --workspace
- cargo xtask build --release
- cargo xtask validate --release