### PR TITLE
Update clap-wrapper subtree

### DIFF
--- a/clap_wrapper_builder/README.md
+++ b/clap_wrapper_builder/README.md
@@ -33,3 +33,19 @@ staging.
 
 AAX is off by default and requires the Avid AAX SDK. Enable it with
 `-DCLAP_WRAPPER_BUILDER_BUILD_AAX=ON` once the SDK is available.
+
+## Maintaining the clap-wrapper subtree
+
+`clap-wrapper` is vendored as ordinary files, not as an active submodule, but it
+keeps git-subtree metadata in history. Use `git subtree pull` for upstream
+updates. Put project-specific follow-up changes in later, small logical commits.
+
+Update command example:
+
+```bash
+git subtree pull \
+  --prefix=clap_wrapper_builder/clap-wrapper \
+  https://github.com/free-audio/clap-wrapper.git \
+  next \
+  -m "Update clap-wrapper from free-audio next"
+```

--- a/clap_wrapper_builder/clap-wrapper/cmake/make_clapfirst.cmake
+++ b/clap_wrapper_builder/clap-wrapper/cmake/make_clapfirst.cmake
@@ -233,7 +233,7 @@ function(make_clapfirst_plugins)
         endif()
         target_add_aax_wrapper(TARGET ${AAX_TARGET}
                 OUTPUT_NAME "${C1ST_OUTPUT_NAME}"
-                BUNDLE_IDENTIFIER "${C1ST_BUNDLE_IDENTIFER}.aaxplugin"
+                BUNDLE_IDENTIFIER "${C1ST_BUNDLE_IDENTIFIER}.aaxplugin"
                 BUNDLE_VERSION "${C1ST_BUNDLE_VERSION}"
                 ASSET_OUTPUT_DIRECTORY "${vod}"
                 

--- a/clap_wrapper_builder/clap-wrapper/src/detail/aax/parameter.cpp
+++ b/clap_wrapper_builder/clap-wrapper/src/detail/aax/parameter.cpp
@@ -15,6 +15,7 @@ AAX_ClapParamDisplayDelegate *AAX_ClapParamDisplayDelegate::Clone() const
 bool AAX_ClapParamDisplayDelegate::ValueToString(double value, AAX_CString *valueString) const
 {
   auto i = _info.get();
+  if (!i || !i->_plugin || !i->_ext_params || !i->_ext_params->value_to_text) return false;
   char buf[101];
   if (i->_ext_params->value_to_text(i->_plugin, i->_clap_param_info.id, i->asClapValue(value), buf, 100))
   {
@@ -28,9 +29,11 @@ bool AAX_ClapParamDisplayDelegate::ValueToString(double value, int32_t maxNumCha
                                                  AAX_CString *valueString) const
 {
   auto i = _info.get();
+  if (!i || !i->_plugin || !i->_ext_params || !i->_ext_params->value_to_text) return false;
   char buf[101];
   int32_t sz = 100;
   if (maxNumChars < 100) sz = maxNumChars;
+  if (sz <= 0) return false;
   if (i->_ext_params->value_to_text(i->_plugin, i->_clap_param_info.id, i->asClapValue(value), buf, sz))
   {
     valueString->Set(buf);
@@ -41,5 +44,17 @@ bool AAX_ClapParamDisplayDelegate::ValueToString(double value, int32_t maxNumCha
 bool AAX_ClapParamDisplayDelegate::StringToValue(const AAX_CString &valueString, double *value) const
 {
   auto i = _info.get();
-  return i->_ext_params->text_to_value(i->_plugin, i->_clap_param_info.id, valueString.Get(), value);
+  if (!i || !i->_plugin || !i->_ext_params || !i->_ext_params->text_to_value || !value) return false;
+
+  double clapValue = 0.0;
+  if (!i->_ext_params->text_to_value(i->_plugin, i->_clap_param_info.id, valueString.Get(),
+                                     &clapValue))
+  {
+    return false;
+  }
+
+  // AAX display delegates exchange normalized values, while CLAP text_to_value
+  // returns the parameter-domain value.
+  *value = i->asAAXValue(clapValue);
+  return true;
 }

--- a/clap_wrapper_builder/clap-wrapper/src/detail/aax/parameter.h
+++ b/clap_wrapper_builder/clap-wrapper/src/detail/aax/parameter.h
@@ -20,8 +20,8 @@ class ClapAsAAX;
 typedef struct AAXWrappedParameterInfo
 {
   AAXWrappedParameterInfo(const clap_plugin_t *plugin, const clap_param_info_t &ci,
-                          const std::string identifier)
-    : _plugin(plugin), _clap_param_info(ci), _aax_identifier(identifier)
+                          const clap_plugin_params_t *ext_params, const std::string identifier)
+    : _plugin(plugin), _ext_params(ext_params), _clap_param_info(ci), _aax_identifier(identifier)
   {
   }
   const clap_plugin_t *_plugin;

--- a/clap_wrapper_builder/clap-wrapper/src/detail/aax/process.cpp
+++ b/clap_wrapper_builder/clap-wrapper/src/detail/aax/process.cpp
@@ -3,6 +3,7 @@
 #include "wrapper.h"
 
 #include "AAX_MIDIUtilities.h"
+#include <cstring>
 
 void AAX_CALLBACK AAXWrapper_AlgorithmProcessProc(
     SAAX_Wrapper_AlgorithmicContext *const inInstancesBegin[], const void *inInstancesEnd)
@@ -60,13 +61,17 @@ void AAXProcessAdapter::setupProcessing(const clap_plugin_t *plugin, double samp
                                         const clap_plugin_audio_ports *ext_audio,
                                         Clap::IAutomation *automation,
                                         std::vector<clap_id> &gesturedparameters,
-                                        ParamChangeQueue &inqueue, uint32_t midiportid, bool preferMIDI)
+                                        ParamChangeQueue &inqueue,
+                                        std::shared_ptr<AAXWrappedParameterInfo_t> bypassParameter,
+                                        uint32_t midiportid, bool preferMIDI)
 {
   _plugin = plugin;
   _ext_param = ext_param;
   _automation = automation;
   _inqueue = &inqueue;
   _gesturedparameters = &gesturedparameters;
+  _bypassParameter = bypassParameter;
+  _lastBypassState = -1;
 
   _midi_first_portid = midiportid;
   _midi_prefer_mididialect = preferMIDI;
@@ -298,6 +303,28 @@ void AAXProcessAdapter::process(SAAX_Wrapper_AlgorithmicContext *context)
   }
 
   _proc.frames_count = *(context->mNumSamples);
+  const int bypassState = (context->mBypass && *context->mBypass != 0) ? 1 : 0;
+
+  if (_bypassParameter && bypassState != _lastBypassState)
+  {
+    // AAX owns master bypass as a host data port. Forward state changes as
+    // CLAP parameter events so the plugin's bypass state remains authoritative.
+    clap_multi_event_t n;
+    n.header = {sizeof(clap_event_param_value_t), 0, CLAP_CORE_EVENT_SPACE_ID,
+                CLAP_EVENT_PARAM_VALUE, 0};
+    n.param.param_id = _bypassParameter->_clap_param_info.id;
+    n.param.cookie = _bypassParameter->_clap_param_info.cookie;
+    n.param.note_id = -1;
+    n.param.port_index = -1;
+    n.param.channel = -1;
+    n.param.key = -1;
+    n.param.value = bypassState ? _bypassParameter->_clap_param_info.max_value
+                                : _bypassParameter->_clap_param_info.min_value;
+
+    _eventindices.push_back(_events.size());
+    _events.emplace_back(n);
+  }
+  _lastBypassState = bypassState;
 
   // distribute the pointers to the audio channels pointer arrays to the
   // appropriate audio ports
@@ -312,6 +339,32 @@ void AAXProcessAdapter::process(SAAX_Wrapper_AlgorithmicContext *context)
   {
     this->_output_ports[i].data32 = context->mAudioOutputs + offset;
     offset += this->_output_ports[i].channel_count;
+  }
+
+  if (bypassState && !_bypassParameter)
+  {
+    // Without a CLAP bypass parameter there is no plugin state to drive. Match
+    // host bypass semantics by bypassing the processor and passing audio through.
+    for (uint32_t i = 0; i < _proc.audio_outputs_count; ++i)
+    {
+      for (uint32_t c = 0; c < _output_ports[i].channel_count; ++c)
+      {
+        float *output = _output_ports[i].data32[c];
+        if (!output) continue;
+
+        float *input = nullptr;
+        if (i < _proc.audio_inputs_count && c < _input_ports[i].channel_count)
+        {
+          input = _input_ports[i].data32[c];
+        }
+
+        if (input)
+          std::memmove(output, input, sizeof(float) * _proc.frames_count);
+        else
+          std::memset(output, 0, sizeof(float) * _proc.frames_count);
+      }
+    }
+    return;
   }
 
   // sort all indices

--- a/clap_wrapper_builder/clap-wrapper/src/detail/aax/process.h
+++ b/clap_wrapper_builder/clap-wrapper/src/detail/aax/process.h
@@ -39,6 +39,8 @@ struct SAAX_Wrapper_AlgorithmicContext
       nullptr;  ///< Transport MIDI node.  Used for querying the state of the MIDI transport.
   //  AAX_IMIDINode*              mAdditionalInputMIDINodes[kMaxAdditionalMIDINodes];  ///< List of additional input MIDI nodes, if your plugin needs them.
 
+  int32_t *mBypass = nullptr;  ///< Host master bypass state.
+
   SAAX_Wrapper_PrivateData *mPrivateData = nullptr;
 
   float **mMeters =

--- a/clap_wrapper_builder/clap-wrapper/src/detail/aax/wrapper.cpp
+++ b/clap_wrapper_builder/clap-wrapper/src/detail/aax/wrapper.cpp
@@ -22,6 +22,8 @@
 #include "AAX_Errors.h"
 #include "AAX_Assert.h"
 #include "AAX_Init.h"
+#include "AAX_CBinaryDisplayDelegate.h"
+#include "AAX_CBinaryTaperDelegate.h"
 // #include <Topology/AAX_CMonolithicParameters.h> <- this introduces way too much clutter
 
 // ----[CLAP]-----------------------------------------------------------------------
@@ -50,6 +52,8 @@
 
 // #include <mutex>
 // #include <functional>
+
+static const char *kAAXMasterBypassID = "MasterBypass";
 
 class ClapAsAAXRegistry
 {
@@ -199,6 +203,9 @@ static void DescribeAlgorithmComponent(AAX_IComponentDescriptor *outDesc,
     err = outDesc->AddPrivateData(
         transportNodeID, sizeof(float),
         AAX_ePrivateDataOptions_DefaultOptions);  //Just here to fill the port.  Not used.
+
+  err = outDesc->AddDataInPort(AAX_FIELD_INDEX(SAAX_Wrapper_AlgorithmicContext, mBypass),
+                               sizeof(int32_t));
 
   //Add pointer to the data model instance and other interesting information.
   err =
@@ -668,6 +675,12 @@ AAX_Result ClapAsAAX::TimerWakeup()
 
 AAX_Result ClapAsAAX::GetParameterIsAutomatable(AAX_CParamID iParameterID, AAX_CBoolean *itIs) const
 {
+  if (!_aaxMasterBypassID.empty() && _aaxMasterBypassID == iParameterID)
+  {
+    *itIs = true;
+    return AAX_SUCCESS;
+  }
+
   auto n = this->_parameterMap.find(iParameterID);
   if (n != _parameterMap.end())
   {
@@ -680,6 +693,12 @@ AAX_Result ClapAsAAX::GetParameterIsAutomatable(AAX_CParamID iParameterID, AAX_C
 
 AAX_Result ClapAsAAX::GetParameterNumberOfSteps(AAX_CParamID iParameterID, int32_t *aNumSteps) const
 {
+  if (!_aaxMasterBypassID.empty() && _aaxMasterBypassID == iParameterID)
+  {
+    *aNumSteps = 2;
+    return AAX_SUCCESS;
+  }
+
   auto n = this->_parameterMap.find(iParameterID);
   if (n != _parameterMap.end())
   {
@@ -708,12 +727,28 @@ AAX_Result ClapAsAAX::GetParameterValueString(AAX_CParamID iParameterID, AAX_ISt
 AAX_Result ClapAsAAX::GetParameterValueFromString(AAX_CParamID iParameterID, double *oValuePtr,
                                                   const AAX_IString &iValueString) const
 {
+  if (!_aaxMasterBypassID.empty() && _aaxMasterBypassID == iParameterID)
+  {
+    return AAX_CEffectParameters::GetParameterValueFromString(iParameterID, oValuePtr,
+                                                              iValueString);
+  }
+
   auto n = this->_parameterMap.find(iParameterID);
   if (n != _parameterMap.end())
   {
-    if (n->second->_ext_params->text_to_value(_plugin->_plugin, n->second->_clap_param_info.id,
-                                              iValueString.Get(), oValuePtr))
+    auto *ext_params = n->second->_ext_params;
+    if (!ext_params || !ext_params->text_to_value)
     {
+      return AAX_ERROR_INVALID_STRING_CONVERSION;
+    }
+
+    double clapValue = 0.0;
+    if (ext_params->text_to_value(_plugin->_plugin, n->second->_clap_param_info.id,
+                                  iValueString.Get(), &clapValue))
+    {
+      // AAX expects normalized parameter values; CLAP text_to_value returns
+      // the parameter-domain value.
+      *oValuePtr = n->second->asAAXValue(clapValue);
       return AAX_SUCCESS;
     }
     else
@@ -730,12 +765,24 @@ AAX_Result ClapAsAAX::GetParameterValueFromString(AAX_CParamID iParameterID, dou
 AAX_Result ClapAsAAX::GetParameterStringFromValue(AAX_CParamID iParameterID, double value,
                                                   AAX_IString *valueString, int32_t maxLength) const
 {
+  if (!_aaxMasterBypassID.empty() && _aaxMasterBypassID == iParameterID)
+  {
+    return AAX_CEffectParameters::GetParameterStringFromValue(iParameterID, value, valueString,
+                                                              maxLength);
+  }
+
   auto n = this->_parameterMap.find(iParameterID);
   if (n != _parameterMap.end())
   {
+    auto *ext_params = n->second->_ext_params;
+    if (!ext_params || !ext_params->value_to_text)
+    {
+      return AAX_ERROR_INVALID_STRING_CONVERSION;
+    }
+
     char flomf[256];
-    if (this->_plugin->_ext._params->value_to_text(_plugin->_plugin, n->second->_clap_param_info.id,
-                                                   n->second->asClapValue(value), flomf, sizeof(flomf)))
+    if (ext_params->value_to_text(_plugin->_plugin, n->second->_clap_param_info.id,
+                                  n->second->asClapValue(value), flomf, sizeof(flomf)))
     {
       *valueString = flomf;
       return AAX_SUCCESS;
@@ -748,6 +795,12 @@ AAX_Result ClapAsAAX::GetParameterStringFromValue(AAX_CParamID iParameterID, dou
 
 AAX_Result ClapAsAAX::GetParameterName(AAX_CParamID iParameterID, AAX_IString *oName) const
 {
+  if (!_aaxMasterBypassID.empty() && _aaxMasterBypassID == iParameterID)
+  {
+    *oName = "Master Bypass";
+    return AAX_SUCCESS;
+  }
+
   auto n = this->_parameterMap.find(iParameterID);
   if (n != _parameterMap.end())
   {
@@ -761,6 +814,12 @@ AAX_Result ClapAsAAX::GetParameterName(AAX_CParamID iParameterID, AAX_IString *o
 AAX_Result ClapAsAAX::GetParameterNameOfLength(AAX_CParamID iParameterID, AAX_IString *oName,
                                                int32_t iNameLength) const
 {
+  if (!_aaxMasterBypassID.empty() && _aaxMasterBypassID == iParameterID)
+  {
+    oName->Set(iNameLength >= 6 ? "Bypass" : "Byp");
+    return AAX_SUCCESS;
+  }
+
   AAX_Result aResult = AAX_ERROR_INVALID_STRING_CONVERSION;
   const uint32_t namelen = (uint32_t)iNameLength;
 
@@ -793,7 +852,14 @@ AAX_Result ClapAsAAX::UpdateParameterNormalizedValue(AAX_CParamID iParameterID, 
   // and yeah, no timestamps for this, so we get the parameter and pass its ID, cookie and the new value
 
   auto p = _parameterMap.find(iParameterID);
-  if (p == _parameterMap.end()) return AAX_ERROR_INVALID_PARAMETER_ID;
+  if (p == _parameterMap.end())
+  {
+    if (!_aaxMasterBypassID.empty() && _aaxMasterBypassID == iParameterID)
+    {
+      return AAX_CEffectParameters::UpdateParameterNormalizedValue(iParameterID, iValue, iSource);
+    }
+    return AAX_ERROR_INVALID_PARAMETER_ID;
+  }
   auto *ptr = p->second.get();
 
   _paramsToProcess.push(
@@ -976,9 +1042,14 @@ void ClapAsAAX::setupParameters(const clap_plugin_t *plugin, const clap_plugin_p
       }
       paramname.append(info.name);
 
-      auto id = createAAXId(info.id);
+      const bool isBypassParameter = (info.flags & CLAP_PARAM_IS_BYPASS) && !_bypassParameter;
+      // Pro Tools exposes master bypass through a reserved AAX parameter path.
+      // Reuse that path for CLAP bypass so host automation reaches the plugin
+      // instead of creating an unrelated wrapper-local bypass parameter.
+      auto id = isBypassParameter ? std::string(kAAXMasterBypassID) : createAAXId(info.id);
 
-      auto wrappedParam = std::make_shared<AAXWrappedParameterInfo_t>(this->_plugin->_plugin, info, id);
+      auto wrappedParam =
+          std::make_shared<AAXWrappedParameterInfo_t>(this->_plugin->_plugin, info, params, id);
 
       auto n = generateShortStrings(paramname);
       wrappedParam->_names.reserve(n.size());
@@ -990,16 +1061,40 @@ void ClapAsAAX::setupParameters(const clap_plugin_t *plugin, const clap_plugin_p
       // now to the lookup maps
       _parameterMap[id] = wrappedParam;
       _parameterMapCLAP[info.id] = wrappedParam;
+      if (isBypassParameter)
+      {
+        _bypassParameter = wrappedParam;
+      }
 
       auto p = new AAX_CParameter<double>(
           _parameterMap[id]->_aax_identifier.c_str(), AAX_CString(paramname),
           wrappedParam->asAAXValue(info.default_value), AAX_CLinearTaperDelegate<double>(0, 1),
           AAX_ClapParamDisplayDelegate(wrappedParam), info.flags & CLAP_PARAM_IS_AUTOMATABLE);
       mParameterManager.AddParameter(p);
+      if (wrappedParam == _bypassParameter)
+      {
+        mPacketDispatcher.RegisterPacket(wrappedParam->_aax_identifier.c_str(),
+                                         AAX_FIELD_INDEX(SAAX_Wrapper_AlgorithmicContext, mBypass));
+      }
 
       // get the index and store it for fast retrieval
       wrappedParam->_paramAAXIndex = mParameterManager.GetParameterIndex(id.c_str());
     }
+  }
+
+  if (!_bypassParameter)
+  {
+    // Keep AAX master bypass usable even for CLAP plugins without an explicit
+    // bypass parameter; the process adapter handles this as wrapper bypass.
+    _aaxMasterBypassID = kAAXMasterBypassID;
+    auto bypass = new AAX_CParameter<bool>(
+        _aaxMasterBypassID.c_str(), AAX_CString("Master Bypass"), false,
+        AAX_CBinaryTaperDelegate<bool>(), AAX_CBinaryDisplayDelegate<bool>("off", "on"), true);
+    bypass->SetNumberOfSteps(2);
+    bypass->SetType(AAX_eParameterType_Discrete);
+    mParameterManager.AddParameter(bypass);
+    mPacketDispatcher.RegisterPacket(_aaxMasterBypassID.c_str(),
+                                     AAX_FIELD_INDEX(SAAX_Wrapper_AlgorithmicContext, mBypass));
   }
   AAX_ASSERT(_activated == false);
 }
@@ -1219,7 +1314,8 @@ void ClapAsAAX::activatePlugin()
     _processAdapter = std::make_unique<AAXProcessAdapter>();
     _processAdapter->setupProcessing(_plugin->_plugin, _plugin->getSampleRate(), _plugin->_ext._params,
                                      _plugin->_ext._audioports, this, _gesturedparameters,
-                                     _paramsToProcess, _midi_first_portid, _midi_prefer_mididialect);
+                                     _paramsToProcess, _bypassParameter, _midi_first_portid,
+                                     _midi_prefer_mididialect);
 
     _activated = true;
     _plugin->activate();

--- a/clap_wrapper_builder/clap-wrapper/src/detail/aax/wrapper.cpp
+++ b/clap_wrapper_builder/clap-wrapper/src/detail/aax/wrapper.cpp
@@ -1066,15 +1066,29 @@ void ClapAsAAX::setupParameters(const clap_plugin_t *plugin, const clap_plugin_p
         _bypassParameter = wrappedParam;
       }
 
-      auto p = new AAX_CParameter<double>(
-          _parameterMap[id]->_aax_identifier.c_str(), AAX_CString(paramname),
-          wrappedParam->asAAXValue(info.default_value), AAX_CLinearTaperDelegate<double>(0, 1),
-          AAX_ClapParamDisplayDelegate(wrappedParam), info.flags & CLAP_PARAM_IS_AUTOMATABLE);
-      mParameterManager.AddParameter(p);
-      if (wrappedParam == _bypassParameter)
+      if (isBypassParameter)
       {
+        // The AAX master bypass data port is an int32 packet. Keep the public
+        // CLAP bypass parameter on AAX's binary path so the default packet
+        // handler writes a compatible value for the process context.
+        auto p = new AAX_CParameter<bool>(
+            wrappedParam->_aax_identifier.c_str(), AAX_CString(paramname),
+            wrappedParam->asAAXValue(info.default_value) >= 0.5,
+            AAX_CBinaryTaperDelegate<bool>(), AAX_CBinaryDisplayDelegate<bool>("off", "on"),
+            info.flags & CLAP_PARAM_IS_AUTOMATABLE);
+        p->SetNumberOfSteps(2);
+        p->SetType(AAX_eParameterType_Discrete);
+        mParameterManager.AddParameter(p);
         mPacketDispatcher.RegisterPacket(wrappedParam->_aax_identifier.c_str(),
                                          AAX_FIELD_INDEX(SAAX_Wrapper_AlgorithmicContext, mBypass));
+      }
+      else
+      {
+        auto p = new AAX_CParameter<double>(
+            _parameterMap[id]->_aax_identifier.c_str(), AAX_CString(paramname),
+            wrappedParam->asAAXValue(info.default_value), AAX_CLinearTaperDelegate<double>(0, 1),
+            AAX_ClapParamDisplayDelegate(wrappedParam), info.flags & CLAP_PARAM_IS_AUTOMATABLE);
+        mParameterManager.AddParameter(p);
       }
 
       // get the index and store it for fast retrieval

--- a/clap_wrapper_builder/clap-wrapper/src/detail/aax/wrapper.h
+++ b/clap_wrapper_builder/clap-wrapper/src/detail/aax/wrapper.h
@@ -82,7 +82,9 @@ class AAXProcessAdapter
   void setupProcessing(const clap_plugin_t *plugin, double samplerate,
                        const clap_plugin_params_t *ext_param, const clap_plugin_audio_ports *ext_audio,
                        Clap::IAutomation *automation, std::vector<clap_id> &gesturedParameters,
-                       ParamChangeQueue &inqueue, uint32_t midiportid, bool preferMIDI);
+                       ParamChangeQueue &inqueue,
+                       std::shared_ptr<AAXWrappedParameterInfo_t> bypassParameter,
+                       uint32_t midiportid, bool preferMIDI);
   void process(SAAX_Wrapper_AlgorithmicContext *context);
   void flush();
 
@@ -121,6 +123,8 @@ class AAXProcessAdapter
   float *_silent_output = nullptr;
 
   ParamChangeQueue *_inqueue;
+  std::shared_ptr<AAXWrappedParameterInfo_t> _bypassParameter;
+  int _lastBypassState = -1;
 
   void sortEventIndices();
 
@@ -250,6 +254,8 @@ class ClapAsAAX : public AAX_CEffectParameters,
   // _parameterMap maps the AAX CParamID to the wrapped parameter
   std::map<std::string, std::shared_ptr<AAXWrappedParameterInfo_t>> _parameterMap;
   std::map<uint32_t, std::shared_ptr<AAXWrappedParameterInfo_t>> _parameterMapCLAP;
+  std::shared_ptr<AAXWrappedParameterInfo_t> _bypassParameter;
+  std::string _aaxMasterBypassID;
 
   Wrapped_AAX_GUI *_aax_view = nullptr;
 

--- a/clap_wrapper_builder/clap-wrapper/src/detail/auv2/auv2_base_classes.h
+++ b/clap_wrapper_builder/clap-wrapper/src/detail/auv2/auv2_base_classes.h
@@ -523,11 +523,8 @@ class WrapAsAUV2 : public ausdk::AUBase,
 
   void activateCLAP();
   void deactivateCLAP();
-  bool IsBypassEffect()
-  {
-    return false;
-  }
-  void SetBypassEffect(bool bypass) {};
+  bool IsBypassEffect();
+  void SetBypassEffect(bool bypass);
 
   // --------------- internals
 
@@ -542,6 +539,8 @@ class WrapAsAUV2 : public ausdk::AUBase,
 
   std::unique_ptr<Clap::AUv2::ProcessAdapter> _processAdapter;
   std::atomic<bool> _initialized = false;
+  bool _hasBypassParameter = false;
+  clap_param_info_t _bypassParameterInfo = {};
 
   // some info about the wrapped clap
   uint32_t _midi_preferred_dialect = 0;

--- a/clap_wrapper_builder/clap-wrapper/src/detail/auv2/parameter.cpp
+++ b/clap_wrapper_builder/clap-wrapper/src/detail/auv2/parameter.cpp
@@ -16,9 +16,15 @@ void Parameter::updateInfo(const clap_plugin_t *plugin, const clap_plugin_params
   if (_cfstring)
   {
     CFRelease(_cfstring);
+    _cfstring = nullptr;
   }
   _info = i;
-  _cfstring = CFStringCreateWithCString(NULL, _info.name, kCFStringEncodingUTF8);
+  const char *name = _info.name[0] != '\0' ? _info.name : "Parameter";
+  _cfstring = CFStringCreateWithCString(NULL, name, kCFStringEncodingUTF8);
+  if (!_cfstring)
+  {
+    _cfstring = CFStringCreateWithCString(NULL, "Parameter", kCFStringEncodingUTF8);
+  }
 
   const auto &info = _info;
   AudioUnitParameterOptions flags = 0;
@@ -67,7 +73,10 @@ void Parameter::updateInfo(const clap_plugin_t *plugin, const clap_plugin_params
 }
 Parameter::~Parameter()
 {
-  CFRelease(_cfstring);
+  if (_cfstring)
+  {
+    CFRelease(_cfstring);
+  }
 }
 
 }  // namespace Clap::AUv2

--- a/clap_wrapper_builder/clap-wrapper/src/detail/vst3/state.h
+++ b/clap_wrapper_builder/clap-wrapper/src/detail/vst3/state.h
@@ -27,7 +27,10 @@ class CLAPVST3StreamAdapter
   {
     auto self = static_cast<CLAPVST3StreamAdapter *>(stream->ctx);
     Steinberg::int32 bytesRead = 0;
-    if (kResultOk == self->vst_stream->read(buffer, (int32)size, &bytesRead)) return bytesRead;
+    const auto result = self->vst_stream->read(buffer, (int32)size, &bytesRead);
+    // Some VST3 hosts report EOF as kResultFalse. CLAP treats EOF as a
+    // successful zero-byte read, so prefer the byte count for non-error results.
+    if (result == kResultOk || result == kResultFalse) return bytesRead;
     return -1;
   }
   static int64_t write(const struct clap_ostream *stream, const void *buffer, uint64_t size)

--- a/clap_wrapper_builder/clap-wrapper/src/wrapasauv2.cpp
+++ b/clap_wrapper_builder/clap-wrapper/src/wrapasauv2.cpp
@@ -351,6 +351,8 @@ void WrapAsAUV2::setupParameters(const clap_plugin_t *plugin, const clap_plugin_
   _clumps.reset();
   _orderedParameterList.clear();
   _paramOrderingProvided = false;
+  _hasBypassParameter = false;
+  _bypassParameterInfo = {};
   auto *p = _plugin->_ext._params;
   if (p)
   {
@@ -427,12 +429,42 @@ void WrapAsAUV2::setupParameters(const clap_plugin_t *plugin, const clap_plugin_
           {
             piter->second->updateInfo(_plugin->_plugin, p, paraminfo);
           }
+          if ((paraminfo.flags & CLAP_PARAM_IS_BYPASS) && !_hasBypassParameter)
+          {
+            // AU hosts can drive kAudioUnitProperty_BypassEffect without touching
+            // the plugin parameter list. Back it with the CLAP bypass parameter
+            // so AU bypass and plugin-format bypass share the same state.
+            _hasBypassParameter = true;
+            _bypassParameterInfo = paraminfo;
+          }
           Globals()->SetParameter(paraminfo.id, result);
           _orderedParameterList.push_back(static_cast<AudioUnitParameterID>(paraminfo.id));
         }
       }
     }
   }
+}
+
+bool WrapAsAUV2::IsBypassEffect()
+{
+  if (!_hasBypassParameter)
+  {
+    return false;
+  }
+  const auto value = Globals()->GetParameter(_bypassParameterInfo.id);
+  const auto midpoint = (_bypassParameterInfo.min_value + _bypassParameterInfo.max_value) * 0.5;
+  return value >= midpoint;
+}
+
+void WrapAsAUV2::SetBypassEffect(bool bypass)
+{
+  if (!_hasBypassParameter)
+  {
+    return;
+  }
+  const auto value = bypass ? _bypassParameterInfo.max_value : _bypassParameterInfo.min_value;
+  SetParameter(static_cast<AudioUnitParameterID>(_bypassParameterInfo.id), kAudioUnitScope_Global,
+               0, static_cast<AudioUnitParameterValue>(value), 0);
 }
 
 OSStatus WrapAsAUV2::GetParameterList(AudioUnitScope inScope, AudioUnitParameterID *outParameterList,
@@ -522,8 +554,22 @@ OSStatus WrapAsAUV2::GetParameterInfo(AudioUnitScope inScope, AudioUnitParameter
       // strcpy(outParameterInfo.name, info.name);
       memset(outParameterInfo.name, 0, sizeof(outParameterInfo.name));
 
-      CFRetain(f->CFString());
-      outParameterInfo.cfNameString = f->CFString();
+      CFStringRef name = f->CFString();
+      if (name)
+      {
+        CFRetain(name);
+      }
+      else
+      {
+        // The parameter advertises a CF name, so provide a stable fallback even
+        // if the plugin supplied a name CoreFoundation could not encode.
+        name = CFStringCreateWithCString(NULL, "Parameter", kCFStringEncodingUTF8);
+        if (!name)
+        {
+          return kAudioUnitErr_InvalidParameter;
+        }
+      }
+      outParameterInfo.cfNameString = name;
       outParameterInfo.minValue = info.min_value;
       outParameterInfo.maxValue = info.max_value;
       outParameterInfo.defaultValue = info.default_value;

--- a/clap_wrapper_builder/clap-wrapper/src/wrapasvst3.cpp
+++ b/clap_wrapper_builder/clap-wrapper/src/wrapasvst3.cpp
@@ -261,6 +261,24 @@ tresult PLUGIN_API ClapAsVst3::getState(IBStream *state)
   return (_plugin->save(CLAPVST3StreamAdapter(state)) ? Steinberg::kResultOk : Steinberg::kResultFalse);
 }
 
+tresult PLUGIN_API ClapAsVst3::setComponentState(IBStream *state)
+{
+  // Some hosts restore a combined component through the controller state path.
+  return setState(state);
+}
+
+tresult PLUGIN_API ClapAsVst3::setEditorState(IBStream *state)
+{
+  // SingleComponentEffect separates IEditController::setState into this path.
+  return setState(state);
+}
+
+tresult PLUGIN_API ClapAsVst3::getEditorState(IBStream *state)
+{
+  // Preserve project state for hosts that request controller/editor state.
+  return getState(state);
+}
+
 uint32 PLUGIN_API ClapAsVst3::getLatencySamples()
 {
   if (!_plugin->_ext._latency)

--- a/clap_wrapper_builder/clap-wrapper/src/wrapasvst3.h
+++ b/clap_wrapper_builder/clap-wrapper/src/wrapasvst3.h
@@ -171,6 +171,9 @@ class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect,
   tresult PLUGIN_API setIoMode(Vst::IoMode mode) override;
 
   // from IEditController
+  tresult PLUGIN_API setComponentState(IBStream *state) override;
+  tresult PLUGIN_API setEditorState(IBStream *state) override;
+  tresult PLUGIN_API getEditorState(IBStream *state) override;
   tresult PLUGIN_API setComponentHandler(Vst::IComponentHandler *handler) override;
 
   //----from IEditControllerEx1--------------------------------

--- a/cmake/make_clapfirst.cmake
+++ b/cmake/make_clapfirst.cmake
@@ -166,7 +166,7 @@ function(make_clapfirst_plugins)
         endif()
         target_add_vst3_wrapper(TARGET ${VST3_TARGET}
                 OUTPUT_NAME "${C1ST_OUTPUT_NAME}"
-                BUNDLE_IDENTIFIER "${C1ST_BUNDLE_IDENTIFER}.vst3"
+                BUNDLE_IDENTIFIER "${C1ST_BUNDLE_IDENTIFIER}.vst3"
                 BUNDLE_VERSION "${C1ST_BUNDLE_VERSION}"
                 ASSET_OUTPUT_DIRECTORY "${vod}"
                 WINDOWS_FOLDER_VST3 ${C1ST_WINDOWS_FOLDER_VST3}

--- a/cmake/make_clapfirst.cmake
+++ b/cmake/make_clapfirst.cmake
@@ -186,7 +186,7 @@ function(make_clapfirst_plugins)
             target_add_auv2_wrapper(
                     TARGET ${AUV2_TARGET}
                     OUTPUT_NAME "${C1ST_OUTPUT_NAME}"
-                    BUNDLE_IDENTIFIER "${C1ST_BUNDLE_IDENTIFER}.auv2"
+                    BUNDLE_IDENTIFIER "${C1ST_BUNDLE_IDENTIFIER}.auv2"
                     BUNDLE_VERSION "${C1ST_BUNDLE_VERSION}"
                     RESOURCE_DIRECTORY "${C1ST_RESOURCE_DIRECTORY}"
 
@@ -199,7 +199,7 @@ function(make_clapfirst_plugins)
             target_add_auv2_wrapper(
                     TARGET ${AUV2_TARGET}
                     OUTPUT_NAME "${C1ST_OUTPUT_NAME}"
-                    BUNDLE_IDENTIFIER "${C1ST_BUNDLE_IDENTIFER}.auv2"
+                    BUNDLE_IDENTIFIER "${C1ST_BUNDLE_IDENTIFIER}.auv2"
                     BUNDLE_VERSION "${C1ST_BUNDLE_VERSION}"
                     RESOURCE_DIRECTORY "${C1ST_RESOURCE_DIRECTORY}"
 

--- a/src/detail/auv2/auv2_shared.mm
+++ b/src/detail/auv2/auv2_shared.mm
@@ -14,6 +14,6 @@ bool auv2shared_mm_request_resize(const clap_window_t* win, uint32_t w, uint32_t
   auto* nsv = (NSView*)win;
   [nsv setFrame:NSMakeRect(0, 0, w, h)];
 
-  return false;
+  return true;
 }
 }  // namespace free_audio::auv2_wrapper

--- a/src/detail/auv2/wrappedview.asinclude.mm
+++ b/src/detail/auv2/wrappedview.asinclude.mm
@@ -118,7 +118,8 @@ void CLAP_WRAPPER_TIMER_CALLBACK(CFRunLoopTimerRef timer, void *info)
   m.ptr = self;
 
   gui->set_parent(ui._plugin->_plugin, &m);
-  gui->set_scale(ui._plugin->_plugin, 1.0);
+  // gui->set_scale is intentionally not called because
+  // AUv2 gui always uses logical size
 
   if (gui->can_resize(ui._plugin->_plugin))
   {
@@ -188,7 +189,8 @@ void CLAP_WRAPPER_TIMER_CALLBACK(CFRunLoopTimerRef timer, void *info)
   if (canary)
   {
     auto gui = ui._plugin->_ext._gui;
-    gui->set_scale(ui._plugin->_plugin, 1.0);
+    // gui->set_scale is intentionally not called because
+    // AUv2 gui always uses logical size
     gui->set_size(ui._plugin->_plugin, newSize.size.width, newSize.size.height);
   }
   // gui->show(ui._plugin->_plugin);


### PR DESCRIPTION
## Summary
- Document the clap-wrapper subtree maintenance flow using git subtree pull.
- Update clap-wrapper from free-audio next while preserving subtree metadata.
- Apply selected archive fixes for VST3 state restore, AUv2/AAX parameter and bypass handling, and clap-first build configuration.

## Notes
- Main-thread marshalling changes were intentionally not imported.
- The new wrac CLAP adapter already issues parameter value rescans after state restore, so the archive-side explicit VST3 parameter cache sync was not brought over.

## Verification
- cargo fmt --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace