### PR TITLE
Support multi-product wrapper builds in xtask

### DIFF
--- a/clap_wrapper_builder/CMakeLists.txt
+++ b/clap_wrapper_builder/CMakeLists.txt
@@ -30,6 +30,20 @@ project(clap_wrapper_builder)
 #                                           (<name>.vst3/.component/.app/.exe).
 #                                           Leave empty to skip staging.
 #
+#   Multi-product metadata (optional)
+#     CLAP_WRAPPER_BUILDER_PRODUCT_COUNT    Number of CLAP plugin products in
+#                                           the wrapped static library. Default 1.
+#     CLAP_WRAPPER_BUILDER_PRODUCT_<N>_OUTPUT_NAME
+#                                           Product output name. Single-product
+#                                           builds default to OUTPUT_NAME.
+#     CLAP_WRAPPER_BUILDER_PRODUCT_<N>_PLUGIN_ID
+#                                           CLAP plugin ID for standalone launch.
+#     CLAP_WRAPPER_BUILDER_PRODUCT_<N>_AUV2_TYPE
+#     CLAP_WRAPPER_BUILDER_PRODUCT_<N>_AUV2_SUBTYPE
+#                                           Product AUv2 type/subtype codes.
+#     CLAP_WRAPPER_BUILDER_PRODUCT_<N>_STANDALONE_NAME
+#                                           Standalone app name for this product.
+#
 #   Format toggles
 #     CLAP_WRAPPER_BUILDER_BUILD_VST3        Default ON.
 #     CLAP_WRAPPER_BUILDER_BUILD_AUV2        Default ON on macOS, OFF elsewhere.
@@ -90,6 +104,7 @@ else()
 endif()
 set(CLAP_WRAPPER_BUILDER_STANDALONE_OUTPUT_NAME "" CACHE STRING "Output name for standalone app")
 set(CLAP_WRAPPER_BUILDER_STANDALONE_PLUGIN_ID "" CACHE STRING "Plugin ID used by standalone app")
+set(CLAP_WRAPPER_BUILDER_PRODUCT_COUNT "1" CACHE STRING "Number of plugin products exposed by the wrapped library")
 
 # Validate required parameters
 if(NOT CLAP_WRAPPER_BUILDER_TARGET_LIB)
@@ -118,6 +133,8 @@ message(STATUS "  Plugin Name: ${PLUGIN_NAME}")
 message(STATUS "  Safe Plugin Name: ${PLUGIN_NAME_SAFE}")
 message(STATUS "  Stage Dir: ${CLAP_WRAPPER_BUILDER_STAGE_DIR}")
 message(STATUS "  Build AAX: ${CLAP_WRAPPER_BUILDER_BUILD_AAX}")
+message(STATUS "  Product Count: ${CLAP_WRAPPER_BUILDER_PRODUCT_COUNT}")
+math(EXPR PRODUCT_LAST_INDEX "${CLAP_WRAPPER_BUILDER_PRODUCT_COUNT} - 1")
 
 # Add the clap-wrapper subproject
 add_subdirectory(clap-wrapper)
@@ -127,6 +144,35 @@ add_subdirectory(clap-wrapper)
 if(APPLE AND TARGET clap-wrapper-compile-options)
   target_compile_options(clap-wrapper-compile-options INTERFACE -Wno-shorten-64-to-32)
 endif()
+
+function(clap_wrapper_builder_product_value INDEX FIELD FALLBACK OUT_VAR)
+    set(var_name "CLAP_WRAPPER_BUILDER_PRODUCT_${INDEX}_${FIELD}")
+    if(DEFINED ${var_name} AND NOT "${${var_name}}" STREQUAL "")
+        set(${OUT_VAR} "${${var_name}}" PARENT_SCOPE)
+    else()
+        set(${OUT_VAR} "${FALLBACK}" PARENT_SCOPE)
+    endif()
+endfunction()
+
+function(clap_wrapper_builder_product_target_name INDEX OUTPUT_NAME OUT_VAR)
+    if(CLAP_WRAPPER_BUILDER_PRODUCT_COUNT EQUAL 1)
+        set(${OUT_VAR} "${PLUGIN_NAME_SAFE}" PARENT_SCOPE)
+    else()
+        string(MAKE_C_IDENTIFIER "${OUTPUT_NAME}" product_name_safe)
+        set(${OUT_VAR} "${PLUGIN_NAME_SAFE}_${INDEX}_${product_name_safe}" PARENT_SCOPE)
+    endif()
+endfunction()
+
+function(clap_wrapper_builder_standalone_target_name INDEX OUTPUT_NAME OUT_TARGET_VAR OUT_POSTFIX_VAR)
+    if(CLAP_WRAPPER_BUILDER_PRODUCT_COUNT EQUAL 1)
+        set(postfix "standalone")
+    else()
+        string(MAKE_C_IDENTIFIER "${OUTPUT_NAME}" product_name_safe)
+        set(postfix "${INDEX}_${product_name_safe}_standalone")
+    endif()
+    set(${OUT_POSTFIX_VAR} "${postfix}" PARENT_SCOPE)
+    set(${OUT_TARGET_VAR} "${PLUGIN_NAME_SAFE}_${postfix}" PARENT_SCOPE)
+endfunction()
 
 # Create the static library target
 # Set up the external static library as an imported library
