### PR TITLE
Tidy gain template logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2906,6 +2906,7 @@ dependencies = [
  "clap-sys",
  "log",
  "parking_lot",
+ "wrac_log",
 ]
 
 [[package]]

--- a/crates/wrac_clap_adapter/Cargo.toml
+++ b/crates/wrac_clap_adapter/Cargo.toml
@@ -12,6 +12,7 @@ publish = false
 clap-sys = { workspace = true }
 log = "0.4"
 parking_lot = "0.12"
+wrac_log = { workspace = true }
 
 [lints.rust]
 unreachable_pub = "deny"

--- a/crates/wrac_clap_adapter/src/abi.rs
+++ b/crates/wrac_clap_adapter/src/abi.rs
@@ -94,7 +94,6 @@ pub(crate) struct PluginInstance {
     // deadlock (GUI query callbacks do not go through this guard).
     gui_callback_busy: Mutex<()>,
     parameter_edits: Arc<ParameterEditQueue>,
-    rt_log: wrac_log::RtLog,
     // To preserve soundness even when a wrapper violates thread/lifecycle annotations,
     // the RT path never takes a lock — only a callback that wins the atomic guard
     // constructs a `&mut` to `Processor`.
@@ -194,7 +193,6 @@ impl PluginInstance {
             latency,
             gui_callback_busy: Mutex::new(()),
             parameter_edits,
-            rt_log: wrac_log::RtLog::new_registered("clap-process"),
             processor: UnsafeCell::new(None),
             processor_busy: AtomicBool::new(false),
             lifecycle_busy: AtomicBool::new(false),
@@ -633,15 +631,14 @@ unsafe extern "C" fn plugin_reset(plugin: *const clap_plugin) {
             log::warn!("plugin.reset: missing plugin instance");
             return;
         };
-        let rt_log = instance.rt_log.writer();
         let Some(()) = instance.with_processor_mut(|processor| {
             if let Some(processor) = processor {
                 processor.reset();
             } else {
-                wrac_log::rtdebug!(rt_log, 0, 0, "plugin.reset: no processor is available");
+                wrac_log::rtdebug!("plugin.reset: no processor is available");
             }
         }) else {
-            wrac_log::rtwarn!(rt_log, 0, 0, "plugin.reset: processor is busy");
+            wrac_log::rtwarn!("plugin.reset: processor is busy");
             return;
         };
     });
@@ -656,32 +653,21 @@ unsafe extern "C" fn plugin_process(
             log::error!("plugin.process: missing plugin instance");
             return CLAP_PROCESS_ERROR;
         };
-        let rt_log = instance.rt_log.writer();
 
         if process.is_null() {
-            wrac_log::rtwarn!(rt_log, 0, 0, "plugin.process: null process pointer");
+            wrac_log::rtwarn!("plugin.process: null process pointer");
             return CLAP_PROCESS_SLEEP;
         }
         let process = unsafe { &*process };
-        let mut events = unsafe {
-            crate::ProcessEvents::from_raw_realtime(
-                process.in_events,
-                process.out_events,
-                rt_log.clone(),
-            )
-        };
+        let mut events =
+            unsafe { crate::ProcessEvents::from_raw(process.in_events, process.out_events) };
         instance
             .parameter_edits
             .drain_output_parameter_events(&mut events.output);
         let audio = match unsafe { audio_buffers(process) } {
             Ok(audio) => audio,
             Err(error) => {
-                wrac_log::rterror!(
-                    rt_log,
-                    0,
-                    0,
-                    "plugin.process: invalid audio buffers: {error}"
-                );
+                wrac_log::rterror!("plugin.process: invalid audio buffers: {error}");
                 return CLAP_PROCESS_ERROR;
             }
         };
@@ -692,7 +678,7 @@ unsafe extern "C" fn plugin_process(
         // sleep/error without waiting.
         let Some(result) = instance.with_processor_mut(|processor| {
             let Some(processor) = processor else {
-                wrac_log::rtdebug!(rt_log, 0, 0, "plugin.process: no processor is available");
+                wrac_log::rtdebug!("plugin.process: no processor is available");
                 return CLAP_PROCESS_SLEEP;
             };
 
@@ -701,19 +687,18 @@ unsafe extern "C" fn plugin_process(
                 audio,
                 events,
                 transport: unsafe { process.transport.as_ref() }.map(TransportEvent::from_raw),
-                rt_log: rt_log.clone(),
             }) {
                 Ok(ProcessStatus::Continue) => CLAP_PROCESS_CONTINUE,
                 Ok(ProcessStatus::ContinueIfNotQuiet) => CLAP_PROCESS_CONTINUE_IF_NOT_QUIET,
                 Ok(ProcessStatus::Tail) => CLAP_PROCESS_TAIL,
                 Ok(ProcessStatus::Sleep) => CLAP_PROCESS_SLEEP,
                 Err(error) => {
-                    wrac_log::rterror!(rt_log, 0, 0, "plugin.process: processor failed: {error}");
+                    wrac_log::rterror!("plugin.process: processor failed: {error}");
                     CLAP_PROCESS_ERROR
                 }
             }
         }) else {
-            wrac_log::rtwarn!(rt_log, 0, 0, "plugin.process: processor is busy");
+            wrac_log::rtwarn!("plugin.process: processor is busy");
             return CLAP_PROCESS_SLEEP;
         };
         result

--- a/crates/wrac_clap_adapter/src/abi.rs
+++ b/crates/wrac_clap_adapter/src/abi.rs
@@ -94,6 +94,7 @@ pub(crate) struct PluginInstance {
     // deadlock (GUI query callbacks do not go through this guard).
     gui_callback_busy: Mutex<()>,
     parameter_edits: Arc<ParameterEditQueue>,
+    rt_log: wrac_log::RtLog,
     // To preserve soundness even when a wrapper violates thread/lifecycle annotations,
     // the RT path never takes a lock — only a callback that wins the atomic guard
     // constructs a `&mut` to `Processor`.
@@ -193,6 +194,7 @@ impl PluginInstance {
             latency,
             gui_callback_busy: Mutex::new(()),
             parameter_edits,
+            rt_log: wrac_log::RtLog::new_registered("clap-process"),
             processor: UnsafeCell::new(None),
             processor_busy: AtomicBool::new(false),
             lifecycle_busy: AtomicBool::new(false),
@@ -631,14 +633,15 @@ unsafe extern "C" fn plugin_reset(plugin: *const clap_plugin) {
             log::warn!("plugin.reset: missing plugin instance");
             return;
         };
+        let rt_log = instance.rt_log.writer();
         let Some(()) = instance.with_processor_mut(|processor| {
             if let Some(processor) = processor {
                 processor.reset();
             } else {
-                log::debug!("plugin.reset: no processor is available");
+                wrac_log::rtdebug!(rt_log, 0, 0, "plugin.reset: no processor is available");
             }
         }) else {
-            log::warn!("plugin.reset: processor is busy");
+            wrac_log::rtwarn!(rt_log, 0, 0, "plugin.reset: processor is busy");
             return;
         };
     });
@@ -653,21 +656,32 @@ unsafe extern "C" fn plugin_process(
             log::error!("plugin.process: missing plugin instance");
             return CLAP_PROCESS_ERROR;
         };
+        let rt_log = instance.rt_log.writer();
 
         if process.is_null() {
-            log::warn!("plugin.process: null process pointer");
+            wrac_log::rtwarn!(rt_log, 0, 0, "plugin.process: null process pointer");
             return CLAP_PROCESS_SLEEP;
         }
         let process = unsafe { &*process };
-        let mut events =
-            unsafe { crate::ProcessEvents::from_raw(process.in_events, process.out_events) };
+        let mut events = unsafe {
+            crate::ProcessEvents::from_raw_realtime(
+                process.in_events,
+                process.out_events,
+                rt_log.clone(),
+            )
+        };
         instance
             .parameter_edits
             .drain_output_parameter_events(&mut events.output);
         let audio = match unsafe { audio_buffers(process) } {
             Ok(audio) => audio,
             Err(error) => {
-                log::error!("plugin.process: invalid audio buffers: {error}");
+                wrac_log::rterror!(
+                    rt_log,
+                    0,
+                    0,
+                    "plugin.process: invalid audio buffers: {error}"
+                );
                 return CLAP_PROCESS_ERROR;
             }
         };
@@ -678,7 +692,7 @@ unsafe extern "C" fn plugin_process(
         // sleep/error without waiting.
         let Some(result) = instance.with_processor_mut(|processor| {
             let Some(processor) = processor else {
-                log::debug!("plugin.process: no processor is available");
+                wrac_log::rtdebug!(rt_log, 0, 0, "plugin.process: no processor is available");
                 return CLAP_PROCESS_SLEEP;
             };
 
@@ -687,18 +701,19 @@ unsafe extern "C" fn plugin_process(
                 audio,
                 events,
                 transport: unsafe { process.transport.as_ref() }.map(TransportEvent::from_raw),
+                rt_log: rt_log.clone(),
             }) {
                 Ok(ProcessStatus::Continue) => CLAP_PROCESS_CONTINUE,
                 Ok(ProcessStatus::ContinueIfNotQuiet) => CLAP_PROCESS_CONTINUE_IF_NOT_QUIET,
                 Ok(ProcessStatus::Tail) => CLAP_PROCESS_TAIL,
                 Ok(ProcessStatus::Sleep) => CLAP_PROCESS_SLEEP,
                 Err(error) => {
-                    log::error!("plugin.process: processor failed: {error}");
+                    wrac_log::rterror!(rt_log, 0, 0, "plugin.process: processor failed: {error}");
                     CLAP_PROCESS_ERROR
                 }
             }
         }) else {
-            log::warn!("plugin.process: processor is busy");
+            wrac_log::rtwarn!(rt_log, 0, 0, "plugin.process: processor is busy");
             return CLAP_PROCESS_SLEEP;
         };
         result

--- a/crates/wrac_clap_adapter/src/api.rs
+++ b/crates/wrac_clap_adapter/src/api.rs
@@ -490,8 +490,6 @@ pub struct ProcessContext<'a> {
     pub audio: AudioProcessBuffer<'a>,
     pub events: ProcessEvents<'a>,
     pub transport: Option<TransportEvent>,
-    /// Realtime-safe logger for diagnostics emitted from `process()`.
-    pub rt_log: wrac_log::RtLogWriter,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/wrac_clap_adapter/src/api.rs
+++ b/crates/wrac_clap_adapter/src/api.rs
@@ -490,6 +490,8 @@ pub struct ProcessContext<'a> {
     pub audio: AudioProcessBuffer<'a>,
     pub events: ProcessEvents<'a>,
     pub transport: Option<TransportEvent>,
+    /// Realtime-safe logger for diagnostics emitted from `process()`.
+    pub rt_log: wrac_log::RtLogWriter,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/wrac_clap_adapter/src/events.rs
+++ b/crates/wrac_clap_adapter/src/events.rs
@@ -1,4 +1,3 @@
-use std::fmt::Display;
 use std::marker::PhantomData;
 use std::mem::size_of;
 use std::ptr;
@@ -43,23 +42,11 @@ impl<'a> ProcessEvents<'a> {
             output: unsafe { OutputEvents::from_raw(output) },
         }
     }
