### PR TITLE
Fix LUNA VST3 automation edits

### DIFF
--- a/clap_wrapper_builder/clap-wrapper/src/clap_proxy.cpp
+++ b/clap_wrapper_builder/clap-wrapper/src/clap_proxy.cpp
@@ -15,6 +15,9 @@ namespace Clap
 {
 namespace HostExt
 {
+static constexpr const char *WRAC_CLAP_EXT_HOST_PARAMETER_EDIT =
+    "com.novonotes.wrac.host-parameter-edit/1";
+
 static Plugin *self(const clap_host_t *host)
 {
   return static_cast<Plugin *>(host->host_data);
@@ -53,6 +56,28 @@ void request_flush(const clap_host_t *host)
   self(host)->param_request_flush();
 }
 clap_host_params_t params = {rescan, clear, request_flush};
+
+struct wrac_clap_host_parameter_edit
+{
+  bool (*begin_edit)(const clap_host_t *host, clap_id param_id);
+  bool (*update_edit)(const clap_host_t *host, clap_id param_id, double value);
+  bool (*end_edit)(const clap_host_t *host, clap_id param_id);
+};
+
+// Private WRAC extension used by the Rust adapter to route UI-originated edit
+// gestures directly to wrapper-specific host APIs. Native CLAP still uses the
+// standard params event path; this exists so VST3 compatibility fixes do not
+// leak into the plugin-facing parameter API.
+wrac_clap_host_parameter_edit wrac_parameter_edit = {
+    [](const clap_host_t *host, clap_id param_id) -> bool {
+      return self(host)->wrac_param_begin_edit(param_id);
+    },
+    [](const clap_host_t *host, clap_id param_id, double value) -> bool {
+      return self(host)->wrac_param_update_edit(param_id, value);
+    },
+    [](const clap_host_t *host, clap_id param_id) -> bool {
+      return self(host)->wrac_param_end_edit(param_id);
+    }};
 
 bool is_main_thread(const clap_host_t *host)
 {
@@ -522,10 +547,27 @@ void Plugin::param_request_flush()
   _parentHost->param_request_flush();
 }
 
+bool Plugin::wrac_param_begin_edit(clap_id param)
+{
+  return _parentHost->wrac_param_begin_edit(param);
+}
+
+bool Plugin::wrac_param_update_edit(clap_id param, double value)
+{
+  return _parentHost->wrac_param_update_edit(param, value);
+}
+
+bool Plugin::wrac_param_end_edit(clap_id param)
+{
+  return _parentHost->wrac_param_end_edit(param);
+}
+
 // Query an extension.
 // [thread-safe]
 const void *Plugin::clapExtension(const clap_host * /*host*/, const char *extension)
 {
+  if (!strcmp(extension, HostExt::WRAC_CLAP_EXT_HOST_PARAMETER_EDIT))
+    return &HostExt::wrac_parameter_edit;
   if (!strcmp(extension, CLAP_EXT_LOG)) return &HostExt::log;
   if (!strcmp(extension, CLAP_EXT_PARAMS)) return &HostExt::params;
   if (!strcmp(extension, CLAP_EXT_TRACK_INFO)) return &HostExt::trackinfo;

--- a/clap_wrapper_builder/clap-wrapper/src/clap_proxy.h
+++ b/clap_wrapper_builder/clap-wrapper/src/clap_proxy.h
@@ -58,6 +58,9 @@ class IHost
   virtual void param_rescan(clap_param_rescan_flags flags) = 0;  // ext_host_params
   virtual void param_clear(clap_id param, clap_param_clear_flags flags) = 0;
   virtual void param_request_flush() = 0;
+  virtual bool wrac_param_begin_edit(clap_id param) { return false; }
+  virtual bool wrac_param_update_edit(clap_id param, double value) { return false; }
+  virtual bool wrac_param_end_edit(clap_id param) { return false; }
 
   virtual void latency_changed() = 0;
   virtual void tail_changed() = 0;
@@ -200,6 +203,9 @@ class Plugin
   void param_rescan(clap_param_rescan_flags flags);
   void param_clear(clap_id param, clap_param_clear_flags flags);
   void param_request_flush();
+  bool wrac_param_begin_edit(clap_id param);
+  bool wrac_param_update_edit(clap_id param, double value);
+  bool wrac_param_end_edit(clap_id param);
 
   // state
   void mark_dirty();

--- a/clap_wrapper_builder/clap-wrapper/src/wrapasvst3.cpp
+++ b/clap_wrapper_builder/clap-wrapper/src/wrapasvst3.cpp
@@ -22,6 +22,7 @@
 #include "detail/vst3/process.h"
 #include "detail/vst3/parameter.h"
 #include "detail/clap/fsutil.h"
+#include <cstdlib>
 #include <locale>
 #include <sstream>
 
@@ -1238,6 +1239,42 @@ void ClapAsVst3::param_request_flush()
   _requestedFlush = true;
 }
 
+bool ClapAsVst3::wrac_param_begin_edit(clap_id param)
+{
+  // The normal wrapper path queues CLAP parameter events and relies on
+  // request_flush()/onIdle(). LUNA 2.0.3.4381 VST3 does not write automation from
+  // that path, but it does write when UI gestures are forwarded as VST3 component
+  // handler edits. Keep this compatibility path host-specific so hosts that already
+  // handle the standard wrapper behavior keep their existing timing.
+  if (!shouldUseLunaVst3AutomationCompatMode() || !componentHandler) return false;
+
+  auto vst3id = param & 0x7FFFFFFF;
+  return beginEdit(vst3id) == kResultOk;
+}
+
+bool ClapAsVst3::wrac_param_update_edit(clap_id param, double value)
+{
+  if (!shouldUseLunaVst3AutomationCompatMode() || !componentHandler) return false;
+
+  auto *vst3param = (Vst3Parameter *)(parameters.getParameter(param & 0x7FFFFFFF));
+  if (!vst3param) return false;
+
+  auto vst3id = vst3param->getInfo().id;
+  auto vst3value = vst3param->asVst3Value(value);
+  // performEdit is the automation-writing notification. setParamNormalized is
+  // intentionally not called here: LUNA writes correctly without it, and the plugin
+  // state has already been updated by the UI-side parameter edit.
+  return performEdit(vst3id, vst3value) == kResultOk;
+}
+
+bool ClapAsVst3::wrac_param_end_edit(clap_id param)
+{
+  if (!shouldUseLunaVst3AutomationCompatMode() || !componentHandler) return false;
+
+  auto vst3id = param & 0x7FFFFFFF;
+  return endEdit(vst3id) == kResultOk;
+}
+
 bool ClapAsVst3::gui_can_resize()
 {
   // the plugin asks if the host can do a resize
@@ -1400,6 +1437,20 @@ const char *ClapAsVst3::host_get_name()
     }
   }
   return wrapper_hostname.c_str();
+}
+
+bool ClapAsVst3::shouldUseLunaVst3AutomationCompatMode()
+{
+  // Prefer the VST3 host name, but LUNA's process name is a useful fallback while
+  // the wrapper host name is still unavailable or normalized differently by the host.
+  const auto *hostName = host_get_name();
+#if MAC
+  const auto *processName = getprogname();
+#else
+  const char *processName = nullptr;
+#endif
+  return (hostName && std::string(hostName).find("LUNA") != std::string::npos) ||
+         (processName && std::string(processName).find("LUNA") != std::string::npos);
 }
 
 void ClapAsVst3::onIdle()

