### PR TITLE
Update template for wxp RunLoop API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1418,7 +1418,7 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 [[package]]
 name = "novonotes_run_loop"
 version = "0.6.0"
-source = "git+https://github.com/novonotes/wxp.git?rev=e13c91e8effb625489d2487050226b75f1557a33#e13c91e8effb625489d2487050226b75f1557a33"
+source = "git+https://github.com/novonotes/wxp.git?rev=0feb83811e0b7e65ed3f06a5c5ed8a9a77e9b717#0feb83811e0b7e65ed3f06a5c5ed8a9a77e9b717"
 dependencies = [
  "core-foundation",
  "futures",
@@ -1969,7 +1969,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 [[package]]
 name = "run_loop_timer"
 version = "0.1.0"
-source = "git+https://github.com/novonotes/wxp.git?rev=e13c91e8effb625489d2487050226b75f1557a33#e13c91e8effb625489d2487050226b75f1557a33"
+source = "git+https://github.com/novonotes/wxp.git?rev=0feb83811e0b7e65ed3f06a5c5ed8a9a77e9b717#0feb83811e0b7e65ed3f06a5c5ed8a9a77e9b717"
 dependencies = [
  "novonotes_run_loop",
 ]
@@ -3008,7 +3008,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 [[package]]
 name = "wry"
 version = "0.55.1"
-source = "git+https://github.com/novonotes/wxp.git?rev=e13c91e8effb625489d2487050226b75f1557a33#e13c91e8effb625489d2487050226b75f1557a33"
+source = "git+https://github.com/novonotes/wxp.git?rev=0feb83811e0b7e65ed3f06a5c5ed8a9a77e9b717#0feb83811e0b7e65ed3f06a5c5ed8a9a77e9b717"
 dependencies = [
  "base64",
  "block2 0.6.2",
@@ -3051,7 +3051,7 @@ dependencies = [
 [[package]]
 name = "wxp"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/novonotes/wxp.git?rev=e13c91e8effb625489d2487050226b75f1557a33#e13c91e8effb625489d2487050226b75f1557a33"
+source = "git+https://github.com/novonotes/wxp.git?rev=0feb83811e0b7e65ed3f06a5c5ed8a9a77e9b717#0feb83811e0b7e65ed3f06a5c5ed8a9a77e9b717"
 dependencies = [
  "async-trait",
  "directories",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,9 @@ resolver = "2"
 
 [workspace.dependencies]
 clap-sys = "0.5.0"
-novonotes_run_loop = { git = "https://github.com/novonotes/wxp.git", package = "novonotes_run_loop", rev = "e13c91e8effb625489d2487050226b75f1557a33" }
-run_loop_timer = { git = "https://github.com/novonotes/wxp.git", package = "run_loop_timer", rev = "e13c91e8effb625489d2487050226b75f1557a33" }
+novonotes_run_loop = { git = "https://github.com/novonotes/wxp.git", package = "novonotes_run_loop", rev = "0feb83811e0b7e65ed3f06a5c5ed8a9a77e9b717" }
+run_loop_timer = { git = "https://github.com/novonotes/wxp.git", package = "run_loop_timer", rev = "0feb83811e0b7e65ed3f06a5c5ed8a9a77e9b717" }
 wrac_clap_adapter = { path = "crates/wrac_clap_adapter" }
 wrac_log = { path = "crates/wrac_log" }
 wrac_wxp_gui = { path = "crates/wrac_wxp_gui" }
-wxp = { git = "https://github.com/novonotes/wxp.git", rev = "e13c91e8effb625489d2487050226b75f1557a33" }
+wxp = { git = "https://github.com/novonotes/wxp.git", rev = "0feb83811e0b7e65ed3f06a5c5ed8a9a77e9b717" }

--- a/crates/wrac_wxp_gui/src/controller.rs
+++ b/crates/wrac_wxp_gui/src/controller.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
+use novonotes_run_loop::{RunLoop, RunLoopLocal};
 use parking_lot::Mutex;
 use wrac_clap_adapter::{
     GuiApi, GuiConfig, GuiResizeHints, GuiSize, HostGuiResizeRequester, HostWindow, PluginError,
@@ -82,6 +83,14 @@ struct GuiSession {
     parent_lease: Option<GuiThreadLease>,
     handle: Option<GuiRuntimeHandle>,
     visible: bool,
+}
+
+struct RuntimeCreationRequest {
+    configuration: GuiConfig,
+    size: GuiSize,
+    parent: StoredParentWindow,
+    scale: f64,
+    generation: u64,
 }
 
 #[derive(Clone)]
@@ -167,7 +176,7 @@ fn schedule_runtime_creation(
     // makes host lifecycle re-entry more likely. Posting to the run loop centralizes
     // creation serialization, pending visibility/size application, and stale-generation
     // teardown in one place.
-    let (configuration, parent, sender) = {
+    let (configuration, parent) = {
         let mut state = runtime.lock();
         if state.is_creating_runtime {
             log::debug!(
@@ -187,163 +196,179 @@ fn schedule_runtime_creation(
             return Ok(());
         }
         let parent = session.parent.ok_or(PluginError::InvalidState)?;
-        let sender = session
+        session
             .parent_lease
             .as_ref()
-            .ok_or(PluginError::InvalidState)?
-            .sender();
+            .ok_or(PluginError::InvalidState)?;
         let configuration = session.configuration;
         state.is_creating_runtime = true;
         state.creating_generation = Some(generation);
         state.pending_creation_generation = None;
         state.destroy_requested_while_creating = false;
-        (configuration, parent, sender)
+        (configuration, parent)
     };
 
     log::debug!("wxp controller: posting runtime creation: generation={generation}");
     let factory_for_callback = factory.clone();
     let runtime_for_callback = runtime.clone();
     let layout_for_callback = layout.clone();
-    sender.send(move || {
-            log::debug!("wxp controller: posted runtime creation started: generation={generation}");
-            let result = create_runtime_on_gui_thread(
-                factory_for_callback.as_ref(),
-                runtime_for_callback.as_ref(),
-                layout_for_callback.as_ref(),
-                configuration,
-                parent,
-                generation,
+    let post_result = RunLoop::post(move |run_loop| {
+        log::debug!("wxp controller: posted runtime creation started: generation={generation}");
+        let result = create_runtime_on_gui_thread(
+            run_loop,
+            factory_for_callback.as_ref(),
+            runtime_for_callback.as_ref(),
+            layout_for_callback.as_ref(),
+            configuration,
+            parent,
+            generation,
+        );
+
+        let handle = match result {
+            Ok(handle) => handle,
+            Err(error) => {
+                log::warn!(
+                    "wxp controller: posted runtime creation failed: generation={generation}, error={error:?}"
+                );
+                schedule_pending_runtime_creation(
+                    factory_for_callback,
+                    runtime_for_callback,
+                    layout_for_callback,
+                );
+                return;
+            }
+        };
+
+        let Some((visible, size, scale)) = latest_runtime_state(
+            runtime_for_callback.as_ref(),
+            layout_for_callback.as_ref(),
+            generation,
+        ) else {
+            log::debug!(
+                "wxp controller: posted runtime creation produced stale runtime: generation={generation}"
             );
-
-            let handle = match result {
-                Ok(handle) => handle,
-                Err(error) => {
-                    log::warn!(
-                        "wxp controller: posted runtime creation failed: generation={generation}, error={error:?}"
-                    );
-                    schedule_pending_runtime_creation(
-                        factory_for_callback,
-                        runtime_for_callback,
-                        layout_for_callback,
-                    );
-                    return;
-                }
-            };
-
-            let Some((visible, size, scale)) = latest_runtime_state(
-                runtime_for_callback.as_ref(),
-                layout_for_callback.as_ref(),
-                generation,
-            ) else {
-                log::debug!(
-                    "wxp controller: posted runtime creation produced stale runtime: generation={generation}"
-                );
-                handle.destroy();
-                runtime_for_callback.lock().last_runtime_destroyed_at = Some(Instant::now());
-                schedule_pending_runtime_creation(
-                    factory_for_callback,
-                    runtime_for_callback,
-                    layout_for_callback,
-                );
-                return;
-            };
-
-            if let Err(error) = handle.set_size(size) {
-                log::warn!(
-                    "wxp controller: posted runtime creation latest set_size failed: {error:?}"
-                );
-                handle.destroy();
-                runtime_for_callback.lock().last_runtime_destroyed_at = Some(Instant::now());
-                schedule_pending_runtime_creation(
-                    factory_for_callback,
-                    runtime_for_callback,
-                    layout_for_callback,
-                );
-                return;
-            }
-            if let Err(error) = handle.set_scale(scale) {
-                log::warn!(
-                    "wxp controller: posted runtime creation latest set_scale failed: {error:?}"
-                );
-                handle.destroy();
-                runtime_for_callback.lock().last_runtime_destroyed_at = Some(Instant::now());
-                schedule_pending_runtime_creation(
-                    factory_for_callback,
-                    runtime_for_callback,
-                    layout_for_callback,
-                );
-                return;
-            }
-
-            if !visible {
-                log::debug!("wxp controller: posted runtime creation hiding initially hidden runtime");
-                if let Err(error) = handle.hide() {
-                    log::warn!(
-                        "wxp controller: posted runtime creation initial hide failed: {error:?}"
-                    );
-                    handle.destroy();
-                    runtime_for_callback.lock().last_runtime_destroyed_at = Some(Instant::now());
-                    schedule_pending_runtime_creation(
-                        factory_for_callback,
-                        runtime_for_callback,
-                        layout_for_callback,
-                    );
-                    return;
-                }
-            }
-
-            let mut state = runtime_for_callback.lock();
-            let Some(session) = state.session.as_mut() else {
-                drop(state);
-                handle.destroy();
-                runtime_for_callback.lock().last_runtime_destroyed_at = Some(Instant::now());
-                schedule_pending_runtime_creation(
-                    factory_for_callback,
-                    runtime_for_callback,
-                    layout_for_callback,
-                );
-                return;
-            };
-            if session.generation != generation {
-                drop(state);
-                handle.destroy();
-                runtime_for_callback.lock().last_runtime_destroyed_at = Some(Instant::now());
-                schedule_pending_runtime_creation(
-                    factory_for_callback,
-                    runtime_for_callback,
-                    layout_for_callback,
-                );
-                return;
-            }
-            if let Some(old_handle) = session.handle.replace(handle) {
-                log::debug!(
-                    "wxp controller: destroying previous runtime before replacing handle: generation={generation}"
-                );
-                drop(state);
-                old_handle.destroy();
-                runtime_for_callback.lock().last_runtime_destroyed_at = Some(Instant::now());
-                schedule_pending_runtime_creation(
-                    factory_for_callback,
-                    runtime_for_callback,
-                    layout_for_callback,
-                );
-                return;
-            }
-            if state.pending_creation_generation == Some(generation) {
-                log::debug!(
-                    "wxp controller: dropping redundant pending runtime creation: generation={generation}"
-                );
-                state.pending_creation_generation = None;
-            }
-            log::debug!("wxp controller: posted runtime creation completed: generation={generation}");
-            drop(state);
+            handle.destroy();
+            runtime_for_callback.lock().last_runtime_destroyed_at = Some(Instant::now());
             schedule_pending_runtime_creation(
                 factory_for_callback,
                 runtime_for_callback,
                 layout_for_callback,
             );
-        });
+            return;
+        };
+
+        if let Err(error) = handle.set_size(size) {
+            log::warn!("wxp controller: posted runtime creation latest set_size failed: {error:?}");
+            handle.destroy();
+            runtime_for_callback.lock().last_runtime_destroyed_at = Some(Instant::now());
+            schedule_pending_runtime_creation(
+                factory_for_callback,
+                runtime_for_callback,
+                layout_for_callback,
+            );
+            return;
+        }
+        if let Err(error) = handle.set_scale(scale) {
+            log::warn!(
+                "wxp controller: posted runtime creation latest set_scale failed: {error:?}"
+            );
+            handle.destroy();
+            runtime_for_callback.lock().last_runtime_destroyed_at = Some(Instant::now());
+            schedule_pending_runtime_creation(
+                factory_for_callback,
+                runtime_for_callback,
+                layout_for_callback,
+            );
+            return;
+        }
+
+        if !visible {
+            log::debug!("wxp controller: posted runtime creation hiding initially hidden runtime");
+            if let Err(error) = handle.hide() {
+                log::warn!(
+                    "wxp controller: posted runtime creation initial hide failed: {error:?}"
+                );
+                handle.destroy();
+                runtime_for_callback.lock().last_runtime_destroyed_at = Some(Instant::now());
+                schedule_pending_runtime_creation(
+                    factory_for_callback,
+                    runtime_for_callback,
+                    layout_for_callback,
+                );
+                return;
+            }
+        }
+
+        let mut state = runtime_for_callback.lock();
+        let Some(session) = state.session.as_mut() else {
+            drop(state);
+            handle.destroy();
+            runtime_for_callback.lock().last_runtime_destroyed_at = Some(Instant::now());
+            schedule_pending_runtime_creation(
+                factory_for_callback,
+                runtime_for_callback,
+                layout_for_callback,
+            );
+            return;
+        };
+        if session.generation != generation {
+            drop(state);
+            handle.destroy();
+            runtime_for_callback.lock().last_runtime_destroyed_at = Some(Instant::now());
+            schedule_pending_runtime_creation(
+                factory_for_callback,
+                runtime_for_callback,
+                layout_for_callback,
+            );
+            return;
+        }
+        if let Some(old_handle) = session.handle.replace(handle) {
+            log::debug!(
+                "wxp controller: destroying previous runtime before replacing handle: generation={generation}"
+            );
+            drop(state);
+            old_handle.destroy();
+            runtime_for_callback.lock().last_runtime_destroyed_at = Some(Instant::now());
+            schedule_pending_runtime_creation(
+                factory_for_callback,
+                runtime_for_callback,
+                layout_for_callback,
+            );
+            return;
+        }
+        if state.pending_creation_generation == Some(generation) {
+            log::debug!(
+                "wxp controller: dropping redundant pending runtime creation: generation={generation}"
+            );
+            state.pending_creation_generation = None;
+        }
+        log::debug!("wxp controller: posted runtime creation completed: generation={generation}");
+        drop(state);
+        schedule_pending_runtime_creation(
+            factory_for_callback,
+            runtime_for_callback,
+            layout_for_callback,
+        );
+    });
+    if post_result.is_err() {
+        log::warn!("wxp controller: runtime creation could not be posted: generation={generation}");
+        clear_runtime_creation_after_post_failure(runtime.as_ref(), generation);
+        return Err(PluginError::InvalidState);
+    }
     Ok(())
+}
+
+fn clear_runtime_creation_after_post_failure(runtime: &Mutex<GuiRuntimeState>, generation: u64) {
+    let mut state = runtime.lock();
+    if state.creating_generation != Some(generation) {
+        return;
+    }
+    state.is_creating_runtime = false;
+    state.creating_generation = None;
+    if state.pending_creation_generation == Some(generation) {
+        state.pending_creation_generation = None;
+    }
+    state.destroy_requested_while_creating = false;
 }
 
 fn schedule_pending_runtime_creation(
@@ -378,6 +403,7 @@ fn schedule_pending_runtime_creation(
 }
 
 fn create_runtime_on_gui_thread(
+    run_loop: &RunLoopLocal,
     factory: &dyn WxpGuiFactory,
     runtime: &Mutex<GuiRuntimeState>,
     layout: &HostGuiLayout,
@@ -402,11 +428,14 @@ fn create_runtime_on_gui_thread(
         return create_runtime_after_wait(
             factory,
             runtime,
-            configuration,
-            size,
-            parent,
-            scale,
-            generation,
+            RuntimeCreationRequest {
+                configuration,
+                size,
+                parent,
+                scale,
+                generation,
+            },
+            run_loop,
         );
     };
     log::debug!(
@@ -420,42 +449,45 @@ fn create_runtime_on_gui_thread(
     create_runtime_after_wait(
         factory,
         runtime,
-        configuration,
-        size,
-        parent,
-        scale,
-        generation,
+        RuntimeCreationRequest {
+            configuration,
+            size,
+            parent,
+            scale,
+            generation,
+        },
+        run_loop,
     )
 }
 
 fn create_runtime_after_wait(
     factory: &dyn WxpGuiFactory,
     runtime: &Mutex<GuiRuntimeState>,
-    configuration: GuiConfig,
-    size: GuiSize,
-    parent: StoredParentWindow,
-    scale: f64,
-    generation: u64,
+    request: RuntimeCreationRequest,
+    run_loop: &RunLoopLocal,
 ) -> PluginResult<GuiRuntimeHandle> {
-    let parent = parent.to_parent_window_handle()?;
+    let parent = request.parent.to_parent_window_handle()?;
     log::debug!("wxp controller: parent handle converted");
-    let handle =
-        match create_gui_runtime_handle(|| factory.create_gui_runtime(configuration, size, parent))
-        {
-            Ok(handle) => handle,
-            Err(error) => {
-                let mut state = runtime.lock();
-                if state.creating_generation == Some(generation) {
-                    state.is_creating_runtime = false;
-                    state.creating_generation = None;
-                    state.pending_creation_generation = None;
-                    state.destroy_requested_while_creating = false;
-                }
-                return Err(error);
+    let handle = match create_gui_runtime_handle(
+        |run_loop| {
+            factory.create_gui_runtime(run_loop, request.configuration, request.size, parent)
+        },
+        run_loop,
+    ) {
+        Ok(handle) => handle,
+        Err(error) => {
+            let mut state = runtime.lock();
+            if state.creating_generation == Some(request.generation) {
+                state.is_creating_runtime = false;
+                state.creating_generation = None;
+                state.pending_creation_generation = None;
+                state.destroy_requested_while_creating = false;
             }
-        };
+            return Err(error);
+        }
+    };
     log::debug!("wxp controller: runtime handle created");
-    if finish_runtime_creation_requested_destroy(runtime, generation) {
+    if finish_runtime_creation_requested_destroy(runtime, request.generation) {
         log::debug!(
             "wxp controller: destroying newly created runtime after stale/deferred destroy"
         );
@@ -463,7 +495,7 @@ fn create_runtime_after_wait(
         runtime.lock().last_runtime_destroyed_at = Some(Instant::now());
         return Err(PluginError::InvalidState);
     }
-    if let Err(error) = handle.set_scale(scale) {
+    if let Err(error) = handle.set_scale(request.scale) {
         log::warn!("wxp controller: initial set_scale failed: {error:?}");
         handle.destroy();
         return Err(error);

--- a/crates/wrac_wxp_gui/src/runtime.rs
+++ b/crates/wrac_wxp_gui/src/runtime.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::thread::ThreadId;
 
-use novonotes_run_loop::{RunLoop, RunLoopSender};
+use novonotes_run_loop::{RunLoop, RunLoopGuard, RunLoopLocal};
 use parking_lot::Mutex;
 use wrac_clap_adapter::{GuiConfig, GuiSize, PluginError, PluginResult};
 
@@ -13,6 +13,9 @@ thread_local! {
     // Native GUI objects such as WebViews are typically bound to the thread that created them.
     // `WxpGuiController` lives inside a Send/Sync `PluginCore`, so runtimes are confined to TLS.
     static GUI_RUNTIMES: RefCell<HashMap<u64, GuiRuntimeEntry>> = RefCell::new(HashMap::new());
+    // Keep the `!Send` run-loop guard on the GUI thread. `GuiThreadLease` is only a
+    // cross-thread token; it releases this guard by dispatching back to the owner thread.
+    static GUI_RUN_LOOP_GUARD: RefCell<Option<RunLoopGuard>> = const { RefCell::new(None) };
 }
 
 static NEXT_GUI_ID: AtomicU64 = AtomicU64::new(1);
@@ -41,16 +44,12 @@ struct GuiRuntimeEntry {
 /// RAII token representing a reference to the GUI thread's run loop.
 ///
 /// The token is `Send + Sync` because `WxpGuiController` is shared with host callbacks,
-/// but the run-loop reference itself is released on the GUI thread captured at acquisition.
-/// Dropping this token from another host thread blocks until `RunLoop::deinit()` has run
-/// on the owning GUI thread.
-///
-/// `novonotes_run_loop` does not provide a transactional guard API, so failed
-/// `RunLoop::init()` calls cannot be treated as fully rolled back. Local state is
-/// advanced only after the part we can safely undo has succeeded.
+/// but the `!Send` [`RunLoopGuard`] itself stays in GUI-thread TLS. Dropping this token
+/// from another host thread blocks until the reference has been released on the owning
+/// GUI thread.
 pub(crate) struct GuiThreadLease {
     owner: ThreadId,
-    sender: RunLoopSender,
+    is_active: bool,
 }
 
 /// The actual WebView runtime owned by the UI thread.
@@ -61,7 +60,7 @@ pub(crate) struct GuiThreadLease {
 pub trait WxpGuiRuntime: 'static {
     fn set_scale(&mut self, scale: f64) -> PluginResult<()>;
     fn set_size(&mut self, size: GuiSize) -> PluginResult<()>;
-    fn show(&mut self) -> PluginResult<()> {
+    fn show(&mut self, _run_loop: &RunLoopLocal) -> PluginResult<()> {
         Ok(())
     }
     fn hide(&mut self) -> PluginResult<()> {
@@ -77,6 +76,7 @@ pub trait WxpGuiRuntime: 'static {
 pub trait WxpGuiFactory: Send + Sync + 'static {
     fn create_gui_runtime(
         &self,
+        run_loop: &RunLoopLocal,
         configuration: GuiConfig,
         initial_size: GuiSize,
         parent: ParentWindowHandle,
@@ -85,35 +85,41 @@ pub trait WxpGuiFactory: Send + Sync + 'static {
 
 impl<F> WxpGuiFactory for F
 where
-    F: Fn(GuiConfig, GuiSize, ParentWindowHandle) -> PluginResult<Box<dyn WxpGuiRuntime>>
+    F: for<'a> Fn(
+            &'a RunLoopLocal,
+            GuiConfig,
+            GuiSize,
+            ParentWindowHandle,
+        ) -> PluginResult<Box<dyn WxpGuiRuntime>>
         + Send
         + Sync
         + 'static,
 {
     fn create_gui_runtime(
         &self,
+        run_loop: &RunLoopLocal,
         configuration: GuiConfig,
         initial_size: GuiSize,
         parent: ParentWindowHandle,
     ) -> PluginResult<Box<dyn WxpGuiRuntime>> {
-        self(configuration, initial_size, parent)
+        self(run_loop, configuration, initial_size, parent)
     }
 }
 
 #[derive(Clone)]
 pub(crate) struct GuiRuntimeHandle {
     id: u64,
-    sender: RunLoopSender,
 }
 
 pub(crate) fn create_gui_runtime_handle(
-    create: impl FnOnce() -> PluginResult<Box<dyn WxpGuiRuntime>>,
+    create: impl FnOnce(&RunLoopLocal) -> PluginResult<Box<dyn WxpGuiRuntime>>,
+    run_loop: &RunLoopLocal,
 ) -> PluginResult<GuiRuntimeHandle> {
     log::debug!("wxp runtime: acquiring GUI thread lease");
     let lease = GuiThreadLease::acquire()?;
     // If `create` fails, the lease is dropped here. Drop order guarantees that a failed
     // runtime creation leaves no GUI thread reference behind.
-    match create() {
+    match create(run_loop) {
         Ok(runtime) => {
             log::debug!("wxp runtime: factory returned runtime");
             Ok(insert_gui_runtime(runtime, lease))
@@ -129,7 +135,7 @@ impl GuiRuntimeHandle {
     pub(crate) fn destroy(self) {
         let id = self.id;
         log::debug!("wxp runtime {id}: destroy requested");
-        self.sender.send_and_wait(move || {
+        let _ = RunLoop::call(move |_| {
             log::debug!("wxp runtime {id}: removing runtime from GUI thread");
             GUI_RUNTIMES.with(|runtimes| {
                 runtimes.borrow_mut().remove(&id);
@@ -142,7 +148,7 @@ impl GuiRuntimeHandle {
     pub(crate) fn set_scale(&self, scale: f64) -> PluginResult<()> {
         let id = self.id;
         log::debug!("wxp runtime {id}: set_scale requested: scale={scale}");
-        self.sender.send_and_wait(move || {
+        RunLoop::call(move |_| {
             GUI_RUNTIMES.with(|runtimes| {
                 let mut runtimes = runtimes.borrow_mut();
                 let entry = runtimes.get_mut(&id).ok_or(PluginError::InvalidState)?;
@@ -151,6 +157,7 @@ impl GuiRuntimeHandle {
                 result
             })
         })
+        .map_err(|_| PluginError::InvalidState)?
     }
 
     pub(crate) fn set_size(&self, size: GuiSize) -> PluginResult<()> {
@@ -160,7 +167,7 @@ impl GuiRuntimeHandle {
             size.width,
             size.height
         );
-        self.sender.send_and_wait(move || {
+        RunLoop::call(move |_| {
             GUI_RUNTIMES.with(|runtimes| {
                 let mut runtimes = runtimes.borrow_mut();
                 let entry = runtimes.get_mut(&id).ok_or(PluginError::InvalidState)?;
@@ -169,26 +176,28 @@ impl GuiRuntimeHandle {
                 result
             })
         })
+        .map_err(|_| PluginError::InvalidState)?
     }
 
     pub(crate) fn show(&self) -> PluginResult<()> {
         let id = self.id;
         log::debug!("wxp runtime {id}: show requested");
-        self.sender.send_and_wait(move || {
+        RunLoop::call(move |run_loop| {
             GUI_RUNTIMES.with(|runtimes| {
                 let mut runtimes = runtimes.borrow_mut();
                 let entry = runtimes.get_mut(&id).ok_or(PluginError::InvalidState)?;
-                let result = entry.runtime.show();
+                let result = entry.runtime.show(run_loop);
                 log::debug!("wxp runtime {id}: show completed: result={result:?}");
                 result
             })
         })
+        .map_err(|_| PluginError::InvalidState)?
     }
 
     pub(crate) fn hide(&self) -> PluginResult<()> {
         let id = self.id;
         log::debug!("wxp runtime {id}: hide requested");
-        self.sender.send_and_wait(move || {
+        RunLoop::call(move |_| {
             GUI_RUNTIMES.with(|runtimes| {
                 let mut runtimes = runtimes.borrow_mut();
                 let entry = runtimes.get_mut(&id).ok_or(PluginError::InvalidState)?;
@@ -197,6 +206,7 @@ impl GuiRuntimeHandle {
                 result
             })
         })
+        .map_err(|_| PluginError::InvalidState)?
     }
 }
 
@@ -213,10 +223,7 @@ fn insert_gui_runtime(runtime: Box<dyn WxpGuiRuntime>, lease: GuiThreadLease) ->
         );
     });
     log::debug!("wxp runtime {id}: inserted runtime on GUI thread");
-    GuiRuntimeHandle {
-        id,
-        sender: RunLoop::sender(),
-    }
+    GuiRuntimeHandle { id }
 }
 
 impl GuiThreadLease {
@@ -234,15 +241,18 @@ impl GuiThreadLease {
             Some(_) | None => {}
         }
 
-        if RunLoop::init().is_err() {
-            log::debug!("wxp GUI thread lease: RunLoop::init failed");
-            return Err(PluginError::UnsupportedHostGuiThreadingModel);
+        if gui_thread.ref_count == 0 {
+            let guard = RunLoop::init().map_err(|_| {
+                log::debug!("wxp GUI thread lease: RunLoop::init failed");
+                PluginError::UnsupportedHostGuiThreadingModel
+            })?;
+            GUI_RUN_LOOP_GUARD.with(|stored_guard| {
+                debug_assert!(stored_guard.borrow().is_none());
+                *stored_guard.borrow_mut() = Some(guard);
+            });
         }
 
-        // Advance the owner only after `RunLoop::init()` succeeds. The dependency's init
-        // does not guarantee full rollback on failure, so at least keep our own source of
-        // truth clean.
-        let sender = RunLoop::sender();
+        // Advance the owner only after `RunLoop::init()` succeeds.
         gui_thread.owner = Some(current_thread);
         gui_thread.ref_count += 1;
         log::debug!(
@@ -251,12 +261,8 @@ impl GuiThreadLease {
         );
         Ok(Self {
             owner: current_thread,
-            sender,
+            is_active: true,
         })
-    }
-
-    pub(crate) fn sender(&self) -> RunLoopSender {
-        self.sender.clone()
     }
 }
 
@@ -264,20 +270,32 @@ impl Drop for GuiThreadLease {
     fn drop(&mut self) {
         let current_thread = std::thread::current().id();
         log::debug!("wxp GUI thread lease: dropping on thread {current_thread:?}");
+        if !self.is_active {
+            return;
+        }
+        self.is_active = false;
         if current_thread == self.owner {
-            RunLoop::deinit();
+            release_gui_thread_lease();
         } else {
             log::debug!(
-                "wxp GUI thread lease: dispatching deinit from thread {current_thread:?} to owner {:?}",
+                "wxp GUI thread lease: dispatching release from thread {current_thread:?} to owner {:?}",
                 self.owner
             );
-            self.sender.send_and_wait(RunLoop::deinit);
+            if RunLoop::call(move |_| release_gui_thread_lease()).is_err() {
+                log::error!("wxp GUI thread lease: failed to release on owner thread");
+            }
         }
+    }
+}
+
+fn release_gui_thread_lease() {
+    let current_thread = std::thread::current().id();
+    let should_drop_guard = {
         let mut gui_thread = GUI_THREAD_STATE.lock();
         debug_assert!(gui_thread.ref_count > 0);
         gui_thread.ref_count = gui_thread.ref_count.saturating_sub(1);
         log::debug!(
-            "wxp GUI thread lease: dropped on thread {current_thread:?}; ref_count={}",
+            "wxp GUI thread lease: released on thread {current_thread:?}; ref_count={}",
             gui_thread.ref_count
         );
         if gui_thread.ref_count == 0 {
@@ -285,7 +303,17 @@ impl Drop for GuiThreadLease {
             // are released, allow the next GUI session to arrive from a different host window.
             gui_thread.owner = None;
             log::debug!("wxp GUI thread lease: owner cleared");
+            true
+        } else {
+            false
         }
+    };
+    if should_drop_guard {
+        GUI_RUN_LOOP_GUARD.with(|stored_guard| {
+            let guard = stored_guard.borrow_mut().take();
+            debug_assert!(guard.is_some());
+            drop(guard);
+        });
     }
 }
 

--- a/plugins/wrac-gain/src-plugin/src/gui.rs
+++ b/plugins/wrac-gain/src-plugin/src/gui.rs
@@ -19,17 +19,46 @@ pub(crate) use notifier::{
     GuiStateNotifier, GuiSubscriptionId, editor_page_payload, parameter_payload,
 };
 
+use novonotes_run_loop::RunLoopLocal;
 use runtime::{
     DEFAULT_GUI_SIZE, GuiRuntimeDependencies, MAX_GUI_SIZE, MIN_GUI_SIZE, WracGainGuiRuntime,
 };
-use wrac_clap_adapter::{HostGuiResizeRequester, HostParamsEditNotifier};
-use wrac_wxp_gui::{GuiSizeLimits, WxpGuiController, WxpGuiResizeHandle, WxpGuiRuntime};
+use wrac_clap_adapter::{
+    GuiConfig, GuiSize, HostGuiResizeRequester, HostParamsEditNotifier, PluginResult,
+};
+use wrac_wxp_gui::{
+    GuiSizeLimits, ParentWindowHandle, WxpGuiController, WxpGuiFactory, WxpGuiResizeHandle,
+    WxpGuiRuntime,
+};
 
 use crate::state::{ProjectStateStore, SharedState};
 
 pub(crate) struct GuiIntegration {
     pub(crate) controller: Arc<WxpGuiController>,
     pub(crate) notifier: Arc<GuiStateNotifier>,
+}
+
+struct WracGainGuiFactory {
+    dependencies: GuiRuntimeDependencies,
+}
+
+impl WxpGuiFactory for WracGainGuiFactory {
+    fn create_gui_runtime(
+        &self,
+        run_loop: &RunLoopLocal,
+        configuration: GuiConfig,
+        initial_size: GuiSize,
+        parent: ParentWindowHandle,
+    ) -> PluginResult<Box<dyn WxpGuiRuntime>> {
+        WracGainGuiRuntime::create(
+            run_loop,
+            self.dependencies.clone(),
+            configuration,
+            initial_size,
+            parent,
+        )
+        .map(|runtime| Box::new(runtime) as Box<dyn WxpGuiRuntime>)
+    }
 }
 
 /// Assembles the complete GUI extension set used by the plugin core.
@@ -57,14 +86,8 @@ pub(crate) fn create_gui_integration(
         resize_handle: resize_handle.clone(),
     };
     let controller = Arc::new(WxpGuiController::new_with_resize_handle(
-        move |configuration, initial_size, parent| {
-            WracGainGuiRuntime::create(
-                runtime_dependencies.clone(),
-                configuration,
-                initial_size,
-                parent,
-            )
-            .map(|runtime| Box::new(runtime) as Box<dyn WxpGuiRuntime>)
+        WracGainGuiFactory {
+            dependencies: runtime_dependencies,
         },
         resize_handle,
     ));

--- a/plugins/wrac-gain/src-plugin/src/gui/notifier.rs
+++ b/plugins/wrac-gain/src-plugin/src/gui/notifier.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use novonotes_run_loop::{RunLoop, RunLoopSender};
+use novonotes_run_loop::RunLoop;
 use parking_lot::Mutex;
 use serde_json::json;
 use wxp::Channel;
@@ -23,8 +23,6 @@ pub(crate) struct GuiStateNotifier {
 #[derive(Clone)]
 struct GuiSubscription {
     kind: GuiSubscriptionKind,
-    // Run loop sender for dispatching notifications back to the UI thread.
-    sender: RunLoopSender,
     // Channel for sending values to the JS subscriber in the WebView.
     channel: Channel,
 }
@@ -71,14 +69,9 @@ impl GuiStateNotifier {
         // IDs are assigned independently of wxp's Channel IDs so that transport and
         // subscription lifecycle can be managed separately.
         let id = GuiSubscriptionId(self.next_subscription_id.fetch_add(1, Ordering::Relaxed));
-        self.subscriptions.lock().insert(
-            id,
-            GuiSubscription {
-                kind,
-                sender: RunLoop::sender(),
-                channel,
-            },
-        );
+        self.subscriptions
+            .lock()
+            .insert(id, GuiSubscription { kind, channel });
         id
     }
 
@@ -124,7 +117,7 @@ impl GuiStateNotifier {
             // WebView channels may only be touched on the same UI thread as the GUI
             // runtime. Sending directly from a host or audio thread would violate thread
             // affinity, so always dispatch back through the run loop first.
-            subscription.sender.send(move || {
+            let _ = RunLoop::post(move |_| {
                 let _ = subscription.channel.send(payload);
             });
         }

--- a/plugins/wrac-gain/src-plugin/src/gui/runtime.rs
+++ b/plugins/wrac-gain/src-plugin/src/gui/runtime.rs
@@ -2,6 +2,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 use std::time::Duration;
 
+use novonotes_run_loop::RunLoopLocal;
 use run_loop_timer::Timer;
 use wrac_clap_adapter::{
     GuiConfig, GuiSize, HostGuiResizeRequester, HostParamsEditNotifier, PluginError, PluginResult,
@@ -60,6 +61,7 @@ impl WracGainGuiRuntime {
     /// Factory called from the closure in `plugin.rs` when the host requests the GUI to open.
     /// Creates a WebView attached to the parent window and returns it.
     pub(super) fn create(
+        run_loop: &RunLoopLocal,
         dependencies: GuiRuntimeDependencies,
         configuration: GuiConfig,
         initial_size: GuiSize,
@@ -115,7 +117,7 @@ impl WracGainGuiRuntime {
                 gui_notifier.notify_parameter(PARAM_GAIN_ID, shared.gain());
             }
         });
-        gui_update_timer.start();
+        gui_update_timer.start(run_loop);
 
         log::debug!("creating GUI runtime: completed");
         Ok(Self {
@@ -138,10 +140,10 @@ impl WxpGuiRuntime for WracGainGuiRuntime {
         self.webview.set_size(size)
     }
 
-    fn show(&mut self) -> PluginResult<()> {
+    fn show(&mut self, run_loop: &RunLoopLocal) -> PluginResult<()> {
         log::debug!("showing GUI runtime");
         self.webview.show()?;
-        self.gui_update_timer.start();
+        self.gui_update_timer.start(run_loop);
         log::debug!("showing GUI runtime completed");
         Ok(())
     }


### PR DESCRIPTION
## Summary
- Update wxp to the merged main commit with the refactored RunLoop dispatch API
- Remove the local wxp patch and pin git dependencies to the merged revision
- Migrate the template GUI runtime and notification dispatch to the new RunLoop API
- Clear pending runtime-creation state if RunLoop::post fails before enqueueing the callback

## Verification
- cargo fmt --all --check
- cargo clippy --locked --workspace --all-targets -- -D warnings
- cargo test --locked --workspace
- cargo xtask validate -p wrac_gain_plugin