### PR TITLE
Add host context detection and Cubase GUI quirks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2778,6 +2778,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -2816,6 +2825,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
 name = "windows-threading"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2846,6 +2871,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2856,6 +2887,12 @@ name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2870,6 +2907,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2880,6 +2929,12 @@ name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2894,6 +2949,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2906,6 +2967,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2916,6 +2983,12 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -2942,6 +3015,7 @@ dependencies = [
  "clap-sys",
  "log",
  "parking_lot",
+ "wrac_host_context",
  "wrac_log",
 ]
 
@@ -2967,6 +3041,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "wrac_host_context"
+version = "0.1.0"
+
+[[package]]
 name = "wrac_log"
 version = "0.1.0"
 dependencies = [
@@ -2985,7 +3063,9 @@ dependencies = [
  "parking_lot",
  "raw-window-handle",
  "url",
+ "windows-sys 0.59.0",
  "wrac_clap_adapter",
+ "wrac_host_context",
  "wxp",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "plugins/wrac-gain/src-plugin",
     "xtask",
     "crates/wrac_clap_adapter",
+    "crates/wrac_host_context",
     "crates/wrac_log",
     "crates/wrac_xtask",
     "crates/wrac_wxp_gui",
@@ -14,6 +15,7 @@ clap-sys = "0.5.0"
 novonotes_run_loop = { git = "https://github.com/novonotes/wxp.git", package = "novonotes_run_loop", rev = "0feb83811e0b7e65ed3f06a5c5ed8a9a77e9b717" }
 run_loop_timer = { git = "https://github.com/novonotes/wxp.git", package = "run_loop_timer", rev = "0feb83811e0b7e65ed3f06a5c5ed8a9a77e9b717" }
 wrac_clap_adapter = { path = "crates/wrac_clap_adapter" }
+wrac_host_context = { path = "crates/wrac_host_context" }
 wrac_log = { path = "crates/wrac_log" }
 wrac_wxp_gui = { path = "crates/wrac_wxp_gui" }
 wxp = { git = "https://github.com/novonotes/wxp.git", rev = "0feb83811e0b7e65ed3f06a5c5ed8a9a77e9b717" }

--- a/crates/wrac_clap_adapter/Cargo.toml
+++ b/crates/wrac_clap_adapter/Cargo.toml
@@ -12,6 +12,7 @@ publish = false
 clap-sys = { workspace = true }
 log = "0.4"
 parking_lot = "0.12"
+wrac_host_context = { workspace = true }
 wrac_log = { workspace = true }
 
 [lints.rust]

--- a/crates/wrac_clap_adapter/src/abi.rs
+++ b/crates/wrac_clap_adapter/src/abi.rs
@@ -134,15 +134,6 @@ impl PluginInstance {
         let parameter_edits = Arc::new(ParameterEditQueue::new(host));
         let clap_host_name = unsafe { clap_host_name(host) };
         let host_context = HostContext::detect_current(clap_host_name.as_deref());
-        // Emit before product construction so wrapper/host routing is visible even when
-        // plugin initialization or WebView attachment fails later in the session.
-        log::info!(
-            "factory.create_plugin: host_context host=\"{}\" process=\"{}\" format={} clap_host_name=\"{}\"",
-            host_context.host.display_name,
-            host_context.host.process_name,
-            host_context.plugin_format.as_str(),
-            clap_host_name.as_deref().unwrap_or("")
-        );
         // Pass as a safe proxy so product GUI code can hold it without knowing about
         // host pointers or CLAP event lifetimes.
         let context = PluginCoreContext {
@@ -155,6 +146,15 @@ impl PluginInstance {
             .entry
             .plugin_factory()?
             .create_plugin(plugin_id, context)?;
+        // Product construction initializes logging. Emit immediately afterward so
+        // wrapper/host routing is visible before capability queries or GUI attachment.
+        log::info!(
+            "factory.create_plugin: host_context host=\"{}\" process=\"{}\" format={} clap_host_name=\"{}\"",
+            host_context.host.display_name,
+            host_context.host.process_name,
+            host_context.plugin_format.as_str(),
+            clap_host_name.as_deref().unwrap_or("")
+        );
         // Freeze capabilities here, before callbacks begin. Waiting on the core lock
         // inside get_extension would make us dependent on host re-entry order. The Arc
         // is just an entry point; the source of truth remains in the plugin's store.

--- a/crates/wrac_clap_adapter/src/abi.rs
+++ b/crates/wrac_clap_adapter/src/abi.rs
@@ -29,6 +29,7 @@ use clap_sys::process::{
 };
 use clap_sys::version::clap_version_is_compatible;
 use parking_lot::{Mutex, RwLock};
+use wrac_host_context::HostContext;
 
 mod audio_buffers;
 mod audio_ports;
@@ -91,6 +92,7 @@ pub(crate) struct PluginInstance {
     render: Option<Arc<dyn PluginRenderExtension>>,
     tail: Option<Arc<dyn PluginTailExtension>>,
     latency: Option<Arc<dyn PluginLatencyExtension>>,
+    host_context: HostContext,
     // Re-entry guard for GUI mutation callbacks. Fails immediately on re-entry to avoid
     // deadlock (GUI query callbacks do not go through this guard).
     gui_callback_busy: Mutex<()>,
@@ -130,12 +132,24 @@ impl PluginInstance {
         host: *const clap_host,
     ) -> Option<Box<Self>> {
         let parameter_edits = Arc::new(ParameterEditQueue::new(host));
+        let clap_host_name = unsafe { clap_host_name(host) };
+        let host_context = HostContext::detect_current(clap_host_name.as_deref());
+        // Emit before product construction so wrapper/host routing is visible even when
+        // plugin initialization or WebView attachment fails later in the session.
+        log::info!(
+            "factory.create_plugin: host_context host=\"{}\" process=\"{}\" format={} clap_host_name=\"{}\"",
+            host_context.host.display_name,
+            host_context.host.process_name,
+            host_context.plugin_format.as_str(),
+            clap_host_name.as_deref().unwrap_or("")
+        );
         // Pass as a safe proxy so product GUI code can hold it without knowing about
         // host pointers or CLAP event lifetimes.
         let context = PluginCoreContext {
             host_parameter_edit_notifier: parameter_edits.clone(),
             host_state_dirty_notifier: Arc::new(HostStateDirtyNotification::new(host)),
             host_gui_resize_requester: Arc::new(HostGuiResizeRequest::new(host)),
+            host_context: host_context.clone(),
         };
         let core = registration
             .entry
@@ -192,6 +206,7 @@ impl PluginInstance {
             render,
             tail,
             latency,
+            host_context,
             gui_callback_busy: Mutex::new(()),
             parameter_edits,
             processor: UnsafeCell::new(None),
@@ -299,6 +314,21 @@ impl PluginInstance {
             std::thread::yield_now();
         }
     }
+}
+
+unsafe fn clap_host_name(host: *const clap_host) -> Option<String> {
+    if host.is_null() {
+        return None;
+    }
+    let name = unsafe { (*host).name };
+    if name.is_null() {
+        return None;
+    }
+    Some(
+        unsafe { CStr::from_ptr(name) }
+            .to_string_lossy()
+            .into_owned(),
+    )
 }
 
 struct LifecycleGuard<'a>(&'a AtomicBool);

--- a/crates/wrac_clap_adapter/src/abi/params_extension.rs
+++ b/crates/wrac_clap_adapter/src/abi/params_extension.rs
@@ -16,6 +16,10 @@ use clap_sys::plugin::clap_plugin;
 use super::PluginInstance;
 use super::ffi::{ffi_bool, ffi_u32, ffi_unit, fill_c_char_array, write_c_str_buffer};
 use crate::ParamFlags;
+use wrac_host_context::PluginFormat;
+
+const CLAP_INVALID_PARAM_ID: u32 = u32::MAX;
+const VST3_MAX_PUBLIC_PARAM_ID: u32 = 0x7fff_ffff;
 
 pub(super) static PARAMS: clap_plugin_params = clap_plugin_params {
     count: Some(params_count),
@@ -70,6 +74,18 @@ unsafe extern "C" fn params_get_info(
             log::warn!("params.get_info: invalid index={param_index}");
             return false;
         };
+        // `UINT32_MAX` is invalid in CLAP. Through VST3, the high-bit range is also
+        // reserved and clap-wrapper masks it when translating IDs, which can collide
+        // otherwise distinct parameters. Rejecting at discovery keeps the bad mapping
+        // out of the host instead of letting automation lanes corrupt later.
+        if !is_param_id_exposable(info.id, instance.host_context.plugin_format) {
+            log::error!(
+                "params.get_info: rejecting unsupported parameter id index={param_index} id={} format={}",
+                info.id,
+                instance.host_context.plugin_format.as_str()
+            );
+            return false;
+        }
         log::debug!(
             "params.get_info: index={param_index} id={} name={} flags={} thread={:?}",
             info.id,
@@ -90,6 +106,13 @@ unsafe extern "C" fn params_get_info(
         }
         true
     })
+}
+
+fn is_param_id_exposable(param_id: u32, plugin_format: PluginFormat) -> bool {
+    if param_id == CLAP_INVALID_PARAM_ID {
+        return false;
+    }
+    plugin_format != PluginFormat::Vst3 || param_id <= VST3_MAX_PUBLIC_PARAM_ID
 }
 
 unsafe extern "C" fn params_get_value(
@@ -270,4 +293,31 @@ fn parameter_flags(flags: ParamFlags) -> u32 {
         raw |= CLAP_PARAM_IS_ENUM;
     }
     raw
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_clap_invalid_param_id_for_all_formats() {
+        assert!(!is_param_id_exposable(
+            CLAP_INVALID_PARAM_ID,
+            PluginFormat::Unknown
+        ));
+        assert!(!is_param_id_exposable(
+            CLAP_INVALID_PARAM_ID,
+            PluginFormat::Vst3
+        ));
+    }
+
+    #[test]
+    fn rejects_vst3_reserved_param_id_range_only_for_vst3() {
+        assert!(is_param_id_exposable(0x8000_0000, PluginFormat::Unknown));
+        assert!(!is_param_id_exposable(0x8000_0000, PluginFormat::Vst3));
+        assert!(is_param_id_exposable(
+            VST3_MAX_PUBLIC_PARAM_ID,
+            PluginFormat::Vst3
+        ));
+    }
 }

--- a/crates/wrac_clap_adapter/src/api.rs
+++ b/crates/wrac_clap_adapter/src/api.rs
@@ -27,3 +27,4 @@ pub use types::{
     GuiResizeHints, GuiSize, HostWindow, NoteDialects, NotePortInfo, ParamFlags, ParamInfo,
     ParamValueEvent, PluginRenderMode, State,
 };
+pub use wrac_host_context::{DetectedHost, HostContext, HostFamily, HostVersion, PluginFormat};

--- a/crates/wrac_clap_adapter/src/api/core.rs
+++ b/crates/wrac_clap_adapter/src/api/core.rs
@@ -6,6 +6,7 @@ use crate::{
     PluginLatencyExtension, PluginNotePortsExtension, PluginParamsExtension, PluginRenderExtension,
     PluginResult, PluginStateExtension, PluginTailExtension, Processor,
 };
+use wrac_host_context::HostContext;
 
 #[derive(Debug, Clone, Copy)]
 pub struct ActivateContext {
@@ -22,6 +23,7 @@ pub struct PluginCoreContext {
     pub host_parameter_edit_notifier: Arc<dyn HostParamsEditNotifier>,
     pub host_state_dirty_notifier: Arc<dyn HostStateDirtyNotifier>,
     pub host_gui_resize_requester: Arc<dyn HostGuiResizeRequester>,
+    pub host_context: HostContext,
 }
 
 /// Entry point for a single plugin instance's lifecycle and capabilities.

--- a/crates/wrac_clap_adapter/src/lib.rs
+++ b/crates/wrac_clap_adapter/src/lib.rs
@@ -17,11 +17,12 @@ mod params;
 mod process_buffer;
 
 pub use api::{
-    ActivateContext, AudioPortConfigRequest, AudioPortFlags, AudioPortInfo, AudioPortType, GuiApi,
-    GuiConfig, GuiResizeHints, GuiSize, HostGuiResizeRequester, HostParamsEditNotifier,
-    HostStateDirtyNotifier, HostWindow, NoteDialects, NotePortInfo, ParamFlags, ParamInfo,
-    ParamValueEvent, PluginAudioPortsExtension, PluginConfigurableAudioPortsExtension, PluginCore,
-    PluginCoreContext, PluginError, PluginGuiExtension, PluginLatencyExtension,
+    ActivateContext, AudioPortConfigRequest, AudioPortFlags, AudioPortInfo, AudioPortType,
+    DetectedHost, GuiApi, GuiConfig, GuiResizeHints, GuiSize, HostContext, HostFamily,
+    HostGuiResizeRequester, HostParamsEditNotifier, HostStateDirtyNotifier, HostVersion,
+    HostWindow, NoteDialects, NotePortInfo, ParamFlags, ParamInfo, ParamValueEvent,
+    PluginAudioPortsExtension, PluginConfigurableAudioPortsExtension, PluginCore,
+    PluginCoreContext, PluginError, PluginFormat, PluginGuiExtension, PluginLatencyExtension,
     PluginNotePortsExtension, PluginParamsExtension, PluginRenderExtension, PluginRenderMode,
     PluginResult, PluginStateExtension, PluginTailExtension, ProcessContext, ProcessStatus,
     Processor, State,

--- a/crates/wrac_host_context/Cargo.toml
+++ b/crates/wrac_host_context/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "wrac_host_context"
+version = "0.1.0"
+edition = "2024"
+description = "Host and wrapper-format detection for WRAC plugins"
+license = "MIT"
+repository = "https://github.com/novonotes/wrac-plugin-template"
+publish = false
+
+[dependencies]
+
+[lints.rust]
+unreachable_pub = "deny"

--- a/crates/wrac_host_context/src/lib.rs
+++ b/crates/wrac_host_context/src/lib.rs
@@ -1,0 +1,879 @@
+use std::path::Path;
+
+#[cfg(target_os = "macos")]
+use std::ffi::CStr;
+
+/// Host process identity plus the wrapper format inferred from CLAP metadata.
+///
+/// The host family is intentionally diagnostic/mechanical context, not policy. Callers
+/// decide which workaround or compatibility decision to apply from this value so product
+/// behavior does not accumulate inside the detection table.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HostContext {
+    pub host: DetectedHost,
+    pub plugin_format: PluginFormat,
+}
+
+impl HostContext {
+    pub fn detect_current(clap_host_name: Option<&str>) -> Self {
+        Self {
+            host: detect_host(),
+            plugin_format: PluginFormat::detect(clap_host_name.unwrap_or_default()),
+        }
+    }
+
+    pub fn is_cubase_vst3(&self) -> bool {
+        self.host.family == HostFamily::SteinbergCubase && self.plugin_format == PluginFormat::Vst3
+    }
+}
+
+/// Parsed host identity from the process executable.
+///
+/// `display_name` preserves the human-readable names historically used in logs, while
+/// `family` and `version` are stable fields for tests and host-specific quirk selection.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DetectedHost {
+    pub display_name: String,
+    pub process_name: String,
+    pub process_path: String,
+    pub family: HostFamily,
+    pub version: Option<HostVersion>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct HostVersion {
+    pub major: u16,
+    pub minor: Option<u16>,
+}
+
+impl HostVersion {
+    pub const fn major(major: u16) -> Self {
+        Self { major, minor: None }
+    }
+
+    pub const fn major_minor(major: u16, minor: u16) -> Self {
+        Self {
+            major,
+            minor: Some(minor),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PluginFormat {
+    Vst3,
+    Au,
+    Aax,
+    Unknown,
+}
+
+impl PluginFormat {
+    /// Detects the outer wrapper format from clap-wrapper's host name suffix.
+    ///
+    /// Native CLAP hosts do not carry this suffix, so absence is reported as `Unknown`
+    /// instead of guessing from the process name.
+    pub fn detect(clap_host_name: &str) -> Self {
+        let normalized = clap_host_name.to_ascii_lowercase();
+        if normalized.contains("clap-as-vst3") {
+            Self::Vst3
+        } else if normalized.contains("clap-as-au") {
+            Self::Au
+        } else if normalized.contains("clap-as-aax") {
+            Self::Aax
+        } else {
+            Self::Unknown
+        }
+    }
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Vst3 => "vst3",
+            Self::Au => "au",
+            Self::Aax => "aax",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HostFamily {
+    AbletonLive,
+    AdobeAudition,
+    AdobePremiere,
+    AppleAuLab,
+    AppleAuval,
+    AppleFinalCut,
+    AppleGarageBand,
+    AppleInfoHelper,
+    AppleLogic,
+    AppleMainStage,
+    Ardour,
+    BitwigStudio,
+    CakewalkByBandlab,
+    CakewalkSonar,
+    DaVinciResolve,
+    DigitalPerformer,
+    FlStudio,
+    JuceAudioPluginHost,
+    Luna,
+    MagixSamplitude,
+    MagixSequoia,
+    MuseReceptor,
+    NiMaschine,
+    Pluginval,
+    ProTools,
+    Pyramix,
+    Reason,
+    Renoise,
+    Reaper,
+    Sadie,
+    SteinbergCubase,
+    SteinbergCubaseBridged,
+    SteinbergNuendo,
+    SteinbergTestHost,
+    SteinbergWavelab,
+    StudioOne,
+    Tracktion,
+    TracktionWaveform,
+    VbVstScanner,
+    ViennaEnsemblePro,
+    WaveBurner,
+    Unknown,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct HostMatch {
+    family: HostFamily,
+    display_name: &'static str,
+    version: Option<HostVersion>,
+}
+
+pub fn detect_host() -> DetectedHost {
+    let process_path = host_process_path();
+    detect_host_from_path(&process_path)
+}
+
+pub fn detect_host_from_path(process_path: &str) -> DetectedHost {
+    let process_name = file_name_or_empty(process_path);
+    let matched = detect_host_match_for_platform(process_path, &process_name);
+    let (family, display_name, version) = matched
+        .map(|matched| (matched.family, matched.display_name, matched.version))
+        .unwrap_or((HostFamily::Unknown, "Unknown", None));
+    DetectedHost {
+        display_name: display_name.to_string(),
+        process_name,
+        process_path: process_path.to_string(),
+        family,
+        version,
+    }
+}
+
+#[cfg(target_os = "macos")]
+unsafe extern "C" {
+    fn _NSGetExecutablePath(buf: *mut std::os::raw::c_char, bufsize: *mut u32) -> i32;
+}
+
+#[cfg(target_os = "macos")]
+fn host_process_path() -> String {
+    let mut size = 8192u32;
+    let mut buffer = vec![0; size as usize + 8];
+    let result = unsafe { _NSGetExecutablePath(buffer.as_mut_ptr(), &mut size) };
+    if result == 0 {
+        return unsafe { CStr::from_ptr(buffer.as_ptr()) }
+            .to_string_lossy()
+            .into_owned();
+    }
+
+    std::env::current_exe()
+        .map(|path| path.display().to_string())
+        .unwrap_or_default()
+}
+
+#[cfg(not(target_os = "macos"))]
+fn host_process_path() -> String {
+    std::env::current_exe()
+        .map(|path| path.display().to_string())
+        .unwrap_or_default()
+}
+
+fn file_name_or_empty(path: &str) -> String {
+    Path::new(path)
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_default()
+}
+
+fn contains_ignore_case(value: &str, pattern: &str) -> bool {
+    value
+        .as_bytes()
+        .windows(pattern.len())
+        .any(|window| window.eq_ignore_ascii_case(pattern.as_bytes()))
+}
+
+fn starts_with_ignore_case(value: &str, pattern: &str) -> bool {
+    value
+        .as_bytes()
+        .get(..pattern.len())
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case(pattern.as_bytes()))
+}
+
+fn host(family: HostFamily, display_name: &'static str, version: Option<HostVersion>) -> HostMatch {
+    HostMatch {
+        family,
+        display_name,
+        version,
+    }
+}
+
+fn detect_host_match_for_platform(host_path: &str, host_filename: &str) -> Option<HostMatch> {
+    #[cfg(target_os = "macos")]
+    {
+        detect_host_macos(host_path, host_filename)
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        detect_host_windows(host_path, host_filename)
+    }
+
+    #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+    {
+        let _ = host_path;
+        detect_host_unix(host_filename)
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn detect_host_macos(host_path: &str, host_filename: &str) -> Option<HostMatch> {
+    if contains_ignore_case(host_path, "Final Cut Pro.app")
+        || contains_ignore_case(host_path, "Final Cut Pro Trial.app")
+    {
+        return Some(host(HostFamily::AppleFinalCut, "Final Cut", None));
+    }
+    if contains_ignore_case(host_path, "Live 6") {
+        return Some(host(
+            HostFamily::AbletonLive,
+            "Ableton Live 6",
+            Some(HostVersion::major(6)),
+        ));
+    }
+    if contains_ignore_case(host_path, "Live 7") {
+        return Some(host(
+            HostFamily::AbletonLive,
+            "Ableton Live 7",
+            Some(HostVersion::major(7)),
+        ));
+    }
+    if contains_ignore_case(host_path, "Live 8") {
+        return Some(host(
+            HostFamily::AbletonLive,
+            "Ableton Live 8",
+            Some(HostVersion::major(8)),
+        ));
+    }
+    if contains_ignore_case(host_path, "Live 9") {
+        return Some(host(
+            HostFamily::AbletonLive,
+            "Ableton Live 9",
+            Some(HostVersion::major(9)),
+        ));
+    }
+    if contains_ignore_case(host_path, "Live 10") {
+        return Some(host(
+            HostFamily::AbletonLive,
+            "Ableton Live 10",
+            Some(HostVersion::major(10)),
+        ));
+    }
+    if contains_ignore_case(host_path, "Live 11") {
+        return Some(host(
+            HostFamily::AbletonLive,
+            "Ableton Live 11",
+            Some(HostVersion::major(11)),
+        ));
+    }
+    if contains_ignore_case(host_filename, "Live") {
+        return Some(host(HostFamily::AbletonLive, "Ableton Live", None));
+    }
+    if contains_ignore_case(host_filename, "Audition") {
+        return Some(host(HostFamily::AdobeAudition, "Adobe Audition", None));
+    }
+    if contains_ignore_case(host_filename, "Adobe Premiere") {
+        return Some(host(HostFamily::AdobePremiere, "Adobe Premiere", None));
+    }
+    if contains_ignore_case(host_filename, "GarageBand") {
+        return Some(host(HostFamily::AppleGarageBand, "Apple GarageBand", None));
+    }
+    if contains_ignore_case(host_filename, "Logic") {
+        return Some(host(HostFamily::AppleLogic, "Apple Logic", None));
+    }
+    if contains_ignore_case(host_filename, "MainStage") {
+        return Some(host(HostFamily::AppleMainStage, "Apple MainStage", None));
+    }
+    if contains_ignore_case(host_filename, "AU Lab") {
+        return Some(host(HostFamily::AppleAuLab, "AU Lab", None));
+    }
+    if contains_ignore_case(host_filename, "Pro Tools") {
+        return Some(host(HostFamily::ProTools, "ProTools", None));
+    }
+    if contains_ignore_case(host_filename, "Nuendo 3") {
+        return Some(host(
+            HostFamily::SteinbergNuendo,
+            "Steinberg Nuendo 3",
+            Some(HostVersion::major(3)),
+        ));
+    }
+    if contains_ignore_case(host_filename, "Nuendo 4") {
+        return Some(host(
+            HostFamily::SteinbergNuendo,
+            "Steinberg Nuendo 4",
+            Some(HostVersion::major(4)),
+        ));
+    }
+    if contains_ignore_case(host_filename, "Nuendo 5") {
+        return Some(host(
+            HostFamily::SteinbergNuendo,
+            "Steinberg Nuendo 5",
+            Some(HostVersion::major(5)),
+        ));
+    }
+    if contains_ignore_case(host_filename, "Nuendo") {
+        return Some(host(HostFamily::SteinbergNuendo, "Steinberg Nuendo", None));
+    }
+    detect_cubase_macos(host_path, host_filename).or_else(|| {
+        if contains_ignore_case(host_path, "Wavelab 7") {
+            Some(host(
+                HostFamily::SteinbergWavelab,
+                "Steinberg Wavelab 7",
+                Some(HostVersion::major(7)),
+            ))
+        } else if contains_ignore_case(host_path, "Wavelab 8") {
+            Some(host(
+                HostFamily::SteinbergWavelab,
+                "Steinberg Wavelab 8",
+                Some(HostVersion::major(8)),
+            ))
+        } else if contains_ignore_case(host_filename, "Wavelab") {
+            Some(host(
+                HostFamily::SteinbergWavelab,
+                "Steinberg Wavelab",
+                None,
+            ))
+        } else if contains_ignore_case(host_filename, "WaveBurner") {
+            Some(host(HostFamily::WaveBurner, "WaveBurner", None))
+        } else if contains_ignore_case(host_path, "Digital Performer") {
+            Some(host(HostFamily::DigitalPerformer, "DigitalPerformer", None))
+        } else if contains_ignore_case(host_filename, "reaper") {
+            Some(host(HostFamily::Reaper, "Reaper", None))
+        } else if contains_ignore_case(host_filename, "Reason") {
+            Some(host(HostFamily::Reason, "Reason", None))
+        } else if contains_ignore_case(host_path, "Studio One") {
+            Some(host(HostFamily::StudioOne, "Studio One", None))
+        } else if starts_with_ignore_case(host_filename, "Waveform") {
+            Some(host(
+                HostFamily::TracktionWaveform,
+                "Tracktion Waveform",
+                None,
+            ))
+        } else if contains_ignore_case(host_path, "Tracktion 3") {
+            Some(host(
+                HostFamily::Tracktion,
+                "Tracktion 3",
+                Some(HostVersion::major(3)),
+            ))
+        } else if contains_ignore_case(host_filename, "Tracktion") {
+            Some(host(HostFamily::Tracktion, "Tracktion", None))
+        } else if contains_ignore_case(host_filename, "Renoise") {
+            Some(host(HostFamily::Renoise, "Renoise", None))
+        } else if contains_ignore_case(host_filename, "Resolve") {
+            Some(host(HostFamily::DaVinciResolve, "DaVinci Resolve", None))
+        } else if starts_with_ignore_case(host_filename, "Bitwig") {
+            Some(host(HostFamily::BitwigStudio, "Bitwig Studio", None))
+        } else if contains_ignore_case(host_filename, "OsxFL") {
+            Some(host(HostFamily::FlStudio, "FL Studio", None))
+        } else if contains_ignore_case(host_filename, "pluginval") {
+            Some(host(HostFamily::Pluginval, "pluginval", None))
+        } else if contains_ignore_case(host_filename, "AudioPluginHost") {
+            Some(host(
+                HostFamily::JuceAudioPluginHost,
+                "JUCE AudioPluginHost",
+                None,
+            ))
+        } else if contains_ignore_case(host_path, "LUNA.app")
+            || contains_ignore_case(host_filename, "LUNA")
+        {
+            Some(host(HostFamily::Luna, "LUNA", None))
+        } else if contains_ignore_case(host_filename, "Maschine") {
+            Some(host(HostFamily::NiMaschine, "NI Maschine", None))
+        } else if contains_ignore_case(host_filename, "Vienna Ensemble Pro") {
+            Some(host(
+                HostFamily::ViennaEnsemblePro,
+                "Vienna Ensemble Pro",
+                None,
+            ))
+        } else if contains_ignore_case(host_filename, "auvaltool") {
+            Some(host(HostFamily::AppleAuval, "auval", None))
+        } else if contains_ignore_case(host_filename, "com.apple.audio.infohelper") {
+            Some(host(
+                HostFamily::AppleInfoHelper,
+                "com.apple.audio.InfoHelper",
+                None,
+            ))
+        } else {
+            None
+        }
+    })
+}
+
+#[cfg(target_os = "macos")]
+fn detect_cubase_macos(host_path: &str, host_filename: &str) -> Option<HostMatch> {
+    if contains_ignore_case(host_filename, "Cubase 4") {
+        return Some(host(
+            HostFamily::SteinbergCubase,
+            "Steinberg Cubase 4",
+            Some(HostVersion::major(4)),
+        ));
+    }
+    if contains_ignore_case(host_filename, "Cubase 5") {
+        return Some(host(
+            HostFamily::SteinbergCubase,
+            "Steinberg Cubase 5",
+            Some(HostVersion::major(5)),
+        ));
+    }
+    if contains_ignore_case(host_filename, "Cubase 6") {
+        return Some(host(
+            HostFamily::SteinbergCubase,
+            "Steinberg Cubase 6",
+            Some(HostVersion::major(6)),
+        ));
+    }
+    if contains_ignore_case(host_filename, "Cubase 7") {
+        return Some(host(
+            HostFamily::SteinbergCubase,
+            "Steinberg Cubase 7",
+            Some(HostVersion::major(7)),
+        ));
+    }
+    if contains_ignore_case(host_path, "Cubase 8.5.app") {
+        return Some(host(
+            HostFamily::SteinbergCubase,
+            "Steinberg Cubase 8.5",
+            Some(HostVersion::major_minor(8, 5)),
+        ));
+    }
+    if contains_ignore_case(host_path, "Cubase 8.app") {
+        return Some(host(
+            HostFamily::SteinbergCubase,
+            "Steinberg Cubase 8",
+            Some(HostVersion::major(8)),
+        ));
+    }
+    if contains_ignore_case(host_path, "Cubase 9.5.app") {
+        return Some(host(
+            HostFamily::SteinbergCubase,
+            "Steinberg Cubase 9.5",
+            Some(HostVersion::major_minor(9, 5)),
+        ));
+    }
+    if contains_ignore_case(host_path, "Cubase 9.app") {
+        return Some(host(
+            HostFamily::SteinbergCubase,
+            "Steinberg Cubase 9",
+            Some(HostVersion::major(9)),
+        ));
+    }
+    if contains_ignore_case(host_path, "Cubase 10.5.app") {
+        return Some(host(
+            HostFamily::SteinbergCubase,
+            "Steinberg Cubase 10.5",
+            Some(HostVersion::major_minor(10, 5)),
+        ));
+    }
+    if contains_ignore_case(host_path, "Cubase 10.app") {
+        return Some(host(
+            HostFamily::SteinbergCubase,
+            "Steinberg Cubase 10",
+            Some(HostVersion::major(10)),
+        ));
+    }
+    if contains_ignore_case(host_filename, "Cubase") {
+        return Some(host(HostFamily::SteinbergCubase, "Steinberg Cubase", None));
+    }
+    None
+}
+
+#[cfg(target_os = "windows")]
+fn detect_host_windows(host_path: &str, host_filename: &str) -> Option<HostMatch> {
+    if contains_ignore_case(host_filename, "Live 6") {
+        return Some(host(
+            HostFamily::AbletonLive,
+            "Ableton Live 6",
+            Some(HostVersion::major(6)),
+        ));
+    }
+    if contains_ignore_case(host_filename, "Live 7") {
+        return Some(host(
+            HostFamily::AbletonLive,
+            "Ableton Live 7",
+            Some(HostVersion::major(7)),
+        ));
+    }
+    if contains_ignore_case(host_filename, "Live 8") {
+        return Some(host(
+            HostFamily::AbletonLive,
+            "Ableton Live 8",
+            Some(HostVersion::major(8)),
+        ));
+    }
+    if contains_ignore_case(host_filename, "Live 9") {
+        return Some(host(
+            HostFamily::AbletonLive,
+            "Ableton Live 9",
+            Some(HostVersion::major(9)),
+        ));
+    }
+    if contains_ignore_case(host_filename, "Live 10") {
+        return Some(host(
+            HostFamily::AbletonLive,
+            "Ableton Live 10",
+            Some(HostVersion::major(10)),
+        ));
+    }
+    if contains_ignore_case(host_filename, "Live 11") {
+        return Some(host(
+            HostFamily::AbletonLive,
+            "Ableton Live 11",
+            Some(HostVersion::major(11)),
+        ));
+    }
+    if contains_ignore_case(host_filename, "Live ") {
+        return Some(host(HostFamily::AbletonLive, "Ableton Live", None));
+    }
+    if contains_ignore_case(host_filename, "Audition") {
+        return Some(host(HostFamily::AdobeAudition, "Adobe Audition", None));
+    }
+    if contains_ignore_case(host_filename, "Adobe Premiere") {
+        return Some(host(HostFamily::AdobePremiere, "Adobe Premiere", None));
+    }
+    if contains_ignore_case(host_filename, "ProTools") {
+        return Some(host(HostFamily::ProTools, "ProTools", None));
+    }
+    if contains_ignore_case(host_path, "SONAR 8") {
+        return Some(host(
+            HostFamily::CakewalkSonar,
+            "Cakewalk Sonar 8",
+            Some(HostVersion::major(8)),
+        ));
+    }
+    if contains_ignore_case(host_filename, "SONAR") {
+        return Some(host(HostFamily::CakewalkSonar, "Cakewalk Sonar", None));
+    }
+    if contains_ignore_case(host_filename, "Cakewalk.exe") {
+        return Some(host(
+            HostFamily::CakewalkByBandlab,
+            "Cakewalk by Bandlab",
+            None,
+        ));
+    }
+    if contains_ignore_case(host_filename, "GarageBand") {
+        return Some(host(HostFamily::AppleGarageBand, "Apple GarageBand", None));
+    }
+    if contains_ignore_case(host_filename, "Logic") {
+        return Some(host(HostFamily::AppleLogic, "Apple Logic", None));
+    }
+    if contains_ignore_case(host_filename, "MainStage") {
+        return Some(host(HostFamily::AppleMainStage, "Apple MainStage", None));
+    }
+    if starts_with_ignore_case(host_filename, "Waveform") {
+        return Some(host(
+            HostFamily::TracktionWaveform,
+            "Tracktion Waveform",
+            None,
+        ));
+    }
+    if contains_ignore_case(host_path, "Tracktion 3") {
+        return Some(host(
+            HostFamily::Tracktion,
+            "Tracktion 3",
+            Some(HostVersion::major(3)),
+        ));
+    }
+    if contains_ignore_case(host_filename, "Tracktion") {
+        return Some(host(HostFamily::Tracktion, "Tracktion", None));
+    }
+    if contains_ignore_case(host_filename, "reaper") {
+        return Some(host(HostFamily::Reaper, "Reaper", None));
+    }
+    detect_cubase_windows(host_path, host_filename).or_else(|| {
+        if contains_ignore_case(host_filename, "VSTBridgeApp") {
+            Some(host(
+                HostFamily::SteinbergCubaseBridged,
+                "Steinberg Cubase 5 Bridged",
+                Some(HostVersion::major(5)),
+            ))
+        } else if contains_ignore_case(host_path, "Wavelab 5") {
+            Some(host(
+                HostFamily::SteinbergWavelab,
+                "Steinberg Wavelab 5",
+                Some(HostVersion::major(5)),
+            ))
+        } else if contains_ignore_case(host_path, "Wavelab 6") {
+            Some(host(
+                HostFamily::SteinbergWavelab,
+                "Steinberg Wavelab 6",
+                Some(HostVersion::major(6)),
+            ))
+        } else if contains_ignore_case(host_path, "Wavelab 7") {
+            Some(host(
+                HostFamily::SteinbergWavelab,
+                "Steinberg Wavelab 7",
+                Some(HostVersion::major(7)),
+            ))
+        } else if contains_ignore_case(host_path, "Wavelab 8") {
+            Some(host(
+                HostFamily::SteinbergWavelab,
+                "Steinberg Wavelab 8",
+                Some(HostVersion::major(8)),
+            ))
+        } else if contains_ignore_case(host_path, "Nuendo") {
+            Some(host(HostFamily::SteinbergNuendo, "Steinberg Nuendo", None))
+        } else if contains_ignore_case(host_filename, "Wavelab") {
+            Some(host(
+                HostFamily::SteinbergWavelab,
+                "Steinberg Wavelab",
+                None,
+            ))
+        } else if contains_ignore_case(host_filename, "TestHost") {
+            Some(host(
+                HostFamily::SteinbergTestHost,
+                "Steinberg TestHost",
+                None,
+            ))
+        } else if contains_ignore_case(host_filename, "rm-host") {
+            Some(host(HostFamily::MuseReceptor, "Muse Receptor", None))
+        } else if contains_ignore_case(host_filename, "Maschine") {
+            Some(host(HostFamily::NiMaschine, "NI Maschine", None))
+        } else if starts_with_ignore_case(host_filename, "FL")
+            || contains_ignore_case(host_filename, "ilbridge.")
+        {
+            Some(host(HostFamily::FlStudio, "FL Studio", None))
+        } else if contains_ignore_case(host_path, "Studio One") {
+            Some(host(HostFamily::StudioOne, "Studio One", None))
+        } else if contains_ignore_case(host_path, "Digital Performer") {
+            Some(host(HostFamily::DigitalPerformer, "DigitalPerformer", None))
+        } else if contains_ignore_case(host_filename, "VST_Scanner") {
+            Some(host(HostFamily::VbVstScanner, "VBVSTScanner", None))
+        } else if contains_ignore_case(host_path, "Merging Technologies") {
+            Some(host(HostFamily::Pyramix, "Pyramix", None))
+        } else if starts_with_ignore_case(host_filename, "Sam") {
+            Some(host(HostFamily::MagixSamplitude, "Magix Samplitude", None))
+        } else if starts_with_ignore_case(host_filename, "Sequoia") {
+            Some(host(HostFamily::MagixSequoia, "Magix Sequoia", None))
+        } else if contains_ignore_case(host_filename, "Reason") {
+            Some(host(HostFamily::Reason, "Reason", None))
+        } else if contains_ignore_case(host_filename, "Renoise") {
+            Some(host(HostFamily::Renoise, "Renoise", None))
+        } else if contains_ignore_case(host_filename, "Resolve") {
+            Some(host(HostFamily::DaVinciResolve, "DaVinci Resolve", None))
+        } else if contains_ignore_case(host_path, "Bitwig Studio") {
+            Some(host(HostFamily::BitwigStudio, "Bitwig Studio", None))
+        } else if contains_ignore_case(host_filename, "Sadie") {
+            Some(host(HostFamily::Sadie, "SADiE", None))
+        } else if contains_ignore_case(host_filename, "pluginval") {
+            Some(host(HostFamily::Pluginval, "pluginval", None))
+        } else if contains_ignore_case(host_filename, "AudioPluginHost") {
+            Some(host(
+                HostFamily::JuceAudioPluginHost,
+                "JUCE AudioPluginHost",
+                None,
+            ))
+        } else if contains_ignore_case(host_filename, "Vienna Ensemble Pro") {
+            Some(host(
+                HostFamily::ViennaEnsemblePro,
+                "Vienna Ensemble Pro",
+                None,
+            ))
+        } else {
+            None
+        }
+    })
+}
+
+#[cfg(target_os = "windows")]
+fn detect_cubase_windows(host_path: &str, host_filename: &str) -> Option<HostMatch> {
+    if contains_ignore_case(host_filename, "Cubase4") {
+        return Some(host(
+            HostFamily::SteinbergCubase,
+            "Steinberg Cubase 4",
+            Some(HostVersion::major(4)),
+        ));
+    }
+    if contains_ignore_case(host_filename, "Cubase5") {
+        return Some(host(
+            HostFamily::SteinbergCubase,
+            "Steinberg Cubase 5",
+            Some(HostVersion::major(5)),
+        ));
+    }
+    if contains_ignore_case(host_filename, "Cubase6") {
+        return Some(host(
+            HostFamily::SteinbergCubase,
+            "Steinberg Cubase 6",
+            Some(HostVersion::major(6)),
+        ));
+    }
+    if contains_ignore_case(host_filename, "Cubase7") {
+        return Some(host(
+            HostFamily::SteinbergCubase,
+            "Steinberg Cubase 7",
+            Some(HostVersion::major(7)),
+        ));
+    }
+    if contains_ignore_case(host_filename, "Cubase8.5.exe") {
+        return Some(host(
+            HostFamily::SteinbergCubase,
+            "Steinberg Cubase 8.5",
+            Some(HostVersion::major_minor(8, 5)),
+        ));
+    }
+    if contains_ignore_case(host_filename, "Cubase8.exe") {
+        return Some(host(
+            HostFamily::SteinbergCubase,
+            "Steinberg Cubase 8",
+            Some(HostVersion::major(8)),
+        ));
+    }
+    if contains_ignore_case(host_filename, "Cubase9.5.exe")
+        || contains_ignore_case(host_path, "Cubase 9.5")
+    {
+        return Some(host(
+            HostFamily::SteinbergCubase,
+            "Steinberg Cubase 9.5",
+            Some(HostVersion::major_minor(9, 5)),
+        ));
+    }
+    if contains_ignore_case(host_filename, "Cubase9.exe")
+        || contains_ignore_case(host_path, "Cubase 9")
+    {
+        return Some(host(
+            HostFamily::SteinbergCubase,
+            "Steinberg Cubase 9",
+            Some(HostVersion::major(9)),
+        ));
+    }
+    if contains_ignore_case(host_filename, "Cubase10.5.exe")
+        || contains_ignore_case(host_path, "Cubase 10.5")
+    {
+        return Some(host(
+            HostFamily::SteinbergCubase,
+            "Steinberg Cubase 10.5",
+            Some(HostVersion::major_minor(10, 5)),
+        ));
+    }
+    if contains_ignore_case(host_filename, "Cubase10.exe")
+        || contains_ignore_case(host_path, "Cubase 10")
+    {
+        return Some(host(
+            HostFamily::SteinbergCubase,
+            "Steinberg Cubase 10",
+            Some(HostVersion::major(10)),
+        ));
+    }
+    if contains_ignore_case(host_filename, "Cubase") {
+        return Some(host(HostFamily::SteinbergCubase, "Steinberg Cubase", None));
+    }
+    None
+}
+
+#[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+fn detect_host_unix(host_filename: &str) -> Option<HostMatch> {
+    if contains_ignore_case(host_filename, "Ardour") {
+        return Some(host(HostFamily::Ardour, "Ardour", None));
+    }
+    if starts_with_ignore_case(host_filename, "Waveform") {
+        return Some(host(
+            HostFamily::TracktionWaveform,
+            "Tracktion Waveform",
+            None,
+        ));
+    }
+    if contains_ignore_case(host_filename, "Tracktion") {
+        return Some(host(HostFamily::Tracktion, "Tracktion", None));
+    }
+    if starts_with_ignore_case(host_filename, "Bitwig") {
+        return Some(host(HostFamily::BitwigStudio, "Bitwig Studio", None));
+    }
+    if contains_ignore_case(host_filename, "pluginval") {
+        return Some(host(HostFamily::Pluginval, "pluginval", None));
+    }
+    if contains_ignore_case(host_filename, "AudioPluginHost") {
+        return Some(host(
+            HostFamily::JuceAudioPluginHost,
+            "JUCE AudioPluginHost",
+            None,
+        ));
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_wrapper_format_from_clap_host_name() {
+        assert_eq!(
+            PluginFormat::detect("Cubase LE AI Elements (CLAP-as-VST3)"),
+            PluginFormat::Vst3
+        );
+        assert_eq!(
+            PluginFormat::detect("Logic Pro (CLAP-as-AU)"),
+            PluginFormat::Au
+        );
+        assert_eq!(PluginFormat::detect("Native CLAP"), PluginFormat::Unknown);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn detects_macos_hosts_like_existing_adapter() {
+        let live =
+            detect_host_from_path("/Applications/Ableton Live 11 Suite.app/Contents/MacOS/Live");
+        assert_eq!(live.display_name, "Ableton Live 11");
+        assert_eq!(live.family, HostFamily::AbletonLive);
+        assert_eq!(live.version, Some(HostVersion::major(11)));
+
+        let luna = detect_host_from_path("/Applications/LUNA.app/Contents/MacOS/LUNA");
+        assert_eq!(luna.display_name, "LUNA");
+        assert_eq!(luna.family, HostFamily::Luna);
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn detects_windows_hosts_like_existing_adapter() {
+        let cubase =
+            detect_host_from_path(r"C:\Program Files\Steinberg\Cubase 10\vst2xscanner.exe");
+        assert_eq!(cubase.display_name, "Steinberg Cubase 10");
+        assert_eq!(cubase.family, HostFamily::SteinbergCubase);
+        assert_eq!(cubase.version, Some(HostVersion::major(10)));
+
+        let live =
+            detect_host_from_path(r"C:\Program Files\Ableton\Live 11 Suite\Program\Live 11.exe");
+        assert_eq!(live.display_name, "Ableton Live 11");
+    }
+
+    #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+    #[test]
+    fn detects_unix_hosts_like_existing_adapter() {
+        let pluginval = detect_host_from_path("/usr/bin/pluginval");
+        assert_eq!(pluginval.display_name, "pluginval");
+        assert_eq!(pluginval.family, HostFamily::Pluginval);
+    }
+
+    #[test]
+    fn unknown_hosts_stay_unknown() {
+        let detected = detect_host_from_path("/Applications/SomeHost.app/Contents/MacOS/SomeHost");
+        assert_eq!(detected.display_name, "Unknown");
+        assert_eq!(detected.family, HostFamily::Unknown);
+    }
+}

--- a/crates/wrac_wxp_gui/Cargo.toml
+++ b/crates/wrac_wxp_gui/Cargo.toml
@@ -16,7 +16,11 @@ parking_lot = "0.12"
 raw-window-handle = "0.6"
 url = "2"
 wrac_clap_adapter = { workspace = true }
+wrac_host_context = { workspace = true }
 wxp = { workspace = true }
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_Graphics_Gdi", "Win32_System_LibraryLoader", "Win32_UI_HiDpi"] }
 
 [lints.rust]
 unreachable_pub = "deny"

--- a/crates/wrac_wxp_gui/src/controller.rs
+++ b/crates/wrac_wxp_gui/src/controller.rs
@@ -8,6 +8,7 @@ use wrac_clap_adapter::{
     GuiApi, GuiConfig, GuiResizeHints, GuiSize, HostGuiResizeRequester, HostWindow, PluginError,
     PluginGuiExtension, PluginResult,
 };
+use wrac_host_context::HostContext;
 use wxp::{WebViewDispatch, dpi::LogicalSize};
 
 use crate::dpi::DpiConverter;
@@ -35,6 +36,7 @@ pub struct WxpGuiController {
     layout: Arc<HostGuiLayout>,
     scale: Arc<Mutex<f64>>,
     runtime: Arc<Mutex<GuiRuntimeState>>,
+    host_context: HostContext,
 }
 
 struct HostGuiLayout {
@@ -112,6 +114,7 @@ impl WxpGuiController {
     pub fn new_with_resize_handle(
         factory: impl WxpGuiFactory,
         resize_handle: WxpGuiResizeHandle,
+        host_context: HostContext,
     ) -> Self {
         Self {
             factory: Arc::new(factory),
@@ -126,6 +129,7 @@ impl WxpGuiController {
                 pending_creation_generation: None,
                 destroy_requested_while_creating: false,
             })),
+            host_context,
         }
     }
 
@@ -150,6 +154,26 @@ impl WxpGuiController {
             self.note_runtime_destroyed();
         }
         log::debug!("wxp controller: destroy_gui_session completed");
+    }
+
+    fn should_async_resync_bounds_after_set_size(&self) -> bool {
+        self.host_context.is_cubase_vst3()
+    }
+
+    fn correct_host_scale(&self, scale: f64, parent: Option<StoredParentWindow>) -> f64 {
+        if !self.host_context.is_cubase_vst3() {
+            return scale;
+        }
+        // Cubase 10 on Windows has been observed to report integer VST3 scale factors
+        // even when the editor is hosted on a fractional-DPI monitor. The host parent
+        // HWND is the closest source of truth for the actual size conversion.
+        let corrected = corrected_scale_for_parent(parent).unwrap_or(scale);
+        if (corrected - scale).abs() > f64::EPSILON {
+            log::info!(
+                "wxp controller: corrected Cubase VST3 host scale from {scale} to {corrected}"
+            );
+        }
+        corrected
     }
 
     fn note_runtime_destroyed(&self) {
@@ -713,6 +737,81 @@ fn unpack_size(size: u64) -> GuiSize {
     }
 }
 
+#[cfg(windows)]
+fn corrected_scale_for_parent(parent: Option<StoredParentWindow>) -> Option<f64> {
+    use std::sync::OnceLock;
+
+    use windows_sys::Win32::Foundation::HWND;
+    use windows_sys::Win32::Graphics::Gdi::{
+        HMONITOR, MONITOR_DEFAULTTONEAREST, MonitorFromWindow,
+    };
+    use windows_sys::Win32::UI::HiDpi::{MDT_EFFECTIVE_DPI, MONITOR_DPI_TYPE};
+
+    type GetDpiForWindowFn = unsafe extern "system" fn(HWND) -> u32;
+    type GetDpiForMonitorFn =
+        unsafe extern "system" fn(HMONITOR, MONITOR_DPI_TYPE, *mut u32, *mut u32) -> i32;
+
+    let hwnd = parent?.win32_hwnd()? as HWND;
+    if hwnd.is_null() {
+        return None;
+    }
+
+    static GET_DPI_FOR_WINDOW: OnceLock<Option<GetDpiForWindowFn>> = OnceLock::new();
+    if let Some(get_dpi_for_window) = *GET_DPI_FOR_WINDOW
+        .get_or_init(|| unsafe { load_windows_proc(b"user32.dll\0", b"GetDpiForWindow\0") })
+    {
+        let window_dpi = unsafe { get_dpi_for_window(hwnd) };
+        if window_dpi > 0 {
+            return Some(window_dpi as f64 / 96.0);
+        }
+    }
+
+    let monitor = unsafe { MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST) };
+    if monitor.is_null() {
+        return None;
+    }
+
+    static GET_DPI_FOR_MONITOR: OnceLock<Option<GetDpiForMonitorFn>> = OnceLock::new();
+    let get_dpi_for_monitor = (*GET_DPI_FOR_MONITOR
+        .get_or_init(|| unsafe { load_windows_proc(b"shcore.dll\0", b"GetDpiForMonitor\0") }))?;
+
+    let mut dpi_x = 0u32;
+    let mut dpi_y = 0u32;
+    let result = unsafe {
+        get_dpi_for_monitor(
+            monitor,
+            MDT_EFFECTIVE_DPI,
+            &mut dpi_x as *mut u32,
+            &mut dpi_y as *mut u32,
+        )
+    };
+    if result == 0 && dpi_x > 0 {
+        Some(dpi_x as f64 / 96.0)
+    } else {
+        None
+    }
+}
+
+#[cfg(windows)]
+unsafe fn load_windows_proc<T>(module_name: &[u8], proc_name: &[u8]) -> Option<T>
+where
+    T: Copy,
+{
+    use windows_sys::Win32::System::LibraryLoader::{GetProcAddress, LoadLibraryA};
+
+    let module = unsafe { LoadLibraryA(module_name.as_ptr()) };
+    if module.is_null() {
+        return None;
+    }
+    let proc = unsafe { GetProcAddress(module, proc_name.as_ptr()) }?;
+    Some(unsafe { std::mem::transmute_copy(&proc) })
+}
+
+#[cfg(not(windows))]
+fn corrected_scale_for_parent(_parent: Option<StoredParentWindow>) -> Option<f64> {
+    None
+}
+
 impl PluginGuiExtension for WxpGuiController {
     fn is_api_supported(&self, api: GuiApi, is_floating: bool) -> bool {
         !is_floating && api == default_gui_api()
@@ -760,13 +859,14 @@ impl PluginGuiExtension for WxpGuiController {
 
     fn set_scale(&self, scale: f64) -> PluginResult<()> {
         log::debug!("wxp controller: set_scale called: scale={scale}");
-        let handle = {
+        let (handle, scale) = {
             let mut state = self.runtime.lock();
             if let Some(session) = &mut state.session {
-                session.scale = scale;
-                session.handle.clone()
+                let corrected_scale = self.correct_host_scale(scale, session.parent);
+                session.scale = corrected_scale;
+                (session.handle.clone(), corrected_scale)
             } else {
-                None
+                (None, scale)
             }
         };
         if let Some(handle) = handle {
@@ -819,6 +919,18 @@ impl PluginGuiExtension for WxpGuiController {
         if let Some(handle) = handle {
             if size_changed {
                 handle.set_size(size)?;
+            }
+            if self.should_async_resync_bounds_after_set_size() {
+                // Cubase 10 on macOS can resize the host-owned editor window after
+                // delivering `set_size`, leaving the embedded child view one geometry
+                // step behind. Re-posting the latest accepted size lets the host finish
+                // its adjustment before wxp reapplies child bounds.
+                log::debug!(
+                    "wxp controller: scheduling Cubase VST3 async bounds resync: width={}, height={}",
+                    size.width,
+                    size.height
+                );
+                handle.post_set_size(size)?;
             }
         }
         self.layout.store_accepted_size(size);
@@ -885,6 +997,9 @@ impl PluginGuiExtension for WxpGuiController {
             return Err(PluginError::InvalidState);
         }
         session.parent = Some(parent);
+        // If `set_scale` arrived before `set_parent`, Cubase VST3 scale correction must
+        // wait until the native parent window is known.
+        session.scale = self.correct_host_scale(session.scale, Some(parent));
         if let Some(parent_lease) = parent_lease {
             session.parent_lease = Some(parent_lease);
         }

--- a/crates/wrac_wxp_gui/src/runtime.rs
+++ b/crates/wrac_wxp_gui/src/runtime.rs
@@ -179,6 +179,30 @@ impl GuiRuntimeHandle {
         .map_err(|_| PluginError::InvalidState)?
     }
 
+    pub(crate) fn post_set_size(&self, size: GuiSize) -> PluginResult<()> {
+        let id = self.id;
+        log::debug!(
+            "wxp runtime {id}: post_set_size requested: width={}, height={}",
+            size.width,
+            size.height
+        );
+        // Used when a host mutates the native parent after the synchronous callback.
+        // Posting keeps the latest bounds tied to the runtime id while allowing stale
+        // editor sessions to disappear without turning a harmless race into an error.
+        RunLoop::post(move |_| {
+            GUI_RUNTIMES.with(|runtimes| {
+                let mut runtimes = runtimes.borrow_mut();
+                let Some(entry) = runtimes.get_mut(&id) else {
+                    log::debug!("wxp runtime {id}: post_set_size skipped missing runtime");
+                    return;
+                };
+                let result = entry.runtime.set_size(size);
+                log::debug!("wxp runtime {id}: post_set_size completed: result={result:?}");
+            });
+        })
+        .map_err(|_| PluginError::InvalidState)
+    }
+
     pub(crate) fn show(&self) -> PluginResult<()> {
         let id = self.id;
         log::debug!("wxp runtime {id}: show requested");

--- a/crates/wrac_wxp_gui/src/window.rs
+++ b/crates/wrac_wxp_gui/src/window.rs
@@ -44,6 +44,16 @@ impl StoredParentWindow {
         }
     }
 
+    #[cfg(windows)]
+    pub(crate) fn win32_hwnd(self) -> Option<*mut c_void> {
+        // Keep platform-specific parent inspection here so GUI policy code does not need
+        // to duplicate raw-window-handle matching or make assumptions about other backends.
+        match self {
+            Self::Win32 { hwnd } => Some(hwnd as *mut c_void),
+            _ => None,
+        }
+    }
+
     pub(crate) fn to_parent_window_handle(self) -> PluginResult<ParentWindowHandle> {
         match self {
             Self::Cocoa { ns_view } => {

--- a/plugins/wrac-gain/src-plugin/src/gui.rs
+++ b/plugins/wrac-gain/src-plugin/src/gui.rs
@@ -24,7 +24,7 @@ use runtime::{
     DEFAULT_GUI_SIZE, GuiRuntimeDependencies, MAX_GUI_SIZE, MIN_GUI_SIZE, WracGainGuiRuntime,
 };
 use wrac_clap_adapter::{
-    GuiConfig, GuiSize, HostGuiResizeRequester, HostParamsEditNotifier, PluginResult,
+    GuiConfig, GuiSize, HostContext, HostGuiResizeRequester, HostParamsEditNotifier, PluginResult,
 };
 use wrac_wxp_gui::{
     GuiSizeLimits, ParentWindowHandle, WxpGuiController, WxpGuiFactory, WxpGuiResizeHandle,
@@ -68,6 +68,7 @@ pub(crate) fn create_gui_integration(
     shared: Arc<SharedState>,
     host_parameter_edit_notifier: Arc<dyn HostParamsEditNotifier>,
     host_gui_resize_requester: Arc<dyn HostGuiResizeRequester>,
+    host_context: HostContext,
 ) -> GuiIntegration {
     let notifier = Arc::new(GuiStateNotifier::new());
     let resize_handle = WxpGuiResizeHandle::new(
@@ -90,6 +91,7 @@ pub(crate) fn create_gui_integration(
             dependencies: runtime_dependencies,
         },
         resize_handle,
+        host_context,
     ));
 
     GuiIntegration {

--- a/plugins/wrac-gain/src-plugin/src/plugin.rs
+++ b/plugins/wrac-gain/src-plugin/src/plugin.rs
@@ -150,6 +150,7 @@ impl WracGainPlugin {
             shared.clone(),
             context.host_parameter_edit_notifier,
             context.host_gui_resize_requester,
+            context.host_context,
         );
         let state_extension = Arc::new(WracGainStateExtension::new(
             project_state,


### PR DESCRIPTION
## Summary
- Add a shared host context crate for host family/version and wrapper format detection.
- Log detected host and wrapper format during plugin creation for release diagnostics.
- Apply Cubase VST3 GUI size resync and Windows DPI scale correction in the wxp GUI adapter.
- Reject invalid CLAP parameter IDs and VST3 reserved parameter ID ranges during parameter discovery.

## Validation
- cargo fmt --check
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo check -p wrac_wxp_gui --target x86_64-pc-windows-msvc