### PR TITLE
Use dense starter parameter IDs

### DIFF
--- a/plugins/wrac-gain/src-plugin/src/plugin.rs
+++ b/plugins/wrac-gain/src-plugin/src/plugin.rs
@@ -180,7 +180,7 @@ pub(crate) fn create_plugin_core(context: PluginCoreContext) -> Box<dyn PluginCo
         PLUGIN_DESCRIPTOR.id,
         PLUGIN_DESCRIPTOR.name
     );
-    for parameter in [gain_param_info(), bypass_param_info()] {
+    for parameter in [bypass_param_info(), gain_param_info()] {
         log::debug!(
             "host parameter schema: id={}, name={}, min={}, max={}, default={}, automatable={}, stepped={}, enum={}, bypass={}",
             parameter.id,

--- a/plugins/wrac-gain/src-plugin/src/plugin/params.rs
+++ b/plugins/wrac-gain/src-plugin/src/plugin/params.rs
@@ -7,10 +7,11 @@ use wrac_clap_adapter::{
 use crate::state::SharedState;
 
 // Parameter IDs are stable values used by the host for automation and project saving.
-// Never change them after publishing. To add a new parameter: append an ID here and
-// keep the `PluginParamsExtension` impl and `SharedState` match arms in sync.
+// Never change them after publishing. This starter template keeps initial IDs equal
+// to parameter-list indices because LUNA 2.0.3.4381 VST3 automation writes fail
+// when the automated parameter's ParamID differs from its index.
+pub(crate) const PARAM_BYPASS_ID: u32 = 0;
 pub(crate) const PARAM_GAIN_ID: u32 = 1;
-pub(crate) const PARAM_BYPASS_ID: u32 = 9;
 
 // Gain is a linear amplitude. 1.0 = 0 dB (unity), 0.0 = silence, 2.0 = +6 dB.
 pub(crate) const DEFAULT_GAIN: f32 = 1.0;
@@ -40,10 +41,9 @@ impl PluginParamsExtension for WracGainParamsExtension {
     }
 
     fn param_info(&self, index: u32) -> Option<ParamInfo> {
-        // Mapping of sequential index to stable ID. IDs persist in project/automation data — never change them.
         match index {
-            0 => Some(gain_param_info()),
-            1 => Some(bypass_param_info()),
+            0 => Some(bypass_param_info()),
+            1 => Some(gain_param_info()),
             _ => None,
         }
     }


### PR DESCRIPTION
## Summary

This updates the WRAC Gain starter template so its initial parameter IDs match the published parameter-list indices:

- Bypass: index/id 0
- Gain: index/id 1

LUNA 2.0.3.4381 VST3 automation writes fail when the automated parameter's VST3 ParamID differs from its parameter-list index. Since WRAC Gain is a starter template and not a published product with existing project compatibility constraints, using dense IDs is the safer default for new plugins.

No clap-wrapper automation scheduling changes are included in this PR.

## Verification

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo xtask install --target=vst3`
- `codesign --verify --deep --strict ~/Library/Audio/Plug-Ins/VST3/WRAC\ Gain.vst3`