@@ -178,13 +224,11 @@ extern \"C\" {
 #endif
 ")
 
-# Configure plugin formats to build
+# Configure bundle plugin formats to build. AUv2 is expanded per product below
+# because each AU component needs its own type/subtype discovery identity.
 set(PLUGIN_FORMATS "CLAP")
 if(CLAP_WRAPPER_BUILDER_BUILD_VST3)
     list(APPEND PLUGIN_FORMATS "VST3")
-endif()
-if(APPLE AND CLAP_WRAPPER_BUILDER_BUILD_AUV2)
-    list(APPEND PLUGIN_FORMATS "AUV2")
 endif()
 if(CLAP_WRAPPER_BUILDER_BUILD_AAX)
     list(APPEND PLUGIN_FORMATS "AAX")
@@ -210,24 +254,75 @@ set(CLAPFIRST_COMMON_ARGS
 )
 
 if(CLAP_WRAPPER_BUILDER_BUILD_STANDALONE)
-    if(NOT CLAP_WRAPPER_BUILDER_STANDALONE_PLUGIN_ID)
-        message(FATAL_ERROR "CLAP_WRAPPER_BUILDER_STANDALONE_PLUGIN_ID must be specified when CLAP_WRAPPER_BUILDER_BUILD_STANDALONE=ON")
-    endif()
-
-    if(NOT CLAP_WRAPPER_BUILDER_STANDALONE_OUTPUT_NAME)
-        set(CLAP_WRAPPER_BUILDER_STANDALONE_OUTPUT_NAME "${PLUGIN_NAME} Standalone")
-    endif()
-
     message(STATUS "  Standalone Enabled: ON")
-    message(STATUS "  Standalone Output Name: ${CLAP_WRAPPER_BUILDER_STANDALONE_OUTPUT_NAME}")
-    message(STATUS "  Standalone Plugin ID: ${CLAP_WRAPPER_BUILDER_STANDALONE_PLUGIN_ID}")
+    set(STANDALONE_CONFIGURATIONS)
+    foreach(PRODUCT_INDEX RANGE 0 ${PRODUCT_LAST_INDEX})
+        clap_wrapper_builder_product_value(${PRODUCT_INDEX} "OUTPUT_NAME" "${PLUGIN_NAME}" PRODUCT_OUTPUT_NAME)
+        if(PRODUCT_INDEX EQUAL 0 AND CLAP_WRAPPER_BUILDER_STANDALONE_OUTPUT_NAME)
+            set(default_standalone_name "${CLAP_WRAPPER_BUILDER_STANDALONE_OUTPUT_NAME}")
+        else()
+            set(default_standalone_name "${PRODUCT_OUTPUT_NAME} Standalone")
+        endif()
+        if(PRODUCT_INDEX EQUAL 0 AND CLAP_WRAPPER_BUILDER_STANDALONE_PLUGIN_ID)
+            set(default_plugin_id "${CLAP_WRAPPER_BUILDER_STANDALONE_PLUGIN_ID}")
+        else()
+            set(default_plugin_id "")
+        endif()
+        clap_wrapper_builder_product_value(${PRODUCT_INDEX} "STANDALONE_NAME" "${default_standalone_name}" PRODUCT_STANDALONE_NAME)
+        clap_wrapper_builder_product_value(${PRODUCT_INDEX} "PLUGIN_ID" "${default_plugin_id}" PRODUCT_PLUGIN_ID)
+        if(NOT PRODUCT_PLUGIN_ID)
+            message(FATAL_ERROR "CLAP_WRAPPER_BUILDER_PRODUCT_${PRODUCT_INDEX}_PLUGIN_ID must be specified when CLAP_WRAPPER_BUILDER_BUILD_STANDALONE=ON")
+        endif()
+        clap_wrapper_builder_standalone_target_name(${PRODUCT_INDEX} "${PRODUCT_OUTPUT_NAME}" STANDALONE_TARGET STANDALONE_POSTFIX)
+        list(APPEND STANDALONE_CONFIGURATIONS "${STANDALONE_POSTFIX}" "${PRODUCT_STANDALONE_NAME}" "${PRODUCT_PLUGIN_ID}")
+        message(STATUS "  Standalone Product: ${PRODUCT_STANDALONE_NAME} -> ${PRODUCT_PLUGIN_ID}")
+    endforeach()
 
     make_clapfirst_plugins(
         ${CLAPFIRST_COMMON_ARGS}
-        STANDALONE_CONFIGURATIONS standalone "${CLAP_WRAPPER_BUILDER_STANDALONE_OUTPUT_NAME}" "${CLAP_WRAPPER_BUILDER_STANDALONE_PLUGIN_ID}"
+        STANDALONE_CONFIGURATIONS ${STANDALONE_CONFIGURATIONS}
     )
 else()
     make_clapfirst_plugins(${CLAPFIRST_COMMON_ARGS})