--- a/clap_wrapper_builder/clap-wrapper/src/wrapasvst3.h
+++ b/clap_wrapper_builder/clap-wrapper/src/wrapasvst3.h
@@ -324,6 +324,9 @@ class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect,
   void param_rescan(clap_param_rescan_flags flags) override;
   void param_clear(clap_id param, clap_param_clear_flags flags) override;
   void param_request_flush() override;
+  bool wrac_param_begin_edit(clap_id param) override;
+  bool wrac_param_update_edit(clap_id param, double value) override;
+  bool wrac_param_end_edit(clap_id param) override;
 
   bool gui_can_resize() override;
   bool gui_request_resize(uint32_t width, uint32_t height) override;
@@ -369,6 +372,7 @@ class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect,
 
  private:
   std::vector<clap_id> _gesturedparameters;
+  bool shouldUseLunaVst3AutomationCompatMode();
   // from Clap::IAutomation
   void onBeginEdit(clap_id id) override;
   void onPerformEdit(const clap_event_param_value_t *value) override;

--- a/crates/wrac_clap_adapter/src/params.rs
+++ b/crates/wrac_clap_adapter/src/params.rs
@@ -1,4 +1,4 @@
-use std::collections::VecDeque;
+use std::{collections::VecDeque, ffi::c_char};
 
 use clap_sys::ext::params::{CLAP_EXT_PARAMS, CLAP_PARAM_RESCAN_VALUES, clap_host_params};
 use clap_sys::host::clap_host;