-
-    pub(crate) unsafe fn from_raw_realtime(
-        input: *const clap_input_events,
-        output: *const clap_output_events,
-        rt_log: wrac_log::RtLogWriter,
-    ) -> Self {
-        Self {
-            input: unsafe { InputEvents::from_raw_realtime(input, rt_log.clone()) },
-            output: unsafe { OutputEvents::from_raw_realtime(output, rt_log) },
-        }
-    }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct InputEvents<'a> {
     raw: *const clap_input_events,
-    rt_log: Option<wrac_log::RtLogWriter>,
     _marker: PhantomData<&'a clap_input_events>,
 }
 
@@ -67,29 +54,17 @@ impl<'a> InputEvents<'a> {
     pub(crate) unsafe fn from_raw(raw: *const clap_input_events) -> Self {
         Self {
             raw,
-            rt_log: None,
-            _marker: PhantomData,
-        }
-    }
-
-    pub(crate) unsafe fn from_raw_realtime(
-        raw: *const clap_input_events,
-        rt_log: wrac_log::RtLogWriter,
-    ) -> Self {
-        Self {
-            raw,
-            rt_log: Some(rt_log),
             _marker: PhantomData,
         }
     }
 
     pub fn len(&self) -> u32 {
         if self.raw.is_null() {
-            self.log_debug("input_events.len: null input event list");
+            wrac_log::rtdebug!("input_events.len: null input event list");
             return 0;
         }
         let Some(size) = (unsafe { (*self.raw).size }) else {
-            self.log_warn("input_events.len: event list has no size callback");
+            wrac_log::rtwarn!("input_events.len: event list has no size callback");
             return 0;
         };
         unsafe { size(self.raw) }
@@ -101,20 +76,16 @@ impl<'a> InputEvents<'a> {
 
     pub fn get(&self, index: u32) -> Option<InputEvent> {
         if index >= self.len() || self.raw.is_null() {
-            self.log_warn(format_args!("input_events.get: invalid index={index}"));
+            wrac_log::rtwarn!("input_events.get: invalid index={index}");
             return None;
         }
         let Some(get) = (unsafe { (*self.raw).get }) else {
-            self.log_warn(format_args!(
-                "input_events.get: event list has no get callback index={index}"
-            ));
+            wrac_log::rtwarn!("input_events.get: event list has no get callback index={index}");
             return None;
         };
         let header = unsafe { get(self.raw, index) };
         if header.is_null() {
-            self.log_warn(format_args!(
-                "input_events.get: host returned null event header index={index}"
-            ));
+            wrac_log::rtwarn!("input_events.get: host returned null event header index={index}");
             return None;
         }
         unsafe { InputEvent::from_header(&*header) }
@@ -122,7 +93,7 @@ impl<'a> InputEvents<'a> {
 
     pub fn iter(&self) -> InputEventsIter<'a> {
         InputEventsIter {
-            events: self.clone(),
+            events: *self,
             index: 0,
             len: self.len(),
         }
@@ -133,22 +104,6 @@ impl<'a> InputEvents<'a> {
             InputEvent::ParamValue(event) => Some(event),
             _ => None,
         })
-    }
-
-    fn log_debug(&self, message: impl Display) {
-        if let Some(rt_log) = &self.rt_log {
-            wrac_log::rtdebug!(rt_log, 0, 0, "{message}");
-        } else {
-            log::debug!("{message}");
-        }
-    }
-
-    fn log_warn(&self, message: impl Display) {
-        if let Some(rt_log) = &self.rt_log {
-            wrac_log::rtwarn!(rt_log, 0, 0, "{message}");
-        } else {
-            log::warn!("{message}");
-        }
     }
 }
 
@@ -180,7 +135,6 @@ impl Iterator for InputEventsIter<'_> {
 
 pub struct OutputEvents<'a> {
     raw: *const clap_output_events,
-    rt_log: Option<wrac_log::RtLogWriter>,
     _marker: PhantomData<&'a mut clap_output_events>,
 }
 
@@ -188,25 +142,13 @@ impl<'a> OutputEvents<'a> {
     pub(crate) unsafe fn from_raw(raw: *const clap_output_events) -> Self {
         Self {
             raw,
-            rt_log: None,
-            _marker: PhantomData,
-        }
-    }
-
-    pub(crate) unsafe fn from_raw_realtime(
-        raw: *const clap_output_events,
-        rt_log: wrac_log::RtLogWriter,
-    ) -> Self {
-        Self {
-            raw,
-            rt_log: Some(rt_log),
             _marker: PhantomData,
         }
     }
 
     pub fn try_push(&mut self, event: OutputEvent) -> bool {
         let Some(try_push) = self.try_push_raw() else {
-            self.log_warn("output_events.try_push: output event queue is unavailable");
+            wrac_log::rtwarn!("output_events.try_push: output event queue is unavailable");
             return false;
         };
 
@@ -261,25 +203,9 @@ impl<'a> OutputEvents<'a> {
             }
         };
         if !pushed {
-            self.log_warn("output_events.try_push: host rejected event");
+            wrac_log::rtwarn!("output_events.try_push: host rejected event");
         }
         pushed
-    }
-
-    pub(crate) fn log_debug(&self, message: impl Display) {
-        if let Some(rt_log) = &self.rt_log {
-            wrac_log::rtdebug!(rt_log, 0, 0, "{message}");
-        } else {
-            log::debug!("{message}");
-        }
-    }
-
-    fn log_warn(&self, message: impl Display) {
-        if let Some(rt_log) = &self.rt_log {
-            wrac_log::rtwarn!(rt_log, 0, 0, "{message}");
-        } else {
-            log::warn!("{message}");
-        }
     }
 
     fn try_push_raw(
@@ -287,12 +213,12 @@ impl<'a> OutputEvents<'a> {
     ) -> Option<unsafe extern "C" fn(*const clap_output_events, *const clap_event_header) -> bool>
     {
         if self.raw.is_null() {
-            self.log_debug("output_events.try_push_raw: null output event list");
+            wrac_log::rtdebug!("output_events.try_push_raw: null output event list");
             return None;
         }
         let try_push = unsafe { (*self.raw).try_push };
         if try_push.is_none() {
-            self.log_warn("output_events.try_push_raw: event list has no try_push callback");
+            wrac_log::rtwarn!("output_events.try_push_raw: event list has no try_push callback");
         }
         try_push
     }

--- a/crates/wrac_clap_adapter/src/events.rs
+++ b/crates/wrac_clap_adapter/src/events.rs
@@ -1,3 +1,4 @@
+use std::fmt::Display;
 use std::marker::PhantomData;
 use std::mem::size_of;
 use std::ptr;
@@ -42,11 +43,23 @@ impl<'a> ProcessEvents<'a> {
             output: unsafe { OutputEvents::from_raw(output) },
         }
     }
+
+    pub(crate) unsafe fn from_raw_realtime(
+        input: *const clap_input_events,
+        output: *const clap_output_events,
+        rt_log: wrac_log::RtLogWriter,
+    ) -> Self {
+        Self {
+            input: unsafe { InputEvents::from_raw_realtime(input, rt_log.clone()) },
+            output: unsafe { OutputEvents::from_raw_realtime(output, rt_log) },
+        }
+    }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct InputEvents<'a> {
     raw: *const clap_input_events,
+    rt_log: Option<wrac_log::RtLogWriter>,
     _marker: PhantomData<&'a clap_input_events>,
 }
 
@@ -54,17 +67,29 @@ impl<'a> InputEvents<'a> {
     pub(crate) unsafe fn from_raw(raw: *const clap_input_events) -> Self {
         Self {
             raw,
+            rt_log: None,
+            _marker: PhantomData,
+        }
+    }
+
+    pub(crate) unsafe fn from_raw_realtime(
+        raw: *const clap_input_events,
+        rt_log: wrac_log::RtLogWriter,
+    ) -> Self {
+        Self {
+            raw,
+            rt_log: Some(rt_log),
             _marker: PhantomData,
         }
     }
 
     pub fn len(&self) -> u32 {
         if self.raw.is_null() {
-            log::debug!("input_events.len: null input event list");
+            self.log_debug("input_events.len: null input event list");
             return 0;
         }
         let Some(size) = (unsafe { (*self.raw).size }) else {
-            log::warn!("input_events.len: event list has no size callback");
+            self.log_warn("input_events.len: event list has no size callback");
             return 0;
         };
         unsafe { size(self.raw) }
@@ -76,16 +101,20 @@ impl<'a> InputEvents<'a> {
 
     pub fn get(&self, index: u32) -> Option<InputEvent> {
         if index >= self.len() || self.raw.is_null() {
-            log::warn!("input_events.get: invalid index={index}");
+            self.log_warn(format_args!("input_events.get: invalid index={index}"));
             return None;
         }
         let Some(get) = (unsafe { (*self.raw).get }) else {
-            log::warn!("input_events.get: event list has no get callback index={index}");
+            self.log_warn(format_args!(
+                "input_events.get: event list has no get callback index={index}"
+            ));
             return None;
         };
         let header = unsafe { get(self.raw, index) };
         if header.is_null() {
-            log::warn!("input_events.get: host returned null event header index={index}");
+            self.log_warn(format_args!(
+                "input_events.get: host returned null event header index={index}"
+            ));
             return None;
         }
         unsafe { InputEvent::from_header(&*header) }
@@ -93,7 +122,7 @@ impl<'a> InputEvents<'a> {
 
     pub fn iter(&self) -> InputEventsIter<'a> {
         InputEventsIter {
-            events: *self,
+            events: self.clone(),
             index: 0,
             len: self.len(),
         }
@@ -104,6 +133,22 @@ impl<'a> InputEvents<'a> {
             InputEvent::ParamValue(event) => Some(event),
             _ => None,
         })
+    }
+
+    fn log_debug(&self, message: impl Display) {
+        if let Some(rt_log) = &self.rt_log {
+            wrac_log::rtdebug!(rt_log, 0, 0, "{message}");
+        } else {
+            log::debug!("{message}");
+        }
+    }
+
+    fn log_warn(&self, message: impl Display) {
+        if let Some(rt_log) = &self.rt_log {
+            wrac_log::rtwarn!(rt_log, 0, 0, "{message}");
+        } else {
+            log::warn!("{message}");
+        }
     }
 }
 
@@ -135,6 +180,7 @@ impl Iterator for InputEventsIter<'_> {
 
 pub struct OutputEvents<'a> {
     raw: *const clap_output_events,
+    rt_log: Option<wrac_log::RtLogWriter>,
     _marker: PhantomData<&'a mut clap_output_events>,
 }
 
@@ -142,13 +188,25 @@ impl<'a> OutputEvents<'a> {
     pub(crate) unsafe fn from_raw(raw: *const clap_output_events) -> Self {
         Self {
             raw,
+            rt_log: None,
+            _marker: PhantomData,
+        }
+    }
+
+    pub(crate) unsafe fn from_raw_realtime(
+        raw: *const clap_output_events,
+        rt_log: wrac_log::RtLogWriter,
+    ) -> Self {
+        Self {
+            raw,
+            rt_log: Some(rt_log),
             _marker: PhantomData,
         }
     }
 
     pub fn try_push(&mut self, event: OutputEvent) -> bool {
         let Some(try_push) = self.try_push_raw() else {
-            log::warn!("output_events.try_push: output event queue is unavailable");
+            self.log_warn("output_events.try_push: output event queue is unavailable");
             return false;
         };
 
@@ -203,9 +261,25 @@ impl<'a> OutputEvents<'a> {
             }
         };
         if !pushed {
-            log::warn!("output_events.try_push: host rejected event");
+            self.log_warn("output_events.try_push: host rejected event");
         }
         pushed
+    }
+
+    pub(crate) fn log_debug(&self, message: impl Display) {
+        if let Some(rt_log) = &self.rt_log {
+            wrac_log::rtdebug!(rt_log, 0, 0, "{message}");
+        } else {
+            log::debug!("{message}");
+        }
+    }
+
+    fn log_warn(&self, message: impl Display) {
+        if let Some(rt_log) = &self.rt_log {
+            wrac_log::rtwarn!(rt_log, 0, 0, "{message}");
+        } else {
+            log::warn!("{message}");
+        }
     }
 
     fn try_push_raw(
@@ -213,12 +287,12 @@ impl<'a> OutputEvents<'a> {
     ) -> Option<unsafe extern "C" fn(*const clap_output_events, *const clap_event_header) -> bool>
     {
         if self.raw.is_null() {
-            log::debug!("output_events.try_push_raw: null output event list");
+            self.log_debug("output_events.try_push_raw: null output event list");
             return None;
         }
         let try_push = unsafe { (*self.raw).try_push };
         if try_push.is_none() {
-            log::warn!("output_events.try_push_raw: event list has no try_push callback");
+            self.log_warn("output_events.try_push_raw: event list has no try_push callback");
         }
         try_push
     }

--- a/crates/wrac_clap_adapter/src/params.rs
+++ b/crates/wrac_clap_adapter/src/params.rs
@@ -49,8 +49,9 @@ impl ParameterEditQueue {
         // momentarily busy, defer to the next flush/process. request_flush to the host
         // was already issued when the edit was enqueued.
         let Some(mut pending) = self.pending.try_lock() else {
-            events
-                .log_debug("parameter_edits.drain: pending queue try_lock failed; retrying later");
+            wrac_log::rtdebug!(
+                "parameter_edits.drain: pending queue try_lock failed; retrying later"
+            );
             return;
         };
 

--- a/crates/wrac_clap_adapter/src/params.rs
+++ b/crates/wrac_clap_adapter/src/params.rs
@@ -49,7 +49,8 @@ impl ParameterEditQueue {
         // momentarily busy, defer to the next flush/process. request_flush to the host
         // was already issued when the edit was enqueued.
         let Some(mut pending) = self.pending.try_lock() else {
-            log::debug!("parameter_edits.drain: pending queue try_lock failed; retrying later");
+            events
+                .log_debug("parameter_edits.drain: pending queue try_lock failed; retrying later");
             return;
         };
 

--- a/crates/wrac_log/src/lib.rs
+++ b/crates/wrac_log/src/lib.rs
@@ -1,8 +1,8 @@
 //! Logging utilities for WRAC plugins.
 //!
 //! Regular logs are written through the `log` facade. Realtime audio threads must use
-//! the `rt*` macros with an [`RtLogWriter`], which writes into a fixed-size buffer
-//! drained later from a non-realtime worker.
+//! the `rt*` macros, which write into a fixed-size global buffer drained later from a
+//! non-realtime worker.
 
 mod file_logger;
 mod rt;
@@ -11,7 +11,9 @@ pub use file_logger::{
     RecentLogFilesOptions, collect_recent_log_files, current_log_dir, current_log_file, init_impl,
     init_test,
 };
-pub use rt::{RtDrainConfig, RtLog, RtLogWriter, drain_rt_logs_once, init_rt_log_drain_once};
+#[doc(hidden)]
+pub use rt::write_rt_log as __write_rt_log;
+pub use rt::{RtDrainConfig, drain_rt_logs_once, init_rt_log_drain_once};
 
 /// Initializes logging for a WRAC plugin.
 ///
@@ -40,65 +42,50 @@ macro_rules! init {
 
 #[macro_export]
 macro_rules! rttrace {
-    ($writer:expr, $block_seq:expr, $sample_time:expr, $($arg:tt)+) => {{
-        (&$writer).write_fmt(
-            log::Level::Trace,
-            module_path!(),
-            $block_seq,
-            $sample_time,
-            format_args!($($arg)+),
-        );
+    (target: $target:expr, $($arg:tt)+) => {{
+        $crate::__write_rt_log(log::Level::Trace, $target, format_args!($($arg)+));
+    }};
+    ($($arg:tt)+) => {{
+        $crate::__write_rt_log(log::Level::Trace, module_path!(), format_args!($($arg)+));
     }};
 }
 
 #[macro_export]
 macro_rules! rtdebug {
-    ($writer:expr, $block_seq:expr, $sample_time:expr, $($arg:tt)+) => {{
-        (&$writer).write_fmt(
-            log::Level::Debug,
-            module_path!(),
-            $block_seq,
-            $sample_time,
-            format_args!($($arg)+),
-        );
+    (target: $target:expr, $($arg:tt)+) => {{
+        $crate::__write_rt_log(log::Level::Debug, $target, format_args!($($arg)+));
+    }};
+    ($($arg:tt)+) => {{
+        $crate::__write_rt_log(log::Level::Debug, module_path!(), format_args!($($arg)+));
     }};
 }
 
 #[macro_export]
 macro_rules! rtinfo {
-    ($writer:expr, $block_seq:expr, $sample_time:expr, $($arg:tt)+) => {{
-        (&$writer).write_fmt(
-            log::Level::Info,
-            module_path!(),
-            $block_seq,
-            $sample_time,
-            format_args!($($arg)+),
-        );
+    (target: $target:expr, $($arg:tt)+) => {{
+        $crate::__write_rt_log(log::Level::Info, $target, format_args!($($arg)+));
+    }};
+    ($($arg:tt)+) => {{
+        $crate::__write_rt_log(log::Level::Info, module_path!(), format_args!($($arg)+));
     }};
 }
 
 #[macro_export]
 macro_rules! rtwarn {
-    ($writer:expr, $block_seq:expr, $sample_time:expr, $($arg:tt)+) => {{
-        (&$writer).write_fmt(
-            log::Level::Warn,
-            module_path!(),
-            $block_seq,
-            $sample_time,
-            format_args!($($arg)+),
-        );
+    (target: $target:expr, $($arg:tt)+) => {{
+        $crate::__write_rt_log(log::Level::Warn, $target, format_args!($($arg)+));
+    }};
+    ($($arg:tt)+) => {{
+        $crate::__write_rt_log(log::Level::Warn, module_path!(), format_args!($($arg)+));
     }};
 }
 
 #[macro_export]
 macro_rules! rterror {
-    ($writer:expr, $block_seq:expr, $sample_time:expr, $($arg:tt)+) => {{
-        (&$writer).write_fmt(
-            log::Level::Error,
-            module_path!(),
-            $block_seq,
-            $sample_time,
-            format_args!($($arg)+),
-        );
+    (target: $target:expr, $($arg:tt)+) => {{
+        $crate::__write_rt_log(log::Level::Error, $target, format_args!($($arg)+));
+    }};
+    ($($arg:tt)+) => {{
+        $crate::__write_rt_log(log::Level::Error, module_path!(), format_args!($($arg)+));
     }};
 }

--- a/crates/wrac_log/src/rt.rs
+++ b/crates/wrac_log/src/rt.rs
@@ -1,8 +1,8 @@
 use log::Level;
 use std::array;
 use std::fmt::{self, Write as _};
-use std::sync::atomic::{AtomicU8, AtomicU32, AtomicU64, AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex, OnceLock, Weak};
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicU8, AtomicU64, AtomicUsize, Ordering};
 use std::thread;
 use std::time::Duration;
 
@@ -10,7 +10,7 @@ const RT_LOG_CAPACITY: usize = 4096;
 const RT_MESSAGE_CAPACITY: usize = 256;
 const RT_TARGET_CAPACITY: usize = 96;
 
-static RT_REGISTRY: OnceLock<RtRegistry> = OnceLock::new();
+static RT_LOG: OnceLock<RtLogInner> = OnceLock::new();
 static RT_DRAIN_WORKER: OnceLock<()> = OnceLock::new();
 
 /// Configuration for the background realtime log drain worker.
@@ -27,7 +27,7 @@ impl Default for RtDrainConfig {
 }
 
 impl RtDrainConfig {
-    /// Sets how often the background worker drains registered realtime logs.
+    /// Sets how often the background worker drains realtime logs.
     pub fn with_interval(mut self, interval: Duration) -> Self {
         self.interval = interval;
         self
@@ -53,112 +53,31 @@ pub fn init_rt_log_drain_once(config: RtDrainConfig) {
     });
 }
 
-/// Drains all currently registered realtime logs once on the current thread.
+/// Drains the global realtime log once on the current thread.
 pub fn drain_rt_logs_once() {
-    rt_registry().drain_all();
+    rt_log().drain_to_log();
 }
 
 pub(crate) fn start_drain_if_enabled() {
+    // Initialize from the non-realtime setup path so the first RT log write only
+    // touches atomics and the fixed buffer.
+    let _ = rt_log();
+
     if cfg!(debug_assertions) || std::env::var_os("WRAC_RT_LOG").is_some() {
         init_rt_log_drain_once(RtDrainConfig::default());
     }
 }
 
-/// A fixed-size realtime-safe log buffer.
-///
-/// Create one per realtime component and move cloned [`RtLogWriter`] values into the
-/// realtime path. Dropping `RtLog` unregisters it from the global drain registry after
-/// one final drain.
-pub struct RtLog {
-    inner: Arc<RtLogInner>,
+#[doc(hidden)]
+pub fn write_rt_log(level: Level, target: &'static str, args: fmt::Arguments<'_>) {
+    rt_log().write_fmt(level, target, args);
 }
 
-impl RtLog {
-    /// Creates and registers a realtime log with the global drain registry.
-    pub fn new_registered(name: &'static str) -> Self {
-        let inner = Arc::new(RtLogInner::new(name));
-        rt_registry().register(&inner);
-        Self { inner }
-    }
-
-    /// Returns a cheap cloneable writer for use from realtime code.
-    pub fn writer(&self) -> RtLogWriter {
-        RtLogWriter {
-            inner: self.inner.clone(),
-        }
-    }
-}
-
-impl Drop for RtLog {
-    fn drop(&mut self) {
-        self.inner.drain_to_log();
-        rt_registry().unregister(&self.inner);
-    }
-}
-
-#[derive(Clone)]
-/// Cloneable handle used by the `rt*` macros to write realtime log records.
-pub struct RtLogWriter {
-    inner: Arc<RtLogInner>,
-}
-
-impl RtLogWriter {
-    #[doc(hidden)]
-    pub fn write_fmt(
-        &self,
-        level: Level,
-        target: &'static str,
-        block_seq: u64,
-        sample_time: u32,
-        args: fmt::Arguments<'_>,
-    ) {
-        self.inner
-            .write_fmt(level, target, block_seq, sample_time, args);
-    }
-}
-
-struct RtRegistry {
-    logs: Mutex<Vec<Weak<RtLogInner>>>,
-}
-
-impl RtRegistry {
-    fn register(&self, log: &Arc<RtLogInner>) {
-        if let Ok(mut logs) = self.logs.lock() {
-            logs.push(Arc::downgrade(log));
-        }
-    }
-
-    fn unregister(&self, log: &Arc<RtLogInner>) {
-        if let Ok(mut logs) = self.logs.lock() {
-            logs.retain(|registered| {
-                registered
-                    .upgrade()
-                    .is_some_and(|inner| !Arc::ptr_eq(&inner, log))
-            });
-        }
-    }
-
-    fn drain_all(&self) {
-        if let Ok(mut logs) = self.logs.lock() {
-            logs.retain(|registered| {
-                let Some(log) = registered.upgrade() else {
-                    return false;
-                };
-                log.drain_to_log();
-                true
-            });
-        }
-    }
-}
-
-fn rt_registry() -> &'static RtRegistry {
-    RT_REGISTRY.get_or_init(|| RtRegistry {
-        logs: Mutex::new(Vec::new()),
-    })
+fn rt_log() -> &'static RtLogInner {
+    RT_LOG.get_or_init(RtLogInner::new)
 }
 
 struct RtLogInner {
-    name: &'static str,
     next_sequence: AtomicU64,
     drain_sequence: AtomicU64,
     dropped: AtomicU64,
@@ -166,9 +85,8 @@ struct RtLogInner {
 }
 
 impl RtLogInner {
-    fn new(name: &'static str) -> Self {
+    fn new() -> Self {
         Self {
-            name,
             next_sequence: AtomicU64::new(0),
             drain_sequence: AtomicU64::new(0),
             dropped: AtomicU64::new(0),
@@ -177,28 +95,14 @@ impl RtLogInner {
         }
     }
 
-    fn write_fmt(
-        &self,
-        level: Level,
-        target: &'static str,
-        block_seq: u64,
-        sample_time: u32,
-        args: fmt::Arguments<'_>,
-    ) {
+    fn write_fmt(&self, level: Level, target: &'static str, args: fmt::Arguments<'_>) {
         let sequence = self.next_sequence.fetch_add(1, Ordering::Relaxed);
         let drain_sequence = self.drain_sequence.load(Ordering::Acquire);
         if sequence.saturating_sub(drain_sequence) >= RT_LOG_CAPACITY as u64 {
             self.dropped.fetch_add(1, Ordering::Relaxed);
         }
 
-        self.slots[sequence as usize % RT_LOG_CAPACITY].write(
-            sequence,
-            level,
-            target,
-            block_seq,
-            sample_time,
-            args,
-        );
+        self.slots[sequence as usize % RT_LOG_CAPACITY].write(sequence, level, target, args);
     }
 
     fn drain_to_log(&self) {
@@ -214,8 +118,7 @@ impl RtLogInner {
         if dropped > 0 || start > previous_drain_sequence {
             log::warn!(
                 target: "wrac_log::rt",
-                "[rt] name={} dropped={} skipped={}",
-                self.name,
+                "[rt] dropped={} skipped={}",
                 dropped,
                 start.saturating_sub(previous_drain_sequence),
             );
@@ -227,11 +130,8 @@ impl RtLogInner {
                 log::log!(
                     target: record.target.as_str(),
                     record.level,
-                    "[rt] name={} seq={} block={} sample={} {}",
-                    self.name,
+                    "[rt] seq={} {}",
                     record.sequence,
-                    record.block_seq,
-                    record.sample_time,
                     record.message.as_str(),
                 );
                 drained_until = sequence + 1;
@@ -248,8 +148,6 @@ impl RtLogInner {
 struct RtLogSlot {
     sequence: AtomicU64,
     level: AtomicU8,
-    block_seq: AtomicU64,
-    sample_time: AtomicU32,
     target_len: AtomicUsize,
     target: [AtomicU8; RT_TARGET_CAPACITY],
     message_len: AtomicUsize,
@@ -261,8 +159,6 @@ impl RtLogSlot {
         Self {
             sequence: AtomicU64::new(0),
             level: AtomicU8::new(level_to_u8(Level::Debug)),
-            block_seq: AtomicU64::new(0),
-            sample_time: AtomicU32::new(0),
             target_len: AtomicUsize::new(0),
             target: array::from_fn(|_| AtomicU8::new(0)),
             message_len: AtomicUsize::new(0),
@@ -270,19 +166,9 @@ impl RtLogSlot {
         }
     }
 
-    fn write(
-        &self,
-        sequence: u64,
-        level: Level,
-        target: &str,
-        block_seq: u64,
-        sample_time: u32,
-        args: fmt::Arguments<'_>,
-    ) {
+    fn write(&self, sequence: u64, level: Level, target: &str, args: fmt::Arguments<'_>) {
         self.sequence.store(0, Ordering::Release);
         self.level.store(level_to_u8(level), Ordering::Relaxed);
-        self.block_seq.store(block_seq, Ordering::Relaxed);
-        self.sample_time.store(sample_time, Ordering::Relaxed);
         write_atomic_bytes(&self.target, &self.target_len, target.as_bytes());
 
         let mut message = FixedMessage::new();
@@ -299,8 +185,6 @@ impl RtLogSlot {
         let record = RtLogRecord {
             sequence,
             level: u8_to_level(self.level.load(Ordering::Relaxed)),
-            block_seq: self.block_seq.load(Ordering::Relaxed),
-            sample_time: self.sample_time.load(Ordering::Relaxed),
             target: read_atomic_string::<RT_TARGET_CAPACITY>(&self.target, &self.target_len),
             message: read_atomic_string::<RT_MESSAGE_CAPACITY>(&self.message, &self.message_len),
         };
@@ -316,8 +200,6 @@ impl RtLogSlot {
 struct RtLogRecord {
     sequence: u64,
     level: Level,
-    block_seq: u64,
-    sample_time: u32,
     target: FixedString<RT_TARGET_CAPACITY>,
     message: FixedString<RT_MESSAGE_CAPACITY>,
 }
@@ -415,13 +297,13 @@ mod tests {
 
     #[test]
     fn drain_stops_before_unpublished_slot() {
-        let log = RtLogInner::new("test");
+        let log = RtLogInner::new();
         log.next_sequence.store(1, Ordering::Release);
 
         log.drain_to_log();
         assert_eq!(log.drain_sequence.load(Ordering::Acquire), 0);
 
-        log.slots[0].write(0, Level::Debug, "test", 10, 20, format_args!("published"));
+        log.slots[0].write(0, Level::Debug, "test", format_args!("published"));
         log.drain_to_log();
         assert_eq!(log.drain_sequence.load(Ordering::Acquire), 1);
     }

--- a/plugins/wrac-gain/src-plugin/src/commands.rs
+++ b/plugins/wrac-gain/src-plugin/src/commands.rs
@@ -37,7 +37,7 @@ pub(crate) fn register_commands(
     // plugin's logger so GUI initialisation progress is visible in native log output.
     command_handler.register_sync("write_to_log", move |ctx| {
         let message = ctx.arg::<String>("message").map_err(|e| e.to_string())?;
-        log::info!("frontend: {message}");
+        log::debug!("frontend: {message}");
         Ok::<_, String>(json!({ "ok": true }))
     });
 

--- a/plugins/wrac-gain/src-plugin/src/gui/runtime.rs
+++ b/plugins/wrac-gain/src-plugin/src/gui/runtime.rs
@@ -78,10 +78,7 @@ impl WracGainGuiRuntime {
             initial_size.height
         );
 
-        // Register parameter commands callable from the WebView.
-        log::debug!("creating GUI runtime: creating command handler");
         let command_handler = Rc::new(WxpCommandHandler::new());
-        log::debug!("creating GUI runtime: registering commands");
         register_commands(
             command_handler.clone(),
             dependencies.project_state.clone(),
@@ -91,7 +88,6 @@ impl WracGainGuiRuntime {
             dependencies.host_gui_resize_requester,
             dependencies.resize_handle,
         );
-        log::debug!("creating GUI runtime: commands registered");
 
         let webview = WxpWebViewSession::create(
             WxpWebViewConfig {
@@ -120,9 +116,7 @@ impl WracGainGuiRuntime {
                 gui_notifier.notify_parameter(PARAM_GAIN_ID, shared.gain());
             }
         });
-        log::debug!("creating GUI runtime: starting GUI update timer");
         gui_update_timer.start();
-        log::debug!("creating GUI runtime: GUI update timer started");
 
         log::debug!("creating GUI runtime: completed");
         Ok(Self {

--- a/plugins/wrac-gain/src-plugin/src/plugin.rs
+++ b/plugins/wrac-gain/src-plugin/src/plugin.rs
@@ -180,7 +180,7 @@ pub(crate) fn create_plugin_core(context: PluginCoreContext) -> Box<dyn PluginCo
         PLUGIN_DESCRIPTOR.name
     );
     for parameter in [gain_parameter_info(), bypass_parameter_info()] {
-        log::info!(
+        log::debug!(
             "host parameter schema: id={}, name={}, min={}, max={}, default={}, automatable={}, stepped={}, enum={}, bypass={}",
             parameter.id,
             parameter.name,

--- a/plugins/wrac-gain/src-plugin/src/plugin/parameters.rs
+++ b/plugins/wrac-gain/src-plugin/src/plugin/parameters.rs
@@ -36,22 +36,16 @@ impl WracGainParameters {
 impl PluginParameters for WracGainParameters {
     fn parameter_count(&self) -> u32 {
         // When adding a new parameter: keep this count in sync with the `parameter_info()` match.
-        log::debug!("parameter_count -> 2");
         2
     }
 
     fn parameter_info(&self, index: u32) -> Option<ParameterInfo> {
         // Mapping of sequential index to stable ID. IDs persist in project/automation data — never change them.
-        let info = match index {
+        match index {
             0 => Some(gain_parameter_info()),
             1 => Some(bypass_parameter_info()),
             _ => None,
-        };
-        log::debug!(
-            "parameter_info: index={index} -> {:?}",
-            info.as_ref().map(|info| (info.id, info.name))
-        );
-        info
+        }
     }
 
     /// Answers the host's query for the current value of a parameter.

--- a/plugins/wrac-gain/src-plugin/src/plugin/state_support.rs
+++ b/plugins/wrac-gain/src-plugin/src/plugin/state_support.rs
@@ -48,12 +48,6 @@ impl PluginStateSupport for WracGainStateSupport {
     fn save_state(&self) -> PluginResult<PluginState> {
         let project = self.project_state.snapshot();
         let params = self.shared.snapshot_parameters();
-        log::debug!(
-            "saving plugin state: gain={}, bypass={}, editor_page={}",
-            params.gain,
-            params.bypass,
-            project.editor_page.as_str()
-        );
         let bytes = serde_json::to_vec(&SavedPluginState {
             gain: params.gain,
             bypass: params.bypass,


### PR DESCRIPTION
## Summary
- Route process/reset diagnostics through the realtime log buffer when running on the audio path
- Pass a realtime log writer through `ProcessContext` and realtime-backed event views
- Reduce noisy gain template logs by demoting frontend/schema logs and removing frequent query/state-save logs

## Validation
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test`
- `cargo xtask build`
- `cargo xtask validate`

Note: `cargo xtask validate` reported the existing CLAP scan-time warning, but all validators completed with zero failures.