+endif()
+
+set(AUV2_PRODUCT_TARGETS)
+if(APPLE AND CLAP_WRAPPER_BUILDER_BUILD_AUV2)
+    foreach(PRODUCT_INDEX RANGE 0 ${PRODUCT_LAST_INDEX})
+        clap_wrapper_builder_product_value(${PRODUCT_INDEX} "OUTPUT_NAME" "${PLUGIN_NAME}" PRODUCT_OUTPUT_NAME)
+        if(PRODUCT_INDEX EQUAL 0)
+            set(default_auv2_type "${CLAP_WRAPPER_AUV2_INSTRUMENT_TYPE}")
+            set(default_auv2_subtype "${CLAP_WRAPPER_AUV2_SUBTYPE_CODE}")
+        else()
+            set(default_auv2_type "")
+            set(default_auv2_subtype "")
+        endif()
+        clap_wrapper_builder_product_value(${PRODUCT_INDEX} "AUV2_TYPE" "${default_auv2_type}" PRODUCT_AUV2_TYPE)
+        clap_wrapper_builder_product_value(${PRODUCT_INDEX} "AUV2_SUBTYPE" "${default_auv2_subtype}" PRODUCT_AUV2_SUBTYPE)
+        if(NOT PRODUCT_AUV2_TYPE)
+            message(FATAL_ERROR "CLAP_WRAPPER_BUILDER_PRODUCT_${PRODUCT_INDEX}_AUV2_TYPE must be specified when CLAP_WRAPPER_BUILDER_BUILD_AUV2=ON")
+        endif()
+        if(NOT PRODUCT_AUV2_SUBTYPE)
+            message(FATAL_ERROR "CLAP_WRAPPER_BUILDER_PRODUCT_${PRODUCT_INDEX}_AUV2_SUBTYPE must be specified when CLAP_WRAPPER_BUILDER_BUILD_AUV2=ON")
+        endif()
+        clap_wrapper_builder_product_target_name(${PRODUCT_INDEX} "${PRODUCT_OUTPUT_NAME}" PRODUCT_TARGET_NAME)
+        set(AUV2_TARGET "${PRODUCT_TARGET_NAME}_auv2")
+        add_library(${AUV2_TARGET} MODULE)
+        target_sources(${AUV2_TARGET} PRIVATE ${ENTRY_SOURCE_FILE})
+        target_link_libraries(${AUV2_TARGET} PRIVATE ${PLUGIN_NAME_SAFE}_impl)
+        target_add_auv2_wrapper(
+            TARGET ${AUV2_TARGET}
+            OUTPUT_NAME "${PRODUCT_OUTPUT_NAME}"
+            BUNDLE_IDENTIFIER "${BUNDLE_ID}.${PRODUCT_TARGET_NAME}.auv2"
+            BUNDLE_VERSION "${BUNDLE_VERSION}"
+            MANUFACTURER_NAME "${CLAP_WRAPPER_AUV2_MANUFACTURER_NAME}"
+            MANUFACTURER_CODE "${CLAP_WRAPPER_AUV2_MANUFACTURER_CODE}"
+            SUBTYPE_CODE "${PRODUCT_AUV2_SUBTYPE}"
+            INSTRUMENT_TYPE "${PRODUCT_AUV2_TYPE}"
+            PREFER_CMAKE_AUV2_CONFIGURATION TRUE
+        )
+        list(APPEND AUV2_PRODUCT_TARGETS "${AUV2_TARGET}")
+    endforeach()
 endif()
 
 if(APPLE)
@@ -251,12 +346,19 @@ if(APPLE)
         )
     endif()
 
-    if(TARGET ${PLUGIN_NAME_SAFE}_auv2)
-        set_target_properties(${PLUGIN_NAME_SAFE}_auv2 PROPERTIES
-            MACOSX_BUNDLE_GUI_IDENTIFIER "${AUV2_BUNDLE_ID}"
-            XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "${AUV2_BUNDLE_ID}"
+    foreach(AUV2_TARGET IN LISTS AUV2_PRODUCT_TARGETS)
+        get_target_property(AUV2_PRODUCT_NAME ${AUV2_TARGET} MACOSX_BUNDLE_BUNDLE_NAME)
+        string(MAKE_C_IDENTIFIER "${AUV2_PRODUCT_NAME}" AUV2_PRODUCT_ID)
+        if(CLAP_WRAPPER_BUILDER_PRODUCT_COUNT EQUAL 1)
+            set(AUV2_PRODUCT_BUNDLE_ID "${AUV2_BUNDLE_ID}")
+        else()
+            set(AUV2_PRODUCT_BUNDLE_ID "${BUNDLE_ID}.${AUV2_PRODUCT_ID}.auv2")
+        endif()
+        set_target_properties(${AUV2_TARGET} PROPERTIES
+            MACOSX_BUNDLE_GUI_IDENTIFIER "${AUV2_PRODUCT_BUNDLE_ID}"
+            XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "${AUV2_PRODUCT_BUNDLE_ID}"
         )
-    endif()
+    endforeach()
 
     if(TARGET ${PLUGIN_NAME_SAFE}_standalone)
         # The standalone app has its own Info.plist template, so set the bundle version
@@ -269,12 +371,38 @@ if(APPLE)
             MACOSX_BUNDLE_INFO_PLIST "${STANDALONE_INFO_PLIST}"
         )
     endif()