@@ -68,6 +68,15 @@ impl ParameterEditQueue {
     }
 
     fn push(&self, event: ParameterEditEvent) {
+        // VST3 hosts expect UI-originated automation gestures through component-handler
+        // edit callbacks. The private wrapper extension lets adapters provide that path
+        // without changing the plugin-facing parameter API or the native CLAP event path.
+        if let Some(direct_edit) = self.host_params.and_then(|params| params.direct_edit)
+            && direct_edit.try_push(event)
+        {
+            return;
+        }
+
         self.pending.lock().push_back(event);
         // Issue request_flush after enqueuing. Some hosts will not call `flush()`
         // without this notification, causing UI edits to never reach the automation lane.
@@ -159,14 +168,50 @@ struct HostParams {
     host: *const clap_host,
     rescan: Option<unsafe extern "C" fn(host: *const clap_host, flags: u32)>,
     request_flush: Option<unsafe extern "C" fn(host: *const clap_host)>,
+    direct_edit: Option<HostDirectParameterEdit>,
 }
 
 // The instance lifetime of the host pointer is the minimal unavoidable assumption of the
-// CLAP ABI. Product-facing usage is limited to `request_flush()`; adapter-internal
-// `rescan_values()` is called only after state load, where CLAP gives the callback a
-// main-thread contract.
+// CLAP ABI. These callbacks are used from non-audio UI/control paths; realtime automation
+// continues to use CLAP input/output events in `process()`.
 unsafe impl Send for HostParams {}
 unsafe impl Sync for HostParams {}
+
+#[derive(Clone, Copy)]
+struct HostDirectParameterEdit {
+    host: *const clap_host,
+    begin_edit: unsafe extern "C" fn(host: *const clap_host, param_id: u32) -> bool,
+    update_edit: unsafe extern "C" fn(host: *const clap_host, param_id: u32, value: f64) -> bool,
+    end_edit: unsafe extern "C" fn(host: *const clap_host, param_id: u32) -> bool,
+}
+
+unsafe impl Send for HostDirectParameterEdit {}
+unsafe impl Sync for HostDirectParameterEdit {}
+
+impl HostDirectParameterEdit {
+    fn try_push(self, event: ParameterEditEvent) -> bool {
+        unsafe {
+            match event {
+                ParameterEditEvent::Begin { param_id } => (self.begin_edit)(self.host, param_id),
+                ParameterEditEvent::Update { param_id, value } => {
+                    (self.update_edit)(self.host, param_id, value)
+                }
+                ParameterEditEvent::End { param_id } => (self.end_edit)(self.host, param_id),
+            }
+        }
+    }
+}
+
+#[repr(C)]
+struct WracClapHostParameterEdit {
+    begin_edit: Option<unsafe extern "C" fn(host: *const clap_host, param_id: u32) -> bool>,
+    update_edit:
+        Option<unsafe extern "C" fn(host: *const clap_host, param_id: u32, value: f64) -> bool>,
+    end_edit: Option<unsafe extern "C" fn(host: *const clap_host, param_id: u32) -> bool>,
+}
+
+const WRAC_CLAP_EXT_HOST_PARAMETER_EDIT: *const c_char =
+    c"com.novonotes.wrac.host-parameter-edit/1".as_ptr();
 
 fn host_params(host: *const clap_host) -> Option<HostParams> {
     if host.is_null() {
@@ -179,10 +224,32 @@ fn host_params(host: *const clap_host) -> Option<HostParams> {
         if params.is_null() {
             return None;
         }
+        let direct_edit = host_direct_parameter_edit(
+            host,
+            get_extension(host, WRAC_CLAP_EXT_HOST_PARAMETER_EDIT),
+        );
         Some(HostParams {
             host,
             rescan: (*params).rescan,
             request_flush: (*params).request_flush,
+            direct_edit,
         })
     }
+}
+
+unsafe fn host_direct_parameter_edit(
+    host: *const clap_host,
+    extension: *const std::ffi::c_void,
+) -> Option<HostDirectParameterEdit> {
+    if extension.is_null() {
+        return None;
+    }
+
+    let direct = extension as *const WracClapHostParameterEdit;
+    Some(HostDirectParameterEdit {
+        host,
+        begin_edit: unsafe { (*direct).begin_edit? },
+        update_edit: unsafe { (*direct).update_edit? },
+        end_edit: unsafe { (*direct).end_edit? },
+    })
 }

--- a/plugins/wrac-gain/src-gui/src/main.ts
+++ b/plugins/wrac-gain/src-gui/src/main.ts
@@ -47,7 +47,7 @@ type SubscribeParametersResponse = {
   subscriptionId: number;
 };
 
-// Keep these ids in sync with PARAM_* constants in src-plugin/src/plugin.rs.
+// Keep these ids in sync with PARAM_* constants in src-plugin/src/plugin/params.rs.
 // When adding parameters to the template, add one id here and route its UI in render().
 const PARAM_GAIN_ID = 1;
 

--- a/plugins/wrac-gain/src-plugin/src/plugin/params.rs
+++ b/plugins/wrac-gain/src-plugin/src/plugin/params.rs
@@ -9,8 +9,13 @@ use crate::state::SharedState;
 // Parameter IDs are stable values used by the host for automation and project saving.
 // Never change them after publishing. To add a new parameter: append an ID here and
 // keep the `PluginParamsExtension` impl and `SharedState` match arms in sync.
+// Work around a LUNA 2.0.3.4381 VST3 automation writing bug: LUNA requires a
+// parameter's VST3 ParamID to match its parameter-list index, even though VST3
+// does not require this.
+// Keep this starter template dense from the beginning so new projects do not inherit
+// sparse IDs that cannot be changed later without breaking saved automation.
+pub(crate) const PARAM_BYPASS_ID: u32 = 0;
 pub(crate) const PARAM_GAIN_ID: u32 = 1;
-pub(crate) const PARAM_BYPASS_ID: u32 = 9;
 
 // Gain is a linear amplitude. 1.0 = 0 dB (unity), 0.0 = silence, 2.0 = +6 dB.
 pub(crate) const DEFAULT_GAIN: f32 = 1.0;
@@ -42,8 +47,8 @@ impl PluginParamsExtension for WracGainParamsExtension {
     fn param_info(&self, index: u32) -> Option<ParamInfo> {
         // Mapping of sequential index to stable ID. IDs persist in project/automation data — never change them.
         match index {
-            0 => Some(gain_param_info()),
-            1 => Some(bypass_param_info()),
+            0 => Some(bypass_param_info()),
+            1 => Some(gain_param_info()),
             _ => None,
         }
     }


### PR DESCRIPTION
## Summary

- add a private WRAC host extension so the Rust adapter can route UI parameter gestures directly to wrapper-specific host edit APIs
- forward LUNA VST3 UI edits to `IComponentHandler::beginEdit`, `performEdit`, and `endEdit` while leaving other hosts on the existing CLAP event path
- make the WRAC Gain starter template use parameter IDs that match the parameter-list indices to avoid LUNA 2.0.3.4381 VST3 automation write failures

## Investigation notes

LUNA 2.0.3.4381 VST3 did not write automation from the existing CLAP-wrapper `request_flush()` / queued parameter event path. AU worked, and the issue was not reproduced in Cubase, Studio One, or Ableton Live VST3.

Manual testing showed that LUNA writes automation when UI-originated gestures are forwarded as VST3 component-handler edits. `performEdit` is sufficient for value updates; `setParamNormalized` was tested and is not required.

LUNA VST3 also appears to require `VST3 ParamID == parameter-list index` for automation writing. With Bypass at index/id 0 and Gain at index/id 1, automation writing works in a new LUNA project.

## Validation

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo xtask install -p wrac_gain_plugin --target=vst3`
- Manual LUNA VST3 automation write check with `performEdit` only
