### PR TITLE
Remove documentation links to user submissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,11 +123,6 @@ cargo xtask --help
 cargo xtask build --help
 ```
 
-## Built with WRAC
-
-Built a plugin with this template? Share it in the [Showcase Discussion](https://github.com/novonotes/wrac-plugin-template/discussions/43).
-Open-source, freeware, and commercial releases are all welcome.
-
 ## Reference
 
 For known DAW compatibility status, see the [DAW Compatibility Matrix](https://github.com/novonotes/wrac-plugin-template/wiki/DAW-Compatibility-Matrix).

--- a/README.md
+++ b/README.md
@@ -57,8 +57,6 @@ npm run dev
 
 Then launch your DAW and insert **WRAC Gain** (a plugin rescan may be required).
 
-If it works, a quick note at [DAW Compatibility Reports](https://github.com/novonotes/wrac-plugin-template/discussions/6) is a big help for the community!
-
 To build your own plugin based on this template, see [Setup](docs/setup.md).
 
 ## FAQ

--- a/README_JA.md
+++ b/README_JA.md
@@ -120,11 +120,6 @@ cargo xtask --help
 cargo xtask build --help
 ```
 
-## Built with WRAC
-
-このテンプレートでプラグインを作ったら、ぜひ [Showcase Discussion](https://github.com/novonotes/wrac-plugin-template/discussions/43) で共有してください。
-オープンソース、フリーウェア、商用リリースのいずれも歓迎です。
-
 ## 参考
 
 主要 DAW での動作確認状況は [Wiki](https://github.com/novonotes/wrac-plugin-template/wiki/DAW-Compatibility-Matrix) を参照してください。

--- a/README_JA.md
+++ b/README_JA.md
@@ -54,8 +54,6 @@ npm run dev
 
 その後、DAW を起動して **WRAC Gain** を挿入してください（プラグインの再スキャンが必要な場合があります）。
 
-動いたら [DAW互換性報告](https://github.com/novonotes/wrac-plugin-template/discussions/6) に一言いただけるとコミュニティにとって大変助かります！
-
 このテンプレートを元に自分のプラグインを作る場合は [Setup](docs/setup_JA.md) を参照してください。
 
 ## FAQ


### PR DESCRIPTION
## Summary
- Remove the Showcase Discussion prompt from README and README_JA
- Remove the DAW Compatibility Reports submission prompt
- Keep the DAW Compatibility Matrix wiki reference

## Verification
- Confirmed with rg that the removed submission links are no longer referenced