+    if(NOT CLAP_WRAPPER_BUILDER_PRODUCT_COUNT EQUAL 1)
+        foreach(PRODUCT_INDEX RANGE 0 ${PRODUCT_LAST_INDEX})
+            clap_wrapper_builder_product_value(${PRODUCT_INDEX} "OUTPUT_NAME" "${PLUGIN_NAME}" PRODUCT_OUTPUT_NAME)
+            clap_wrapper_builder_standalone_target_name(${PRODUCT_INDEX} "${PRODUCT_OUTPUT_NAME}" STANDALONE_TARGET STANDALONE_POSTFIX)
+            if(TARGET ${STANDALONE_TARGET})
+                get_target_property(STANDALONE_PRODUCT_NAME ${STANDALONE_TARGET} MACOSX_BUNDLE_BUNDLE_NAME)
+                string(MAKE_C_IDENTIFIER "${STANDALONE_PRODUCT_NAME}" STANDALONE_PRODUCT_ID)
+                set_target_properties(${STANDALONE_TARGET} PROPERTIES
+                    MACOSX_BUNDLE_GUI_IDENTIFIER "${BUNDLE_ID}.${STANDALONE_PRODUCT_ID}.standalone"
+                    XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "${BUNDLE_ID}.${STANDALONE_PRODUCT_ID}.standalone"
+                    MACOSX_BUNDLE_SHORT_VERSION_STRING "${BUNDLE_VERSION}"
+                    MACOSX_BUNDLE_BUNDLE_VERSION "${BUNDLE_VERSION}"
+                    MACOSX_BUNDLE_INFO_PLIST "${STANDALONE_INFO_PLIST}"
+                )
+            endif()
+        endforeach()
+    endif()
 endif()
 
 # The standalone exe links the impl lib directly rather than through the
 # wrapper, so it needs runtimeobject.lib stated again on its own link line.
 if(MSVC AND TARGET ${PLUGIN_NAME_SAFE}_standalone)
     target_link_libraries(${PLUGIN_NAME_SAFE}_standalone PRIVATE runtimeobject.lib)
+endif()
+if(MSVC)
+    foreach(PRODUCT_INDEX RANGE 0 ${PRODUCT_LAST_INDEX})
+        clap_wrapper_builder_product_value(${PRODUCT_INDEX} "OUTPUT_NAME" "${PLUGIN_NAME}" PRODUCT_OUTPUT_NAME)
+        clap_wrapper_builder_standalone_target_name(${PRODUCT_INDEX} "${PRODUCT_OUTPUT_NAME}" STANDALONE_TARGET STANDALONE_POSTFIX)
+        if(TARGET ${STANDALONE_TARGET})
+            target_link_libraries(${STANDALONE_TARGET} PRIVATE runtimeobject.lib)
+        endif()
+    endforeach()
 endif()
 
 # Only the CLAP target compiles the generated entry shim, which includes
@@ -311,35 +439,41 @@ if(CLAP_WRAPPER_BUILDER_STAGE_DIR)
         endif()
     endif()
 
-    if(APPLE AND TARGET ${PLUGIN_NAME_SAFE}_auv2)
-        set(AUV2_GENERATED_PLIST "${CMAKE_CURRENT_BINARY_DIR}/${PLUGIN_NAME_SAFE}_auv2-build-helper-output/auv2_Info.plist")
+    foreach(AUV2_TARGET IN LISTS AUV2_PRODUCT_TARGETS)
+        get_target_property(AUV2_PRODUCT_NAME ${AUV2_TARGET} MACOSX_BUNDLE_BUNDLE_NAME)
+        set(AUV2_GENERATED_PLIST "${CMAKE_CURRENT_BINARY_DIR}/${AUV2_TARGET}-build-helper-output/auv2_Info.plist")
         # clap-wrapper's AUv2 helper generates the AudioComponents metadata that
         # auval needs; copy it back before staging/signing the component bundle.
-        add_custom_command(TARGET ${PLUGIN_NAME_SAFE}_auv2 POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy_if_different "${AUV2_GENERATED_PLIST}" "$<TARGET_BUNDLE_DIR:${PLUGIN_NAME_SAFE}_auv2>/Contents/Info.plist"
-            COMMAND ${CMAKE_COMMAND} -E rm -rf "${CLAP_WRAPPER_BUILDER_STAGE_DIR}/${PLUGIN_NAME}.component"
-            COMMAND ${CMAKE_COMMAND} -E copy_directory "$<TARGET_BUNDLE_DIR:${PLUGIN_NAME_SAFE}_auv2>" "${CLAP_WRAPPER_BUILDER_STAGE_DIR}/${PLUGIN_NAME}.component"
+        add_custom_command(TARGET ${AUV2_TARGET} POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different "${AUV2_GENERATED_PLIST}" "$<TARGET_BUNDLE_DIR:${AUV2_TARGET}>/Contents/Info.plist"
+            COMMAND ${CMAKE_COMMAND} -E rm -rf "${CLAP_WRAPPER_BUILDER_STAGE_DIR}/${AUV2_PRODUCT_NAME}.component"
+            COMMAND ${CMAKE_COMMAND} -E copy_directory "$<TARGET_BUNDLE_DIR:${AUV2_TARGET}>" "${CLAP_WRAPPER_BUILDER_STAGE_DIR}/${AUV2_PRODUCT_NAME}.component"
             VERBATIM
         )
-    endif()
+    endforeach()
 
-    if(TARGET ${PLUGIN_NAME_SAFE}_standalone)
-        if(APPLE)
-            add_custom_command(TARGET ${PLUGIN_NAME_SAFE}_standalone POST_BUILD
-                COMMAND ${CMAKE_COMMAND} -E rm -rf "${CLAP_WRAPPER_BUILDER_STAGE_DIR}/${CLAP_WRAPPER_BUILDER_STANDALONE_OUTPUT_NAME}.app"
-                COMMAND ${CMAKE_COMMAND} -E copy_directory "$<TARGET_BUNDLE_DIR:${PLUGIN_NAME_SAFE}_standalone>" "${CLAP_WRAPPER_BUILDER_STAGE_DIR}/${CLAP_WRAPPER_BUILDER_STANDALONE_OUTPUT_NAME}.app"
-                VERBATIM
-            )
-        elseif(WIN32)
-            add_custom_command(TARGET ${PLUGIN_NAME_SAFE}_standalone POST_BUILD
-                COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:${PLUGIN_NAME_SAFE}_standalone>" "${CLAP_WRAPPER_BUILDER_STAGE_DIR}/${CLAP_WRAPPER_BUILDER_STANDALONE_OUTPUT_NAME}.exe"
-                VERBATIM
-            )
-        else()
-            add_custom_command(TARGET ${PLUGIN_NAME_SAFE}_standalone POST_BUILD
-                COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:${PLUGIN_NAME_SAFE}_standalone>" "${CLAP_WRAPPER_BUILDER_STAGE_DIR}/${CLAP_WRAPPER_BUILDER_STANDALONE_OUTPUT_NAME}"
-                VERBATIM
-            )
+    foreach(PRODUCT_INDEX RANGE 0 ${PRODUCT_LAST_INDEX})
+        clap_wrapper_builder_product_value(${PRODUCT_INDEX} "OUTPUT_NAME" "${PLUGIN_NAME}" PRODUCT_OUTPUT_NAME)
+        clap_wrapper_builder_product_value(${PRODUCT_INDEX} "STANDALONE_NAME" "${PRODUCT_OUTPUT_NAME} Standalone" PRODUCT_STANDALONE_NAME)
+        clap_wrapper_builder_standalone_target_name(${PRODUCT_INDEX} "${PRODUCT_OUTPUT_NAME}" STANDALONE_TARGET STANDALONE_POSTFIX)
+        if(TARGET ${STANDALONE_TARGET})
+            if(APPLE)
+                add_custom_command(TARGET ${STANDALONE_TARGET} POST_BUILD
+                    COMMAND ${CMAKE_COMMAND} -E rm -rf "${CLAP_WRAPPER_BUILDER_STAGE_DIR}/${PRODUCT_STANDALONE_NAME}.app"
+                    COMMAND ${CMAKE_COMMAND} -E copy_directory "$<TARGET_BUNDLE_DIR:${STANDALONE_TARGET}>" "${CLAP_WRAPPER_BUILDER_STAGE_DIR}/${PRODUCT_STANDALONE_NAME}.app"
+                    VERBATIM
+                )
+            elseif(WIN32)
+                add_custom_command(TARGET ${STANDALONE_TARGET} POST_BUILD
+                    COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:${STANDALONE_TARGET}>" "${CLAP_WRAPPER_BUILDER_STAGE_DIR}/${PRODUCT_STANDALONE_NAME}.exe"
+                    VERBATIM
+                )
+            else()
+                add_custom_command(TARGET ${STANDALONE_TARGET} POST_BUILD
+                    COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:${STANDALONE_TARGET}>" "${CLAP_WRAPPER_BUILDER_STAGE_DIR}/${PRODUCT_STANDALONE_NAME}"
+                    VERBATIM
+                )
+            endif()
         endif()
-    endif()
+    endforeach()
 endif()

--- a/crates/wrac_xtask/src/commands.rs
+++ b/crates/wrac_xtask/src/commands.rs
@@ -273,6 +273,7 @@ fn build_wrapper_set(ctx: &Context, profile: BuildProfile, build: WrapperBuild) 
         .arg("-DCLAP_WRAPPER_BUILDER_BUILD_AAX=OFF")
         .arg("-DCLAP_WRAPPER_DOWNLOAD_DEPENDENCIES=OFF")
         .arg("-DCLAP_WRAPPER_CXX_STANDARD=23");
+    add_wrapper_product_args(ctx, &mut configure);
 
     match build {
         WrapperBuild::Plugin { vst3, au } => {
@@ -292,14 +293,6 @@ fn build_wrapper_set(ctx: &Context, profile: BuildProfile, build: WrapperBuild) 
                 .arg("-DCLAP_WRAPPER_BUILDER_BUILD_VST3=OFF")
                 .arg("-DCLAP_WRAPPER_BUILDER_BUILD_AUV2=OFF")
                 .arg("-DCLAP_WRAPPER_BUILDER_BUILD_STANDALONE=ON")
-                .arg(format!(
-                    "-DCLAP_WRAPPER_BUILDER_STANDALONE_PLUGIN_ID={}",
-                    ctx.metadata.primary_plugin().plugin_id
-                ))
-                .arg(format!(
-                    "-DCLAP_WRAPPER_BUILDER_STANDALONE_OUTPUT_NAME={}",
-                    ctx.metadata.standalone_name
-                ))
                 .arg("-DCLAP_WRAPPER_DOWNLOAD_DEPENDENCIES=ON");
         }
     }
@@ -313,20 +306,12 @@ fn build_wrapper_set(ctx: &Context, profile: BuildProfile, build: WrapperBuild) 
                 ctx.wrapper_dir.join("AudioUnitSDK").display()
             ))
             .arg(format!(
-                "-DCLAP_WRAPPER_AUV2_INSTRUMENT_TYPE={}",
-                ctx.metadata.primary_plugin().auv2_type
-            ))
-            .arg(format!(
                 "-DCLAP_WRAPPER_AUV2_MANUFACTURER_NAME={}",
                 ctx.metadata.company_name
             ))
             .arg(format!(
                 "-DCLAP_WRAPPER_AUV2_MANUFACTURER_CODE={}",
                 ctx.metadata.auv2_manufacturer_code
-            ))
-            .arg(format!(
-                "-DCLAP_WRAPPER_AUV2_SUBTYPE_CODE={}",
-                ctx.metadata.primary_plugin().auv2_subtype
             ));
     }
 
@@ -360,25 +345,63 @@ fn build_wrapper_set(ctx: &Context, profile: BuildProfile, build: WrapperBuild) 
                 ensure_exists(&ctx.vst3_bundle(profile), "VST3 artifact")?;
                 if ctx.platform == Platform::Macos {
                     // macOS hosts may reject unsigned bundles; apply an ad-hoc signature for development.
-                    codesign_nested_macos_bundle(ctx, &ctx.vst3_bundle(profile))?;
+                    codesign_nested_macos_bundle(&ctx.vst3_bundle(profile))?;
                 }
             }
             if au {
-                ensure_exists(&ctx.au_bundle(profile), "AU artifact")?;
-                // AU components are loaded via AudioComponentRegistrar, so they must be signed even for local builds.
-                codesign_nested_macos_bundle(ctx, &ctx.au_bundle(profile))?;
+                for au_bundle in ctx.au_bundles(profile) {
+                    ensure_exists(&au_bundle, "AU artifact")?;
+                    // AU components are loaded via AudioComponentRegistrar, so they must be signed even for local builds.
+                    codesign_nested_macos_bundle(&au_bundle)?;
+                }
             }
         }
         WrapperBuild::Standalone => {
-            ensure_exists(&ctx.standalone_artifact(profile), "standalone artifact")?;
-            if ctx.platform == Platform::Macos {
-                // Apply the same Gatekeeper/loader treatment to the standalone app as to plugin bundles.
-                codesign_nested_macos_bundle(ctx, &ctx.standalone_artifact(profile))?;
+            for artifact in ctx.standalone_artifacts(profile) {
+                ensure_exists(&artifact, "standalone artifact")?;
+                if ctx.platform == Platform::Macos {
+                    // Apply the same Gatekeeper/loader treatment to the standalone app as to plugin bundles.
+                    codesign_nested_macos_bundle(&artifact)?;
+                }
             }
         }
     }
 
     Ok(())
+}
+
+fn add_wrapper_product_args(ctx: &Context, command: &mut Command) {
+    command.arg(format!(
+        "-DCLAP_WRAPPER_BUILDER_PRODUCT_COUNT={}",
+        ctx.metadata.plugins.len()
+    ));
+    for (index, plugin) in ctx.metadata.plugins.iter().enumerate() {
+        command
+            .arg(format!(
+                "-DCLAP_WRAPPER_BUILDER_PRODUCT_{index}_PLUGIN_NAME={}",
+                plugin.plugin_name
+            ))
+            .arg(format!(
+                "-DCLAP_WRAPPER_BUILDER_PRODUCT_{index}_OUTPUT_NAME={}",
+                ctx.metadata.product_output_name(plugin)
+            ))
+            .arg(format!(
+                "-DCLAP_WRAPPER_BUILDER_PRODUCT_{index}_PLUGIN_ID={}",
+                plugin.plugin_id
+            ))
+            .arg(format!(
+                "-DCLAP_WRAPPER_BUILDER_PRODUCT_{index}_AUV2_TYPE={}",
+                plugin.auv2_type
+            ))
+            .arg(format!(
+                "-DCLAP_WRAPPER_BUILDER_PRODUCT_{index}_AUV2_SUBTYPE={}",
+                plugin.auv2_subtype
+            ))
+            .arg(format!(
+                "-DCLAP_WRAPPER_BUILDER_PRODUCT_{index}_STANDALONE_NAME={}",
+                ctx.metadata.product_standalone_name(plugin)
+            ));
+    }
 }
 
 pub(crate) fn install(
@@ -431,10 +454,12 @@ fn install_plugin_targets(
                 &ctx.vst3_bundle(profile),
                 &install_dir(ctx, scope, PluginFormat::Vst3)?,
             )?,
-            PluginTarget::Au => install_artifact(
-                &ctx.au_bundle(profile),
-                &install_dir(ctx, scope, PluginFormat::Au)?,
-            )?,
+            PluginTarget::Au => {
+                let install_dir = install_dir(ctx, scope, PluginFormat::Au)?;
+                for au_bundle in ctx.au_bundles(profile) {
+                    install_artifact(&au_bundle, &install_dir)?;
+                }
+            }
         }
     }
     Ok(())
@@ -561,18 +586,22 @@ fn installed_artifacts(
         PluginTarget::Vst3 => PluginFormat::Vst3,
         PluginTarget::Au => PluginFormat::Au,
     };
-    let bundle_name = match target {
-        PluginTarget::Clap => ctx.metadata.clap_bundle_name(),
-        PluginTarget::Vst3 => ctx.metadata.vst3_bundle_name(),
-        PluginTarget::Au => ctx.metadata.au_bundle_name(),
+    let bundle_names = match target {
+        PluginTarget::Clap => vec![ctx.metadata.clap_bundle_name()],
+        PluginTarget::Vst3 => vec![ctx.metadata.vst3_bundle_name()],
+        PluginTarget::Au => ctx
+            .metadata
+            .plugins
+            .iter()
+            .map(|plugin| ctx.metadata.product_au_bundle_name(plugin))
+            .collect(),
     };
-    uninstall_scopes(scope)
-        .iter()
-        .copied()
-        .map(|install_scope| {
-            install_dir(ctx, install_scope, format).map(|dir| dir.join(&bundle_name))
-        })
-        .collect::<Result<Vec<_>>>()
+    let mut artifacts = Vec::new();
+    for install_scope in uninstall_scopes(scope) {
+        let dir = install_dir(ctx, *install_scope, format)?;
+        artifacts.extend(bundle_names.iter().map(|bundle_name| dir.join(bundle_name)));
+    }
+    Ok(artifacts)
 }
 
 fn uninstall_scopes(scope: UninstallScope) -> &'static [InstallScope] {
@@ -628,14 +657,15 @@ fn validate_targets(
     }
 
     if targets.contains(&ValidateTarget::Au) {
-        let au = ctx.au_bundle(profile);
-        ensure_exists(&au, "AU artifact")?;
         ensure_no_system_au_conflict(ctx)?;
 
         // auval resolves its target via AudioComponentRegistrar rather than a direct path,
         // so the freshly built AU must be installed user-locally before running validation.
         let install_dir = install_dir(ctx, InstallScope::User, PluginFormat::Au)?;
-        install_artifact(&au, &install_dir)?;
+        for au in ctx.au_bundles(profile) {
+            ensure_exists(&au, "AU artifact")?;
+            install_artifact(&au, &install_dir)?;
+        }
 
         // The registrar caches component metadata, so it must be restarted to expose the newly placed AU.
         // If killall fails, auval may still detect the component, so treat this as best-effort.
@@ -728,14 +758,16 @@ fn clap_validator_executable(platform: Platform, validator_dir: &Path) -> PathBu
 }
 
 fn ensure_no_system_au_conflict(ctx: &Context) -> Result<()> {
-    let system_au =
-        Path::new("/Library/Audio/Plug-Ins/Components").join(ctx.metadata.au_bundle_name());
-    if system_au.exists() {
-        return Err(format!(
-            "system-wide AU already exists at {}. auval may validate that copy instead of the freshly built user-local AU. Remove the system-wide component and run validation again.",
-            system_au.display()
-        )
-        .into());
+    for plugin in &ctx.metadata.plugins {
+        let system_au = Path::new("/Library/Audio/Plug-Ins/Components")
+            .join(ctx.metadata.product_au_bundle_name(plugin));
+        if system_au.exists() {
+            return Err(format!(
+                "system-wide AU already exists at {}. auval may validate that copy instead of the freshly built user-local AU. Remove the system-wide component and run validation again.",
+                system_au.display()
+            )
+            .into());
+        }
     }
     Ok(())
 }
@@ -842,9 +874,15 @@ fn print_outputs(ctx: &Context, profile: BuildProfile, targets: &[Target]) {
         match target {
             Target::Clap => println!("CLAP: {}", ctx.clap_bundle(profile).display()),
             Target::Vst3 => println!("VST3: {}", ctx.vst3_bundle(profile).display()),
-            Target::Au => println!("AU: {}", ctx.au_bundle(profile).display()),
+            Target::Au => {
+                for au in ctx.au_bundles(profile) {
+                    println!("AU: {}", au.display());
+                }
+            }
             Target::Standalone => {
-                println!("Standalone: {}", ctx.standalone_artifact(profile).display())
+                for standalone in ctx.standalone_artifacts(profile) {
+                    println!("Standalone: {}", standalone.display());
+                }
             }
         }
     }
@@ -897,13 +935,18 @@ fn codesign(path: &Path) -> Result<()> {
     Ok(())
 }
 
-fn codesign_nested_macos_bundle(ctx: &Context, bundle: &Path) -> Result<()> {
-    let nested_clap = bundle
-        .join("Contents")
-        .join("PlugIns")
-        .join(ctx.metadata.clap_bundle_name());
-    if nested_clap.exists() {
-        codesign(&nested_clap)?;
+fn codesign_nested_macos_bundle(bundle: &Path) -> Result<()> {
+    let plugins_dir = bundle.join("Contents").join("PlugIns");
+    if plugins_dir.exists() {
+        for entry in fs::read_dir(&plugins_dir)? {
+            let path = entry?.path();
+            if path
+                .extension()
+                .is_some_and(|extension| extension == "clap")
+            {
+                codesign(&path)?;
+            }
+        }
     }
     codesign(bundle)?;
     Ok(())

--- a/crates/wrac_xtask/src/context.rs
+++ b/crates/wrac_xtask/src/context.rs
@@ -104,16 +104,39 @@ impl Context {
             .join(self.metadata.vst3_bundle_name())
     }
 
-    pub(crate) fn au_bundle(&self, profile: BuildProfile) -> PathBuf {
-        self.plugins_dir(profile)
-            .join(self.metadata.au_bundle_name())
+    pub(crate) fn au_bundles(&self, profile: BuildProfile) -> Vec<PathBuf> {
+        self.metadata
+            .plugins
+            .iter()
+            .map(|plugin| {
+                self.plugins_dir(profile)
+                    .join(self.metadata.product_au_bundle_name(plugin))
+            })
+            .collect()
     }
 
     pub(crate) fn standalone_artifact(&self, profile: BuildProfile) -> PathBuf {
+        self.product_standalone_artifact(profile, self.metadata.primary_plugin())
+    }
+
+    pub(crate) fn standalone_artifacts(&self, profile: BuildProfile) -> Vec<PathBuf> {
+        self.metadata
+            .plugins
+            .iter()
+            .map(|plugin| self.product_standalone_artifact(profile, plugin))
+            .collect()
+    }
+
+    fn product_standalone_artifact(
+        &self,
+        profile: BuildProfile,
+        plugin: &crate::metadata::PluginProductMetadata,
+    ) -> PathBuf {
+        let standalone_name = self.metadata.product_standalone_name(plugin);
         let filename = match self.platform {
-            Platform::Macos => format!("{}.app", self.metadata.standalone_name),
-            Platform::Windows => format!("{}.exe", self.metadata.standalone_name),
-            Platform::Linux => self.metadata.standalone_name.clone(),
+            Platform::Macos => format!("{standalone_name}.app"),
+            Platform::Windows => format!("{standalone_name}.exe"),
+            Platform::Linux => standalone_name,
         };
         self.standalone_dir(profile).join(filename)
     }

--- a/crates/wrac_xtask/src/metadata.rs
+++ b/crates/wrac_xtask/src/metadata.rs
@@ -71,8 +71,24 @@ impl PluginMetadata {
         format!("{}.vst3", self.bundle_name)
     }
 
-    pub(crate) fn au_bundle_name(&self) -> String {
-        format!("{}.component", self.bundle_name)
+    pub(crate) fn product_au_bundle_name(&self, plugin: &PluginProductMetadata) -> String {
+        format!("{}.component", self.product_output_name(plugin))
+    }
+
+    pub(crate) fn product_standalone_name(&self, plugin: &PluginProductMetadata) -> String {
+        if self.plugins.len() == 1 {
+            self.standalone_name.clone()
+        } else {
+            format!("{} Standalone", plugin.plugin_name)
+        }
+    }
+
+    pub(crate) fn product_output_name(&self, plugin: &PluginProductMetadata) -> String {
+        if self.plugins.len() == 1 {
+            self.bundle_name.clone()
+        } else {
+            plugin.plugin_name.clone()
+        }
     }
 
     pub(crate) fn primary_plugin(&self) -> &PluginProductMetadata {


### PR DESCRIPTION
## Summary
- Pass per-product plugin metadata from xtask to the wrapper builder
- Build, install, uninstall, validate, and print AUv2 / standalone artifacts per plugin product
- Keep existing single-product artifact names and CMake compatibility variables intact

## Verification
- cargo test -p wrac_xtask
- CMake configure smoke checks for multi-product standalone, multi-product AUv2, and single-product standalone compatibility