### PR TITLE
Implement single N-product wrapper pipeline

### DIFF
--- a/clap_wrapper_builder/CMakeLists.txt
+++ b/clap_wrapper_builder/CMakeLists.txt
@@ -26,23 +26,29 @@ project(clap_wrapper_builder)
 #     CLAP_WRAPPER_BUILDER_BUNDLE_VERSION   Version written into bundles.
 #                                           Default "1.0.0".
 #     CLAP_WRAPPER_BUILDER_STAGE_DIR        If set, finished artifacts are
-#                                           copied here under fixed names
-#                                           (<name>.vst3/.component/.app/.exe).
+#                                           copied here under fixed names.
 #                                           Leave empty to skip staging.
+#
+#   Products
+#     CLAP_WRAPPER_BUILDER_PRODUCT_COUNT    Number of plugin products exposed by
+#                                           the wrapped static library. Default 1.
+#     CLAP_WRAPPER_BUILDER_PRODUCT_<N>_OUTPUT_NAME
+#                                           Product name used for AUv2 output.
+#                                           Product 0 defaults to OUTPUT_NAME.
+#     CLAP_WRAPPER_BUILDER_PRODUCT_<N>_PLUGIN_ID
+#                                           CLAP plugin ID used by standalone.
+#     CLAP_WRAPPER_BUILDER_PRODUCT_<N>_STANDALONE_NAME
+#                                           Standalone app output name.
+#     CLAP_WRAPPER_BUILDER_PRODUCT_<N>_AUV2_TYPE
+#     CLAP_WRAPPER_BUILDER_PRODUCT_<N>_AUV2_SUBTYPE
+#                                           Product AUv2 type/subtype codes.
 #
 #   Format toggles
 #     CLAP_WRAPPER_BUILDER_BUILD_VST3        Default ON.
 #     CLAP_WRAPPER_BUILDER_BUILD_AUV2        Default ON on macOS, OFF elsewhere.
 #     CLAP_WRAPPER_BUILDER_BUILD_AAX         Default OFF. Requires the Avid AAX
 #                                            SDK; only meaningful on macOS/Win.
-#     CLAP_WRAPPER_BUILDER_BUILD_STANDALONE  Default OFF. When ON,
-#                                            STANDALONE_PLUGIN_ID is required.
-#
-#   Standalone (only when BUILD_STANDALONE=ON)
-#     CLAP_WRAPPER_BUILDER_STANDALONE_PLUGIN_ID    Required. Plugin ID the
-#                                                  standalone host loads.
-#     CLAP_WRAPPER_BUILDER_STANDALONE_OUTPUT_NAME  Optional. Defaults to
-#                                                  "<name> Standalone".
+#     CLAP_WRAPPER_BUILDER_BUILD_STANDALONE  Default OFF.
 #
 # clap-wrapper is vendored as a git subtree. The clap, vst3sdk, and
 # AudioUnitSDK dependency SDKs live alongside this file as git submodules.
@@ -76,6 +82,7 @@ set(CLAP_WRAPPER_BUILDER_TARGET_NAME "" CACHE STRING "Internal CMake target name
 set(CLAP_WRAPPER_BUILDER_OUTPUT_NAME "" CACHE STRING "Output plugin display/bundle name")
 set(CLAP_WRAPPER_BUILDER_STAGE_DIR "" CACHE PATH "Directory where built artifacts are staged")
 set(CLAP_WRAPPER_BUILDER_BUNDLE_VERSION "1.0.0" CACHE STRING "Version written into wrapped plugin bundles")
+set(CLAP_WRAPPER_BUILDER_PRODUCT_COUNT "1" CACHE STRING "Number of plugin products exposed by the wrapped library")
 option(CLAP_WRAPPER_BUILDER_BUILD_STANDALONE "Build standalone app target in clap_wrapper_builder" OFF)
 option(CLAP_WRAPPER_BUILDER_BUILD_VST3 "Build VST3 target in clap_wrapper_builder" ON)
 if(APPLE)
@@ -88,8 +95,6 @@ if(APPLE OR WIN32)
 else()
     option(CLAP_WRAPPER_BUILDER_BUILD_AAX "Build AAX target in clap_wrapper_builder" OFF)
 endif()
-set(CLAP_WRAPPER_BUILDER_STANDALONE_OUTPUT_NAME "" CACHE STRING "Output name for standalone app")
-set(CLAP_WRAPPER_BUILDER_STANDALONE_PLUGIN_ID "" CACHE STRING "Plugin ID used by standalone app")
 
 # Validate required parameters
 if(NOT CLAP_WRAPPER_BUILDER_TARGET_LIB)
@@ -118,6 +123,11 @@ message(STATUS "  Plugin Name: ${PLUGIN_NAME}")
 message(STATUS "  Safe Plugin Name: ${PLUGIN_NAME_SAFE}")
 message(STATUS "  Stage Dir: ${CLAP_WRAPPER_BUILDER_STAGE_DIR}")
 message(STATUS "  Build AAX: ${CLAP_WRAPPER_BUILDER_BUILD_AAX}")
+message(STATUS "  Product Count: ${CLAP_WRAPPER_BUILDER_PRODUCT_COUNT}")
+if(CLAP_WRAPPER_BUILDER_PRODUCT_COUNT LESS 1)
+    message(FATAL_ERROR "CLAP_WRAPPER_BUILDER_PRODUCT_COUNT must be at least 1")
+endif()
+math(EXPR PRODUCT_LAST_INDEX "${CLAP_WRAPPER_BUILDER_PRODUCT_COUNT} - 1")
 
 # Add the clap-wrapper subproject
 add_subdirectory(clap-wrapper)
@@ -127,6 +137,31 @@ add_subdirectory(clap-wrapper)
 if(APPLE AND TARGET clap-wrapper-compile-options)
   target_compile_options(clap-wrapper-compile-options INTERFACE -Wno-shorten-64-to-32)
 endif()
+
+function(clap_wrapper_builder_product_value INDEX FIELD OUT_VAR)
+    set(var_name "CLAP_WRAPPER_BUILDER_PRODUCT_${INDEX}_${FIELD}")
+    if(DEFINED ${var_name} AND NOT "${${var_name}}" STREQUAL "")
+        set(${OUT_VAR} "${${var_name}}" PARENT_SCOPE)
+    else()
+        set(${OUT_VAR} "" PARENT_SCOPE)
+    endif()
+endfunction()
+
+function(clap_wrapper_builder_product_output_name INDEX OUT_VAR)
+    clap_wrapper_builder_product_value(${INDEX} "OUTPUT_NAME" value)
+    if(value)
+        set(${OUT_VAR} "${value}" PARENT_SCOPE)
+    elseif(INDEX EQUAL 0)
+        set(${OUT_VAR} "${PLUGIN_NAME}" PARENT_SCOPE)
+    else()
+        message(FATAL_ERROR "CLAP_WRAPPER_BUILDER_PRODUCT_${INDEX}_OUTPUT_NAME must be specified")
+    endif()
+endfunction()
+
+function(clap_wrapper_builder_product_target_name INDEX OUTPUT_NAME OUT_VAR)
+    string(MAKE_C_IDENTIFIER "${OUTPUT_NAME}" product_name_safe)
+    set(${OUT_VAR} "${PLUGIN_NAME_SAFE}_product_${INDEX}_${product_name_safe}" PARENT_SCOPE)
+endfunction()
 
 # Create the static library target
 # Set up the external static library as an imported library
@@ -178,13 +213,11 @@ extern \"C\" {
 #endif
 ")
 
-# Configure plugin formats to build
+# Configure bundle plugin formats to build. AUv2 is product-specific and is
+# generated in the product loop below.
 set(PLUGIN_FORMATS "CLAP")
 if(CLAP_WRAPPER_BUILDER_BUILD_VST3)
     list(APPEND PLUGIN_FORMATS "VST3")
-endif()
-if(APPLE AND CLAP_WRAPPER_BUILDER_BUILD_AUV2)
-    list(APPEND PLUGIN_FORMATS "AUV2")
 endif()
 if(CLAP_WRAPPER_BUILDER_BUILD_AAX)
     list(APPEND PLUGIN_FORMATS "AAX")
@@ -194,7 +227,8 @@ endif()
 set(BUNDLE_ID "org.wrapper.${PLUGIN_NAME_BUNDLE}")
 set(BUNDLE_VERSION "${CLAP_WRAPPER_BUILDER_BUNDLE_VERSION}")
 
-# Create multi-format plugins using make_clapfirst_plugins
+# Create bundle-level plugins using make_clapfirst_plugins. CLAP and VST3 can
+# expose every product in one bundle through the CLAP factory descriptors.
 set(CLAPFIRST_COMMON_ARGS
     TARGET_NAME ${PLUGIN_NAME_SAFE}
     IMPL_TARGET ${PLUGIN_NAME_SAFE}_impl
@@ -209,32 +243,70 @@ set(CLAPFIRST_COMMON_ARGS
     WINDOWS_FOLDER_VST3 TRUE
 )
 
+set(STANDALONE_TARGETS)
 if(CLAP_WRAPPER_BUILDER_BUILD_STANDALONE)
-    if(NOT CLAP_WRAPPER_BUILDER_STANDALONE_PLUGIN_ID)
-        message(FATAL_ERROR "CLAP_WRAPPER_BUILDER_STANDALONE_PLUGIN_ID must be specified when CLAP_WRAPPER_BUILDER_BUILD_STANDALONE=ON")
-    endif()
-
-    if(NOT CLAP_WRAPPER_BUILDER_STANDALONE_OUTPUT_NAME)
-        set(CLAP_WRAPPER_BUILDER_STANDALONE_OUTPUT_NAME "${PLUGIN_NAME} Standalone")
-    endif()
-
     message(STATUS "  Standalone Enabled: ON")
-    message(STATUS "  Standalone Output Name: ${CLAP_WRAPPER_BUILDER_STANDALONE_OUTPUT_NAME}")
-    message(STATUS "  Standalone Plugin ID: ${CLAP_WRAPPER_BUILDER_STANDALONE_PLUGIN_ID}")
+    set(STANDALONE_CONFIGURATIONS)
+    foreach(PRODUCT_INDEX RANGE 0 ${PRODUCT_LAST_INDEX})
+        clap_wrapper_builder_product_output_name(${PRODUCT_INDEX} PRODUCT_OUTPUT_NAME)
+        clap_wrapper_builder_product_value(${PRODUCT_INDEX} "PLUGIN_ID" PRODUCT_PLUGIN_ID)
+        clap_wrapper_builder_product_value(${PRODUCT_INDEX} "STANDALONE_NAME" PRODUCT_STANDALONE_NAME)
+        if(NOT PRODUCT_PLUGIN_ID)
+            message(FATAL_ERROR "CLAP_WRAPPER_BUILDER_PRODUCT_${PRODUCT_INDEX}_PLUGIN_ID must be specified when CLAP_WRAPPER_BUILDER_BUILD_STANDALONE=ON")
+        endif()
+        if(NOT PRODUCT_STANDALONE_NAME)
+            message(FATAL_ERROR "CLAP_WRAPPER_BUILDER_PRODUCT_${PRODUCT_INDEX}_STANDALONE_NAME must be specified when CLAP_WRAPPER_BUILDER_BUILD_STANDALONE=ON")
+        endif()
+        set(STANDALONE_POSTFIX "product_${PRODUCT_INDEX}_standalone")
+        set(STANDALONE_TARGET "${PLUGIN_NAME_SAFE}_${STANDALONE_POSTFIX}")
+        list(APPEND STANDALONE_TARGETS "${STANDALONE_TARGET}")
+        list(APPEND STANDALONE_CONFIGURATIONS "${STANDALONE_POSTFIX}" "${PRODUCT_STANDALONE_NAME}" "${PRODUCT_PLUGIN_ID}")
+        message(STATUS "  Standalone Product: ${PRODUCT_STANDALONE_NAME} -> ${PRODUCT_PLUGIN_ID}")
+    endforeach()
 
     make_clapfirst_plugins(
         ${CLAPFIRST_COMMON_ARGS}
-        STANDALONE_CONFIGURATIONS standalone "${CLAP_WRAPPER_BUILDER_STANDALONE_OUTPUT_NAME}" "${CLAP_WRAPPER_BUILDER_STANDALONE_PLUGIN_ID}"
+        STANDALONE_CONFIGURATIONS ${STANDALONE_CONFIGURATIONS}
     )
 else()
     make_clapfirst_plugins(${CLAPFIRST_COMMON_ARGS})
 endif()
 
+set(AUV2_PRODUCT_TARGETS)
+if(APPLE AND CLAP_WRAPPER_BUILDER_BUILD_AUV2)
+    foreach(PRODUCT_INDEX RANGE 0 ${PRODUCT_LAST_INDEX})
+        clap_wrapper_builder_product_output_name(${PRODUCT_INDEX} PRODUCT_OUTPUT_NAME)
+        clap_wrapper_builder_product_value(${PRODUCT_INDEX} "AUV2_TYPE" PRODUCT_AUV2_TYPE)
+        clap_wrapper_builder_product_value(${PRODUCT_INDEX} "AUV2_SUBTYPE" PRODUCT_AUV2_SUBTYPE)
+        if(NOT PRODUCT_AUV2_TYPE)
+            message(FATAL_ERROR "CLAP_WRAPPER_BUILDER_PRODUCT_${PRODUCT_INDEX}_AUV2_TYPE must be specified when CLAP_WRAPPER_BUILDER_BUILD_AUV2=ON")
+        endif()
+        if(NOT PRODUCT_AUV2_SUBTYPE)
+            message(FATAL_ERROR "CLAP_WRAPPER_BUILDER_PRODUCT_${PRODUCT_INDEX}_AUV2_SUBTYPE must be specified when CLAP_WRAPPER_BUILDER_BUILD_AUV2=ON")
+        endif()
+        clap_wrapper_builder_product_target_name(${PRODUCT_INDEX} "${PRODUCT_OUTPUT_NAME}" PRODUCT_TARGET_NAME)
+        set(AUV2_TARGET "${PRODUCT_TARGET_NAME}_auv2")
+        add_library(${AUV2_TARGET} MODULE)
+        target_sources(${AUV2_TARGET} PRIVATE ${ENTRY_SOURCE_FILE})
+        target_link_libraries(${AUV2_TARGET} PRIVATE ${PLUGIN_NAME_SAFE}_impl)
+        target_add_auv2_wrapper(
+            TARGET ${AUV2_TARGET}
+            OUTPUT_NAME "${PRODUCT_OUTPUT_NAME}"
+            BUNDLE_IDENTIFIER "${BUNDLE_ID}.${PRODUCT_TARGET_NAME}.auv2"
+            BUNDLE_VERSION "${BUNDLE_VERSION}"
+            MANUFACTURER_NAME "${CLAP_WRAPPER_AUV2_MANUFACTURER_NAME}"
+            MANUFACTURER_CODE "${CLAP_WRAPPER_AUV2_MANUFACTURER_CODE}"
+            SUBTYPE_CODE "${PRODUCT_AUV2_SUBTYPE}"
+            INSTRUMENT_TYPE "${PRODUCT_AUV2_TYPE}"
+            PREFER_CMAKE_AUV2_CONFIGURATION TRUE
+        )
+        list(APPEND AUV2_PRODUCT_TARGETS "${AUV2_TARGET}")
+    endforeach()
+endif()
+
 if(APPLE)
     set(CLAP_BUNDLE_ID "${BUNDLE_ID}.clap")
     set(VST3_BUNDLE_ID "${BUNDLE_ID}.vst3")
-    set(AUV2_BUNDLE_ID "${BUNDLE_ID}.auv2")
-    set(STANDALONE_BUNDLE_ID "${BUNDLE_ID}.standalone")
     set(STANDALONE_INFO_PLIST "${CMAKE_CURRENT_LIST_DIR}/StandaloneInfo.plist.in")
 
     if(TARGET ${PLUGIN_NAME_SAFE}_clap)
@@ -251,30 +323,34 @@ if(APPLE)
         )
     endif()
 
-    if(TARGET ${PLUGIN_NAME_SAFE}_auv2)
-        set_target_properties(${PLUGIN_NAME_SAFE}_auv2 PROPERTIES
-            MACOSX_BUNDLE_GUI_IDENTIFIER "${AUV2_BUNDLE_ID}"
-            XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "${AUV2_BUNDLE_ID}"
+    foreach(AUV2_TARGET IN LISTS AUV2_PRODUCT_TARGETS)
+        string(REPLACE "_" "-" AUV2_TARGET_BUNDLE_ID "${AUV2_TARGET}")
+        set_target_properties(${AUV2_TARGET} PROPERTIES
+            MACOSX_BUNDLE_GUI_IDENTIFIER "${BUNDLE_ID}.${AUV2_TARGET_BUNDLE_ID}.auv2"
+            XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "${BUNDLE_ID}.${AUV2_TARGET_BUNDLE_ID}.auv2"
         )
-    endif()
+    endforeach()
 
-    if(TARGET ${PLUGIN_NAME_SAFE}_standalone)
+    foreach(STANDALONE_TARGET IN LISTS STANDALONE_TARGETS)
+        string(REPLACE "_" "-" STANDALONE_TARGET_BUNDLE_ID "${STANDALONE_TARGET}")
         # The standalone app has its own Info.plist template, so set the bundle version
         # properties explicitly instead of relying on Xcode's default 1.0/1 values.
-        set_target_properties(${PLUGIN_NAME_SAFE}_standalone PROPERTIES
-            MACOSX_BUNDLE_GUI_IDENTIFIER "${STANDALONE_BUNDLE_ID}"
-            XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "${STANDALONE_BUNDLE_ID}"
+        set_target_properties(${STANDALONE_TARGET} PROPERTIES
+            MACOSX_BUNDLE_GUI_IDENTIFIER "${BUNDLE_ID}.${STANDALONE_TARGET_BUNDLE_ID}.standalone"
+            XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "${BUNDLE_ID}.${STANDALONE_TARGET_BUNDLE_ID}.standalone"
             MACOSX_BUNDLE_SHORT_VERSION_STRING "${BUNDLE_VERSION}"
             MACOSX_BUNDLE_BUNDLE_VERSION "${BUNDLE_VERSION}"
             MACOSX_BUNDLE_INFO_PLIST "${STANDALONE_INFO_PLIST}"
         )
-    endif()
+    endforeach()
 endif()
 
 # The standalone exe links the impl lib directly rather than through the
 # wrapper, so it needs runtimeobject.lib stated again on its own link line.
-if(MSVC AND TARGET ${PLUGIN_NAME_SAFE}_standalone)
-    target_link_libraries(${PLUGIN_NAME_SAFE}_standalone PRIVATE runtimeobject.lib)
+if(MSVC)
+    foreach(STANDALONE_TARGET IN LISTS STANDALONE_TARGETS)
+        target_link_libraries(${STANDALONE_TARGET} PRIVATE runtimeobject.lib)
+    endforeach()
 endif()
 
 # Only the CLAP target compiles the generated entry shim, which includes
@@ -311,35 +387,37 @@ if(CLAP_WRAPPER_BUILDER_STAGE_DIR)
         endif()
     endif()
 
-    if(APPLE AND TARGET ${PLUGIN_NAME_SAFE}_auv2)
-        set(AUV2_GENERATED_PLIST "${CMAKE_CURRENT_BINARY_DIR}/${PLUGIN_NAME_SAFE}_auv2-build-helper-output/auv2_Info.plist")
+    foreach(AUV2_TARGET IN LISTS AUV2_PRODUCT_TARGETS)
+        get_target_property(AUV2_OUTPUT_NAME ${AUV2_TARGET} LIBRARY_OUTPUT_NAME)
+        set(AUV2_GENERATED_PLIST "${CMAKE_CURRENT_BINARY_DIR}/${AUV2_TARGET}-build-helper-output/auv2_Info.plist")
         # clap-wrapper's AUv2 helper generates the AudioComponents metadata that
         # auval needs; copy it back before staging/signing the component bundle.
-        add_custom_command(TARGET ${PLUGIN_NAME_SAFE}_auv2 POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy_if_different "${AUV2_GENERATED_PLIST}" "$<TARGET_BUNDLE_DIR:${PLUGIN_NAME_SAFE}_auv2>/Contents/Info.plist"
-            COMMAND ${CMAKE_COMMAND} -E rm -rf "${CLAP_WRAPPER_BUILDER_STAGE_DIR}/${PLUGIN_NAME}.component"
-            COMMAND ${CMAKE_COMMAND} -E copy_directory "$<TARGET_BUNDLE_DIR:${PLUGIN_NAME_SAFE}_auv2>" "${CLAP_WRAPPER_BUILDER_STAGE_DIR}/${PLUGIN_NAME}.component"
+        add_custom_command(TARGET ${AUV2_TARGET} POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different "${AUV2_GENERATED_PLIST}" "$<TARGET_BUNDLE_DIR:${AUV2_TARGET}>/Contents/Info.plist"
+            COMMAND ${CMAKE_COMMAND} -E rm -rf "${CLAP_WRAPPER_BUILDER_STAGE_DIR}/${AUV2_OUTPUT_NAME}.component"
+            COMMAND ${CMAKE_COMMAND} -E copy_directory "$<TARGET_BUNDLE_DIR:${AUV2_TARGET}>" "${CLAP_WRAPPER_BUILDER_STAGE_DIR}/${AUV2_OUTPUT_NAME}.component"
             VERBATIM
         )
-    endif()
+    endforeach()
 
-    if(TARGET ${PLUGIN_NAME_SAFE}_standalone)
+    foreach(STANDALONE_TARGET IN LISTS STANDALONE_TARGETS)
+        get_target_property(STANDALONE_OUTPUT_NAME ${STANDALONE_TARGET} OUTPUT_NAME)
         if(APPLE)
-            add_custom_command(TARGET ${PLUGIN_NAME_SAFE}_standalone POST_BUILD
-                COMMAND ${CMAKE_COMMAND} -E rm -rf "${CLAP_WRAPPER_BUILDER_STAGE_DIR}/${CLAP_WRAPPER_BUILDER_STANDALONE_OUTPUT_NAME}.app"
-                COMMAND ${CMAKE_COMMAND} -E copy_directory "$<TARGET_BUNDLE_DIR:${PLUGIN_NAME_SAFE}_standalone>" "${CLAP_WRAPPER_BUILDER_STAGE_DIR}/${CLAP_WRAPPER_BUILDER_STANDALONE_OUTPUT_NAME}.app"
+            add_custom_command(TARGET ${STANDALONE_TARGET} POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E rm -rf "${CLAP_WRAPPER_BUILDER_STAGE_DIR}/${STANDALONE_OUTPUT_NAME}.app"
+                COMMAND ${CMAKE_COMMAND} -E copy_directory "$<TARGET_BUNDLE_DIR:${STANDALONE_TARGET}>" "${CLAP_WRAPPER_BUILDER_STAGE_DIR}/${STANDALONE_OUTPUT_NAME}.app"
                 VERBATIM
             )
         elseif(WIN32)
-            add_custom_command(TARGET ${PLUGIN_NAME_SAFE}_standalone POST_BUILD
-                COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:${PLUGIN_NAME_SAFE}_standalone>" "${CLAP_WRAPPER_BUILDER_STAGE_DIR}/${CLAP_WRAPPER_BUILDER_STANDALONE_OUTPUT_NAME}.exe"
+            add_custom_command(TARGET ${STANDALONE_TARGET} POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:${STANDALONE_TARGET}>" "${CLAP_WRAPPER_BUILDER_STAGE_DIR}/${STANDALONE_OUTPUT_NAME}.exe"
                 VERBATIM
             )
         else()
-            add_custom_command(TARGET ${PLUGIN_NAME_SAFE}_standalone POST_BUILD
-                COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:${PLUGIN_NAME_SAFE}_standalone>" "${CLAP_WRAPPER_BUILDER_STAGE_DIR}/${CLAP_WRAPPER_BUILDER_STANDALONE_OUTPUT_NAME}"
+            add_custom_command(TARGET ${STANDALONE_TARGET} POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:${STANDALONE_TARGET}>" "${CLAP_WRAPPER_BUILDER_STAGE_DIR}/${STANDALONE_OUTPUT_NAME}"
                 VERBATIM
             )
         endif()
-    endif()
+    endforeach()
 endif()

--- a/clap_wrapper_builder/CMakeLists.txt
+++ b/clap_wrapper_builder/CMakeLists.txt
@@ -34,7 +34,6 @@ project(clap_wrapper_builder)
 #                                           the wrapped static library. Default 1.
 #     CLAP_WRAPPER_BUILDER_PRODUCT_<N>_OUTPUT_NAME
 #                                           Product name used for AUv2 output.
-#                                           Product 0 defaults to OUTPUT_NAME.
 #     CLAP_WRAPPER_BUILDER_PRODUCT_<N>_PLUGIN_ID
 #                                           CLAP plugin ID used by standalone.
 #     CLAP_WRAPPER_BUILDER_PRODUCT_<N>_STANDALONE_NAME
@@ -151,8 +150,6 @@ function(clap_wrapper_builder_product_output_name INDEX OUT_VAR)
     clap_wrapper_builder_product_value(${INDEX} "OUTPUT_NAME" value)
     if(value)
         set(${OUT_VAR} "${value}" PARENT_SCOPE)
-    elseif(INDEX EQUAL 0)
-        set(${OUT_VAR} "${PLUGIN_NAME}" PARENT_SCOPE)
     else()
         message(FATAL_ERROR "CLAP_WRAPPER_BUILDER_PRODUCT_${INDEX}_OUTPUT_NAME must be specified")
     endif()
@@ -401,21 +398,21 @@ if(CLAP_WRAPPER_BUILDER_STAGE_DIR)
     endforeach()
 
     foreach(STANDALONE_TARGET IN LISTS STANDALONE_TARGETS)
-        get_target_property(STANDALONE_OUTPUT_NAME ${STANDALONE_TARGET} OUTPUT_NAME)
+        get_target_property(PRODUCT_STANDALONE_OUTPUT_NAME ${STANDALONE_TARGET} OUTPUT_NAME)
         if(APPLE)
             add_custom_command(TARGET ${STANDALONE_TARGET} POST_BUILD
-                COMMAND ${CMAKE_COMMAND} -E rm -rf "${CLAP_WRAPPER_BUILDER_STAGE_DIR}/${STANDALONE_OUTPUT_NAME}.app"
-                COMMAND ${CMAKE_COMMAND} -E copy_directory "$<TARGET_BUNDLE_DIR:${STANDALONE_TARGET}>" "${CLAP_WRAPPER_BUILDER_STAGE_DIR}/${STANDALONE_OUTPUT_NAME}.app"
+                COMMAND ${CMAKE_COMMAND} -E rm -rf "${CLAP_WRAPPER_BUILDER_STAGE_DIR}/${PRODUCT_STANDALONE_OUTPUT_NAME}.app"
+                COMMAND ${CMAKE_COMMAND} -E copy_directory "$<TARGET_BUNDLE_DIR:${STANDALONE_TARGET}>" "${CLAP_WRAPPER_BUILDER_STAGE_DIR}/${PRODUCT_STANDALONE_OUTPUT_NAME}.app"
                 VERBATIM
             )
         elseif(WIN32)
             add_custom_command(TARGET ${STANDALONE_TARGET} POST_BUILD
-                COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:${STANDALONE_TARGET}>" "${CLAP_WRAPPER_BUILDER_STAGE_DIR}/${STANDALONE_OUTPUT_NAME}.exe"
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:${STANDALONE_TARGET}>" "${CLAP_WRAPPER_BUILDER_STAGE_DIR}/${PRODUCT_STANDALONE_OUTPUT_NAME}.exe"
                 VERBATIM
             )
         else()
             add_custom_command(TARGET ${STANDALONE_TARGET} POST_BUILD
-                COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:${STANDALONE_TARGET}>" "${CLAP_WRAPPER_BUILDER_STAGE_DIR}/${STANDALONE_OUTPUT_NAME}"
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:${STANDALONE_TARGET}>" "${CLAP_WRAPPER_BUILDER_STAGE_DIR}/${PRODUCT_STANDALONE_OUTPUT_NAME}"
                 VERBATIM
             )
         endif()

--- a/clap_wrapper_builder/CMakeLists.txt
+++ b/clap_wrapper_builder/CMakeLists.txt
@@ -157,6 +157,9 @@ endfunction()
 
 function(clap_wrapper_builder_product_target_name INDEX OUTPUT_NAME OUT_VAR)
     string(MAKE_C_IDENTIFIER "${OUTPUT_NAME}" product_name_safe)
+    # Product display names are user-facing and not guaranteed to be unique after
+    # CMake identifier sanitization. Keep the metadata order in target names so
+    # two products cannot collapse into the same wrapper target.
     set(${OUT_VAR} "${PLUGIN_NAME_SAFE}_product_${INDEX}_${product_name_safe}" PARENT_SCOPE)
 endfunction()
 
@@ -244,6 +247,8 @@ set(STANDALONE_TARGETS)
 if(CLAP_WRAPPER_BUILDER_BUILD_STANDALONE)
     message(STATUS "  Standalone Enabled: ON")
     set(STANDALONE_CONFIGURATIONS)
+    # Standalone hosts load exactly one CLAP plugin ID, so each product needs its
+    # own app target even when all products come from the same static library.
     foreach(PRODUCT_INDEX RANGE 0 ${PRODUCT_LAST_INDEX})
         clap_wrapper_builder_product_output_name(${PRODUCT_INDEX} PRODUCT_OUTPUT_NAME)
         clap_wrapper_builder_product_value(${PRODUCT_INDEX} "PLUGIN_ID" PRODUCT_PLUGIN_ID)
@@ -271,6 +276,9 @@ endif()
 
 set(AUV2_PRODUCT_TARGETS)
 if(APPLE AND CLAP_WRAPPER_BUILDER_BUILD_AUV2)
+    # AUv2 discovery is keyed by type/manufacturer/subtype metadata in each
+    # component bundle. A single multi-product component cannot represent
+    # distinct AUv2 identities, so create one module target per product.
     foreach(PRODUCT_INDEX RANGE 0 ${PRODUCT_LAST_INDEX})
         clap_wrapper_builder_product_output_name(${PRODUCT_INDEX} PRODUCT_OUTPUT_NAME)
         clap_wrapper_builder_product_value(${PRODUCT_INDEX} "AUV2_TYPE" PRODUCT_AUV2_TYPE)

--- a/crates/wrac_xtask/src/cli.rs
+++ b/crates/wrac_xtask/src/cli.rs
@@ -99,11 +99,12 @@ const LAUNCH_AFTER_HELP: &str = "\
 Examples:
   cargo xtask launch
   cargo xtask launch -p wrac_gain_plugin
+  cargo xtask launch -p wrac_gain_plugin --plugin-id=com.your-company.wrac-gain
   cargo xtask launch --package=wrac_gain_plugin
   cargo xtask launch -p wrac_gain_plugin --release
 
 Notes:
-  launch builds the standalone artifact before starting it.";
+  launch builds standalone artifacts before starting one. Use --plugin-id when a package exposes multiple plugin products.";
 
 #[derive(Debug, Parser)]
 #[command(
@@ -301,6 +302,12 @@ pub(crate) struct LaunchArgs {
 
     #[arg(long, help = "Launch release artifact.")]
     pub(crate) release: bool,
+
+    #[arg(
+        long,
+        help = "Plugin ID to launch when the package has multiple products."
+    )]
+    pub(crate) plugin_id: Option<String>,
 }
 
 #[derive(Debug, Args)]

--- a/crates/wrac_xtask/src/commands.rs
+++ b/crates/wrac_xtask/src/commands.rs
@@ -273,6 +273,7 @@ fn build_wrapper_set(ctx: &Context, profile: BuildProfile, build: WrapperBuild) 
         .arg("-DCLAP_WRAPPER_BUILDER_BUILD_AAX=OFF")
         .arg("-DCLAP_WRAPPER_DOWNLOAD_DEPENDENCIES=OFF")
         .arg("-DCLAP_WRAPPER_CXX_STANDARD=23");
+    add_wrapper_product_args(ctx, &mut configure, build);
 
     match build {
         WrapperBuild::Plugin { vst3, au } => {
@@ -292,14 +293,6 @@ fn build_wrapper_set(ctx: &Context, profile: BuildProfile, build: WrapperBuild) 
                 .arg("-DCLAP_WRAPPER_BUILDER_BUILD_VST3=OFF")
                 .arg("-DCLAP_WRAPPER_BUILDER_BUILD_AUV2=OFF")
                 .arg("-DCLAP_WRAPPER_BUILDER_BUILD_STANDALONE=ON")
-                .arg(format!(
-                    "-DCLAP_WRAPPER_BUILDER_STANDALONE_PLUGIN_ID={}",
-                    ctx.metadata.primary_plugin().plugin_id
-                ))
-                .arg(format!(
-                    "-DCLAP_WRAPPER_BUILDER_STANDALONE_OUTPUT_NAME={}",
-                    ctx.metadata.standalone_name
-                ))
                 .arg("-DCLAP_WRAPPER_DOWNLOAD_DEPENDENCIES=ON");
         }
     }
@@ -313,20 +306,12 @@ fn build_wrapper_set(ctx: &Context, profile: BuildProfile, build: WrapperBuild) 
                 ctx.wrapper_dir.join("AudioUnitSDK").display()
             ))
             .arg(format!(
-                "-DCLAP_WRAPPER_AUV2_INSTRUMENT_TYPE={}",
-                ctx.metadata.primary_plugin().auv2_type
-            ))
-            .arg(format!(
                 "-DCLAP_WRAPPER_AUV2_MANUFACTURER_NAME={}",
                 ctx.metadata.company_name
             ))
             .arg(format!(
                 "-DCLAP_WRAPPER_AUV2_MANUFACTURER_CODE={}",
                 ctx.metadata.auv2_manufacturer_code
-            ))
-            .arg(format!(
-                "-DCLAP_WRAPPER_AUV2_SUBTYPE_CODE={}",
-                ctx.metadata.primary_plugin().auv2_subtype
             ));
     }
 
@@ -360,25 +345,71 @@ fn build_wrapper_set(ctx: &Context, profile: BuildProfile, build: WrapperBuild) 
                 ensure_exists(&ctx.vst3_bundle(profile), "VST3 artifact")?;
                 if ctx.platform == Platform::Macos {
                     // macOS hosts may reject unsigned bundles; apply an ad-hoc signature for development.
-                    codesign_nested_macos_bundle(ctx, &ctx.vst3_bundle(profile))?;
+                    codesign_nested_macos_bundle(&ctx.vst3_bundle(profile))?;
                 }
             }
             if au {
-                ensure_exists(&ctx.au_bundle(profile), "AU artifact")?;
-                // AU components are loaded via AudioComponentRegistrar, so they must be signed even for local builds.
-                codesign_nested_macos_bundle(ctx, &ctx.au_bundle(profile))?;
+                for artifact in ctx.au_bundles(profile) {
+                    ensure_exists(&artifact, "AU artifact")?;
+                    // AU components are loaded via AudioComponentRegistrar, so they must be signed even for local builds.
+                    codesign_nested_macos_bundle(&artifact)?;
+                }
             }
         }
         WrapperBuild::Standalone => {
-            ensure_exists(&ctx.standalone_artifact(profile), "standalone artifact")?;
-            if ctx.platform == Platform::Macos {
-                // Apply the same Gatekeeper/loader treatment to the standalone app as to plugin bundles.
-                codesign_nested_macos_bundle(ctx, &ctx.standalone_artifact(profile))?;
+            for artifact in ctx.standalone_artifacts(profile) {
+                ensure_exists(&artifact, "standalone artifact")?;
+                if ctx.platform == Platform::Macos {
+                    // Apply the same Gatekeeper/loader treatment to the standalone app as to plugin bundles.
+                    codesign_nested_macos_bundle(&artifact)?;
+                }
             }
         }
     }
 
     Ok(())
+}
+
+fn add_wrapper_product_args(ctx: &Context, command: &mut Command, build: WrapperBuild) {
+    command.arg(format!(
+        "-DCLAP_WRAPPER_BUILDER_PRODUCT_COUNT={}",
+        ctx.metadata.plugins.len()
+    ));
+    for (index, plugin) in ctx.metadata.plugins.iter().enumerate() {
+        match build {
+            WrapperBuild::Plugin { au: true, .. } => {
+                command
+                    .arg(format!(
+                        "-DCLAP_WRAPPER_BUILDER_PRODUCT_{index}_OUTPUT_NAME={}",
+                        plugin.plugin_name
+                    ))
+                    .arg(format!(
+                        "-DCLAP_WRAPPER_BUILDER_PRODUCT_{index}_AUV2_TYPE={}",
+                        plugin.auv2_type
+                    ))
+                    .arg(format!(
+                        "-DCLAP_WRAPPER_BUILDER_PRODUCT_{index}_AUV2_SUBTYPE={}",
+                        plugin.auv2_subtype
+                    ));
+            }
+            WrapperBuild::Standalone => {
+                command
+                    .arg(format!(
+                        "-DCLAP_WRAPPER_BUILDER_PRODUCT_{index}_OUTPUT_NAME={}",
+                        plugin.plugin_name
+                    ))
+                    .arg(format!(
+                        "-DCLAP_WRAPPER_BUILDER_PRODUCT_{index}_PLUGIN_ID={}",
+                        plugin.plugin_id
+                    ))
+                    .arg(format!(
+                        "-DCLAP_WRAPPER_BUILDER_PRODUCT_{index}_STANDALONE_NAME={}",
+                        plugin.standalone_name
+                    ));
+            }
+            WrapperBuild::Plugin { au: false, .. } => {}
+        }
+    }
 }
 
 pub(crate) fn install(
@@ -391,8 +422,9 @@ pub(crate) fn install(
     install_plugin_targets(ctx, profile, scope, &targets)
 }
 
-pub(crate) fn launch(ctx: &Context, profile: BuildProfile) -> Result<()> {
-    let artifact = ctx.standalone_artifact(profile);
+pub(crate) fn launch(ctx: &Context, profile: BuildProfile, plugin_id: Option<&str>) -> Result<()> {
+    let plugin = standalone_plugin_to_launch(ctx, plugin_id)?;
+    let artifact = ctx.standalone_artifact_for(profile, plugin);
     if !artifact.exists() {
         let release = if profile == BuildProfile::Release {
             " --release"
@@ -415,6 +447,32 @@ pub(crate) fn launch(ctx: &Context, profile: BuildProfile) -> Result<()> {
     Ok(())
 }
 
+fn standalone_plugin_to_launch<'a>(
+    ctx: &'a Context,
+    plugin_id: Option<&str>,
+) -> Result<&'a crate::metadata::PluginProductMetadata> {
+    if let Some(plugin_id) = plugin_id {
+        return ctx
+            .metadata
+            .plugins
+            .iter()
+            .find(|plugin| plugin.plugin_id == plugin_id)
+            .ok_or_else(|| format!("plugin ID not found in WRAC metadata: {plugin_id}").into());
+    }
+    match ctx.metadata.plugins.as_slice() {
+        [plugin] => Ok(plugin),
+        plugins => Err(format!(
+            "multiple plugin products found: {}. Use --plugin-id <PLUGIN_ID>.",
+            plugins
+                .iter()
+                .map(|plugin| plugin.plugin_id.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+        .into()),
+    }
+}
+
 fn install_plugin_targets(
     ctx: &Context,
     profile: BuildProfile,
@@ -431,10 +489,12 @@ fn install_plugin_targets(
                 &ctx.vst3_bundle(profile),
                 &install_dir(ctx, scope, PluginFormat::Vst3)?,
             )?,
-            PluginTarget::Au => install_artifact(
-                &ctx.au_bundle(profile),
-                &install_dir(ctx, scope, PluginFormat::Au)?,
-            )?,
+            PluginTarget::Au => {
+                let install_dir = install_dir(ctx, scope, PluginFormat::Au)?;
+                for artifact in ctx.au_bundles(profile) {
+                    install_artifact(&artifact, &install_dir)?;
+                }
+            }
         }
     }
     Ok(())
@@ -561,18 +621,22 @@ fn installed_artifacts(
         PluginTarget::Vst3 => PluginFormat::Vst3,
         PluginTarget::Au => PluginFormat::Au,
     };
-    let bundle_name = match target {
-        PluginTarget::Clap => ctx.metadata.clap_bundle_name(),
-        PluginTarget::Vst3 => ctx.metadata.vst3_bundle_name(),
-        PluginTarget::Au => ctx.metadata.au_bundle_name(),
+    let bundle_names = match target {
+        PluginTarget::Clap => vec![ctx.metadata.clap_bundle_name()],
+        PluginTarget::Vst3 => vec![ctx.metadata.vst3_bundle_name()],
+        PluginTarget::Au => ctx
+            .metadata
+            .plugins
+            .iter()
+            .map(|plugin| ctx.metadata.au_bundle_name(plugin))
+            .collect(),
     };
-    uninstall_scopes(scope)
-        .iter()
-        .copied()
-        .map(|install_scope| {
-            install_dir(ctx, install_scope, format).map(|dir| dir.join(&bundle_name))
-        })
-        .collect::<Result<Vec<_>>>()
+    let mut artifacts = Vec::new();
+    for install_scope in uninstall_scopes(scope) {
+        let dir = install_dir(ctx, *install_scope, format)?;
+        artifacts.extend(bundle_names.iter().map(|bundle_name| dir.join(bundle_name)));
+    }
+    Ok(artifacts)
 }
 
 fn uninstall_scopes(scope: UninstallScope) -> &'static [InstallScope] {
@@ -628,14 +692,15 @@ fn validate_targets(
     }
 
     if targets.contains(&ValidateTarget::Au) {
-        let au = ctx.au_bundle(profile);
-        ensure_exists(&au, "AU artifact")?;
         ensure_no_system_au_conflict(ctx)?;
 
         // auval resolves its target via AudioComponentRegistrar rather than a direct path,
         // so the freshly built AU must be installed user-locally before running validation.
         let install_dir = install_dir(ctx, InstallScope::User, PluginFormat::Au)?;
-        install_artifact(&au, &install_dir)?;
+        for artifact in ctx.au_bundles(profile) {
+            ensure_exists(&artifact, "AU artifact")?;
+            install_artifact(&artifact, &install_dir)?;
+        }
 
         // The registrar caches component metadata, so it must be restarted to expose the newly placed AU.
         // If killall fails, auval may still detect the component, so treat this as best-effort.
@@ -728,14 +793,16 @@ fn clap_validator_executable(platform: Platform, validator_dir: &Path) -> PathBu
 }
 
 fn ensure_no_system_au_conflict(ctx: &Context) -> Result<()> {
-    let system_au =
-        Path::new("/Library/Audio/Plug-Ins/Components").join(ctx.metadata.au_bundle_name());
-    if system_au.exists() {
-        return Err(format!(
-            "system-wide AU already exists at {}. auval may validate that copy instead of the freshly built user-local AU. Remove the system-wide component and run validation again.",
-            system_au.display()
-        )
-        .into());
+    for plugin in &ctx.metadata.plugins {
+        let system_au = Path::new("/Library/Audio/Plug-Ins/Components")
+            .join(ctx.metadata.au_bundle_name(plugin));
+        if system_au.exists() {
+            return Err(format!(
+                "system-wide AU already exists at {}. auval may validate that copy instead of the freshly built user-local AU. Remove the system-wide component and run validation again.",
+                system_au.display()
+            )
+            .into());
+        }
     }
     Ok(())
 }
@@ -842,9 +909,15 @@ fn print_outputs(ctx: &Context, profile: BuildProfile, targets: &[Target]) {
         match target {
             Target::Clap => println!("CLAP: {}", ctx.clap_bundle(profile).display()),
             Target::Vst3 => println!("VST3: {}", ctx.vst3_bundle(profile).display()),
-            Target::Au => println!("AU: {}", ctx.au_bundle(profile).display()),
+            Target::Au => {
+                for artifact in ctx.au_bundles(profile) {
+                    println!("AU: {}", artifact.display());
+                }
+            }
             Target::Standalone => {
-                println!("Standalone: {}", ctx.standalone_artifact(profile).display())
+                for artifact in ctx.standalone_artifacts(profile) {
+                    println!("Standalone: {}", artifact.display());
+                }
             }
         }
     }
@@ -897,13 +970,18 @@ fn codesign(path: &Path) -> Result<()> {
     Ok(())
 }
 
-fn codesign_nested_macos_bundle(ctx: &Context, bundle: &Path) -> Result<()> {
-    let nested_clap = bundle
-        .join("Contents")
-        .join("PlugIns")
-        .join(ctx.metadata.clap_bundle_name());
-    if nested_clap.exists() {
-        codesign(&nested_clap)?;
+fn codesign_nested_macos_bundle(bundle: &Path) -> Result<()> {
+    let plugins_dir = bundle.join("Contents").join("PlugIns");
+    if plugins_dir.exists() {
+        for entry in fs::read_dir(&plugins_dir)? {
+            let path = entry?.path();
+            if path
+                .extension()
+                .is_some_and(|extension| extension == "clap")
+            {
+                codesign(&path)?;
+            }
+        }
     }
     codesign(bundle)?;
     Ok(())

--- a/crates/wrac_xtask/src/commands.rs
+++ b/crates/wrac_xtask/src/commands.rs
@@ -378,6 +378,9 @@ fn add_wrapper_product_args(ctx: &Context, command: &mut Command, build: Wrapper
     for (index, plugin) in ctx.metadata.plugins.iter().enumerate() {
         match build {
             WrapperBuild::Plugin { au: true, .. } => {
+                // CLAP/VST3 read product descriptors from the Rust plugin factory.
+                // AUv2 cannot, so only AUv2 builds need per-product output and
+                // four-character AudioComponent identity values from xtask.
                 command
                     .arg(format!(
                         "-DCLAP_WRAPPER_BUILDER_PRODUCT_{index}_OUTPUT_NAME={}",
@@ -393,6 +396,9 @@ fn add_wrapper_product_args(ctx: &Context, command: &mut Command, build: Wrapper
                     ));
             }
             WrapperBuild::Standalone => {
+                // Each standalone app embeds the product ID it should host at
+                // compile time; passing all standalone metadata keeps CMake from
+                // choosing an implicit primary product.
                 command
                     .arg(format!(
                         "-DCLAP_WRAPPER_BUILDER_PRODUCT_{index}_OUTPUT_NAME={}",
@@ -461,6 +467,8 @@ fn standalone_plugin_to_launch<'a>(
     }
     match ctx.metadata.plugins.as_slice() {
         [plugin] => Ok(plugin),
+        // Avoid silently launching the first product from a package whose
+        // metadata intentionally exposes more than one standalone artifact.
         plugins => Err(format!(
             "multiple plugin products found: {}. Use --plugin-id <PLUGIN_ID>.",
             plugins

--- a/crates/wrac_xtask/src/commands.rs
+++ b/crates/wrac_xtask/src/commands.rs
@@ -925,7 +925,7 @@ fn print_outputs(ctx: &Context, profile: BuildProfile, targets: &[Target]) {
 
 fn macos_clap_info_plist(metadata: &PluginMetadata) -> String {
     let plugin_name = &metadata.bundle_name;
-    let plugin_id = &metadata.primary_plugin().plugin_id;
+    let plugin_id = &metadata.bundle_identity_plugin().plugin_id;
     let version = &metadata.version;
     format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>

--- a/crates/wrac_xtask/src/context.rs
+++ b/crates/wrac_xtask/src/context.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use cargo_metadata::MetadataCommand;
 
-use crate::metadata::PluginMetadata;
+use crate::metadata::{PluginMetadata, PluginProductMetadata};
 use crate::profile::BuildProfile;
 use crate::targets::Platform;
 use crate::{Result, XtaskConfig};
@@ -104,16 +104,40 @@ impl Context {
             .join(self.metadata.vst3_bundle_name())
     }
 
-    pub(crate) fn au_bundle(&self, profile: BuildProfile) -> PathBuf {
-        self.plugins_dir(profile)
-            .join(self.metadata.au_bundle_name())
+    pub(crate) fn au_bundles(&self, profile: BuildProfile) -> Vec<PathBuf> {
+        self.metadata
+            .plugins
+            .iter()
+            .map(|plugin| self.au_bundle(profile, plugin))
+            .collect()
     }
 
-    pub(crate) fn standalone_artifact(&self, profile: BuildProfile) -> PathBuf {
+    pub(crate) fn au_bundle(
+        &self,
+        profile: BuildProfile,
+        plugin: &PluginProductMetadata,
+    ) -> PathBuf {
+        self.plugins_dir(profile)
+            .join(self.metadata.au_bundle_name(plugin))
+    }
+
+    pub(crate) fn standalone_artifacts(&self, profile: BuildProfile) -> Vec<PathBuf> {
+        self.metadata
+            .plugins
+            .iter()
+            .map(|plugin| self.standalone_artifact_for(profile, plugin))
+            .collect()
+    }
+
+    pub(crate) fn standalone_artifact_for(
+        &self,
+        profile: BuildProfile,
+        plugin: &PluginProductMetadata,
+    ) -> PathBuf {
         let filename = match self.platform {
-            Platform::Macos => format!("{}.app", self.metadata.standalone_name),
-            Platform::Windows => format!("{}.exe", self.metadata.standalone_name),
-            Platform::Linux => self.metadata.standalone_name.clone(),
+            Platform::Macos => format!("{}.app", plugin.standalone_name),
+            Platform::Windows => format!("{}.exe", plugin.standalone_name),
+            Platform::Linux => plugin.standalone_name.clone(),
         };
         self.standalone_dir(profile).join(filename)
     }

--- a/crates/wrac_xtask/src/context.rs
+++ b/crates/wrac_xtask/src/context.rs
@@ -117,6 +117,8 @@ impl Context {
         profile: BuildProfile,
         plugin: &PluginProductMetadata,
     ) -> PathBuf {
+        // AUv2 products are installed as separate component bundles, named by
+        // product display name rather than the shared CLAP/VST3 bundle name.
         self.plugins_dir(profile)
             .join(self.metadata.au_bundle_name(plugin))
     }
@@ -134,6 +136,9 @@ impl Context {
         profile: BuildProfile,
         plugin: &PluginProductMetadata,
     ) -> PathBuf {
+        // Standalone app names are product metadata so multi-product templates
+        // can expose distinct launchable artifacts without deriving names from
+        // bundle-level metadata.
         let filename = match self.platform {
             Platform::Macos => format!("{}.app", plugin.standalone_name),
             Platform::Windows => format!("{}.exe", plugin.standalone_name),

--- a/crates/wrac_xtask/src/context.rs
+++ b/crates/wrac_xtask/src/context.rs
@@ -40,7 +40,7 @@ impl Context {
         let target_dir = target_root
             .join(&config.target_namespace)
             .join(&package.artifact_namespace);
-        // CLAP_WRAPPER_DIR remains an escape hatch for testing SDK changes or a temporary external checkout.
+        // CLAP_WRAPPER_DIR lets wrapper developers point xtask at another clap_wrapper_builder checkout.
         let wrapper_dir = std::env::var_os("CLAP_WRAPPER_DIR")
             .map(PathBuf::from)
             .unwrap_or_else(|| config.wrapper_dir.clone());

--- a/crates/wrac_xtask/src/lib.rs
+++ b/crates/wrac_xtask/src/lib.rs
@@ -69,7 +69,11 @@ pub fn run(config: XtaskConfig) -> Result<()> {
             let package = selected_package(&config, args.package.as_deref())?;
             let ctx = Context::new(&config, &package)?;
             build(&ctx, args_for_launch_build(&args))?;
-            launch(&ctx, BuildProfile::from_release(args.release))?;
+            launch(
+                &ctx,
+                BuildProfile::from_release(args.release),
+                args.plugin_id.as_deref(),
+            )?;
         }
         Commands::Clean(args) => {
             for package in selected_packages(&config, args.package.as_deref(), args.all)? {

--- a/crates/wrac_xtask/src/metadata.rs
+++ b/crates/wrac_xtask/src/metadata.rs
@@ -14,7 +14,6 @@ pub(crate) struct PluginMetadata {
     pub(crate) company_name: String,
     pub(crate) auv2_manufacturer_code: String,
     pub(crate) bundle_name: String,
-    pub(crate) standalone_name: String,
     pub(crate) plugins: Vec<PluginProductMetadata>,
     pub(crate) validation: ValidationMetadata,
 }
@@ -34,6 +33,7 @@ pub(crate) struct DisabledValidationRule {
 pub(crate) struct PluginProductMetadata {
     pub(crate) plugin_id: String,
     pub(crate) plugin_name: String,
+    pub(crate) standalone_name: String,
     pub(crate) auv2_type: String,
     pub(crate) auv2_subtype: String,
 }
@@ -55,7 +55,6 @@ impl PluginMetadata {
             company_name: wrac.company_name,
             auv2_manufacturer_code: wrac.auv2_manufacturer_code,
             bundle_name: wrac.bundle_name,
-            standalone_name: wrac.standalone_name,
             plugins: wrac.plugins,
             validation: wrac.validation.unwrap_or_default(),
         };
@@ -71,15 +70,13 @@ impl PluginMetadata {
         format!("{}.vst3", self.bundle_name)
     }
 
-    pub(crate) fn au_bundle_name(&self) -> String {
-        format!("{}.component", self.bundle_name)
+    pub(crate) fn au_bundle_name(&self, plugin: &PluginProductMetadata) -> String {
+        format!("{}.component", plugin.plugin_name)
     }
 
     pub(crate) fn primary_plugin(&self) -> &PluginProductMetadata {
         // WRAC bundles may expose multiple plugin products from one binary, but wrapper
-        // fallbacks and standalone launch still need one stable identity. The first
-        // metadata entry is that primary product; validation and generated Rust metadata
-        // still cover every entry in `plugins`.
+        // bundle-level metadata still needs one stable identity.
         self.plugins
             .first()
             .expect("validated metadata must contain at least one plugin")
@@ -90,15 +87,12 @@ impl PluginMetadata {
         validate_required("package.version", &self.version)?;
         validate_required("package.metadata.wrac.company_name", &self.company_name)?;
         validate_required("package.metadata.wrac.bundle_name", &self.bundle_name)?;
-        validate_required(
-            "package.metadata.wrac.standalone_name",
-            &self.standalone_name,
-        )?;
         if self.plugins.is_empty() {
             return Err("package.metadata.wrac.plugins must contain at least one plugin".into());
         }
         validate_four_ascii("auv2_manufacturer_code", &self.auv2_manufacturer_code)?;
         let mut plugin_ids = HashSet::new();
+        let mut standalone_names = HashSet::new();
         let mut auv2_ids = HashSet::new();
         for plugin in &self.plugins {
             validate_required("package.metadata.wrac.plugins.plugin_id", &plugin.plugin_id)?;
@@ -106,12 +100,23 @@ impl PluginMetadata {
                 "package.metadata.wrac.plugins.plugin_name",
                 &plugin.plugin_name,
             )?;
+            validate_required(
+                "package.metadata.wrac.plugins.standalone_name",
+                &plugin.standalone_name,
+            )?;
             validate_four_ascii("auv2_type", &plugin.auv2_type)?;
             validate_four_ascii("auv2_subtype", &plugin.auv2_subtype)?;
             if !plugin_ids.insert(plugin.plugin_id.as_str()) {
                 return Err(format!(
                     "duplicate package.metadata.wrac.plugins plugin_id: {}",
                     plugin.plugin_id
+                )
+                .into());
+            }
+            if !standalone_names.insert(plugin.standalone_name.as_str()) {
+                return Err(format!(
+                    "duplicate package.metadata.wrac.plugins standalone_name: {}",
+                    plugin.standalone_name
                 )
                 .into());
             }
@@ -173,7 +178,6 @@ struct WracMetadata {
     company_name: String,
     auv2_manufacturer_code: String,
     bundle_name: String,
-    standalone_name: String,
     #[serde(default)]
     plugins: Vec<PluginProductMetadata>,
     validation: Option<ValidationMetadata>,

--- a/crates/wrac_xtask/src/metadata.rs
+++ b/crates/wrac_xtask/src/metadata.rs
@@ -74,7 +74,7 @@ impl PluginMetadata {
         format!("{}.component", plugin.plugin_name)
     }
 
-    pub(crate) fn primary_plugin(&self) -> &PluginProductMetadata {
+    pub(crate) fn bundle_identity_plugin(&self) -> &PluginProductMetadata {
         // WRAC bundles may expose multiple plugin products from one binary, but wrapper
         // bundle-level metadata still needs one stable identity.
         self.plugins

--- a/crates/wrac_xtask/src/metadata.rs
+++ b/crates/wrac_xtask/src/metadata.rs
@@ -75,8 +75,10 @@ impl PluginMetadata {
     }
 
     pub(crate) fn bundle_identity_plugin(&self) -> &PluginProductMetadata {
-        // WRAC bundles may expose multiple plugin products from one binary, but wrapper
-        // bundle-level metadata still needs one stable identity.
+        // CLAP bundle Info.plist has one CFBundleIdentifier even when the CLAP
+        // factory exposes multiple products. Use the first metadata entry only
+        // for that bundle-level identifier; product-specific outputs must still
+        // iterate over `plugins`.
         self.plugins
             .first()
             .expect("validated metadata must contain at least one plugin")

--- a/crates/wrac_xtask/src/validation/checks.rs
+++ b/crates/wrac_xtask/src/validation/checks.rs
@@ -269,14 +269,6 @@ fn template_placeholder_violations(
         &metadata.bundle_name,
         "WRAC Gain",
     );
-    check_template_placeholder(
-        &mut violations,
-        &subject,
-        location,
-        "package.metadata.wrac.standalone_name",
-        &metadata.standalone_name,
-        "WRAC Gain",
-    );
     for plugin in &metadata.plugins {
         check_template_placeholder(
             &mut violations,
@@ -292,6 +284,14 @@ fn template_placeholder_violations(
             location,
             "package.metadata.wrac.plugins.plugin_name",
             &plugin.plugin_name,
+            "WRAC Gain",
+        );
+        check_template_placeholder(
+            &mut violations,
+            &subject,
+            location,
+            "package.metadata.wrac.plugins.standalone_name",
+            &plugin.standalone_name,
             "WRAC Gain",
         );
         check_template_placeholder(
@@ -493,10 +493,10 @@ mod tests {
             company_name: "Example".to_string(),
             auv2_manufacturer_code: "ExCo".to_string(),
             bundle_name: "Test Plugin".to_string(),
-            standalone_name: "Test Plugin Standalone".to_string(),
             plugins: vec![PluginProductMetadata {
                 plugin_id: "com.example.test".to_string(),
                 plugin_name: "Test Plugin".to_string(),
+                standalone_name: "Test Plugin Standalone".to_string(),
                 auv2_type: "aufx".to_string(),
                 auv2_subtype: "TstP".to_string(),
             }],

--- a/crates/wrac_xtask/src/validation/checks.rs
+++ b/crates/wrac_xtask/src/validation/checks.rs
@@ -406,9 +406,9 @@ struct CheckSubject {
 
 impl CheckSubject {
     fn bundle(metadata: &PluginMetadata) -> Self {
-        let primary = metadata.primary_plugin();
+        let bundle_identity = metadata.bundle_identity_plugin();
         Self {
-            plugin_id: primary.plugin_id.clone(),
+            plugin_id: bundle_identity.plugin_id.clone(),
             plugin_name: metadata.bundle_name.clone(),
         }
     }

--- a/docs/setup-ja.md
+++ b/docs/setup-ja.md
@@ -59,11 +59,11 @@ VST3 / AU、開発用 standalone app、または VST3 / AU の検証を行う場
 company_name = "Your Company"
 auv2_manufacturer_code = "YrCo"
 bundle_name = "My Plugin"
-standalone_name = "My Plugin Standalone"
 
 [[package.metadata.wrac.plugins]]
 plugin_id = "com.your-company.my-plugin"
 plugin_name = "My Plugin"
+standalone_name = "My Plugin Standalone"
 auv2_type = "aufx"
 auv2_subtype = "MyPl"
 ```

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -59,11 +59,11 @@ Edit `[package.metadata.wrac]` first.
 company_name = "Your Company"
 auv2_manufacturer_code = "YrCo"
 bundle_name = "My Plugin"
-standalone_name = "My Plugin Standalone"
 
 [[package.metadata.wrac.plugins]]
 plugin_id = "com.your-company.my-plugin"
 plugin_name = "My Plugin"
+standalone_name = "My Plugin Standalone"
 auv2_type = "aufx"
 auv2_subtype = "MyPl"
 ```

--- a/plugins/wrac-gain/src-plugin/Cargo.toml
+++ b/plugins/wrac-gain/src-plugin/Cargo.toml
@@ -17,8 +17,6 @@ company_name = "Your Company"
 auv2_manufacturer_code = "YrCo"
 # User-visible bundle name.
 bundle_name = "WRAC Gain"
-# User-visible standalone app name.
-standalone_name = "WRAC Gain Standalone"
 
 [package.metadata.wrac.validation.disabled_rules.fender-studio-pro-generic-editor-single-knob]
 reason = "WRAC Gain is a minimal one-knob starter example. Products that support Fender Studio Pro should add a second real visible control instead of shipping this exception."
@@ -28,6 +26,8 @@ reason = "WRAC Gain is a minimal one-knob starter example. Products that support
 plugin_id = "com.your-company.wrac-gain"
 # User-visible plugin name shown by hosts and the template GUI.
 plugin_name = "WRAC Gain"
+# User-visible standalone app name.
+standalone_name = "WRAC Gain Standalone"
 # AUv2 component type. Audio effects usually use "aufx"; instruments usually use "aumu".
 auv2_type = "aufx"
 # AUv2 subtype. Pick a unique 4-byte ASCII code for each plugin from the same vendor.

--- a/plugins/wrac-gain/src-plugin/build.rs
+++ b/plugins/wrac-gain/src-plugin/build.rs
@@ -132,6 +132,7 @@ struct WracMetadata {
 struct WracPluginMetadata {
     plugin_id: String,
     plugin_name: String,
+    standalone_name: String,
     auv2_type: String,
     auv2_subtype: String,
 }
@@ -151,6 +152,7 @@ fn read_wrac_metadata(manifest_path: &Path) -> io::Result<WracMetadata> {
         return Err(missing_metadata("plugins"));
     }
     let mut plugin_ids = HashSet::new();
+    let mut standalone_names = HashSet::new();
     let mut auv2_subtypes = HashSet::new();
     for plugin in &metadata.plugins {
         validate_required("package.metadata.wrac.plugins.plugin_id", &plugin.plugin_id)?;
@@ -158,9 +160,18 @@ fn read_wrac_metadata(manifest_path: &Path) -> io::Result<WracMetadata> {
             "package.metadata.wrac.plugins.plugin_name",
             &plugin.plugin_name,
         )?;
+        validate_required(
+            "package.metadata.wrac.plugins.standalone_name",
+            &plugin.standalone_name,
+        )?;
         validate_four_ascii("auv2_type", &plugin.auv2_type)?;
         validate_four_ascii("auv2_subtype", &plugin.auv2_subtype)?;
         validate_unique("plugin_id", &plugin.plugin_id, &mut plugin_ids)?;
+        validate_unique(
+            "standalone_name",
+            &plugin.standalone_name,
+            &mut standalone_names,
+        )?;
         validate_unique("auv2_subtype", &plugin.auv2_subtype, &mut auv2_subtypes)?;
     }
     Ok(metadata)

--- a/plugins/wrac-gain/src-plugin/build.rs
+++ b/plugins/wrac-gain/src-plugin/build.rs
@@ -153,7 +153,7 @@ fn read_wrac_metadata(manifest_path: &Path) -> io::Result<WracMetadata> {
     }
     let mut plugin_ids = HashSet::new();
     let mut standalone_names = HashSet::new();
-    let mut auv2_subtypes = HashSet::new();
+    let mut auv2_ids = HashSet::new();
     for plugin in &metadata.plugins {
         validate_required("package.metadata.wrac.plugins.plugin_id", &plugin.plugin_id)?;
         validate_required(
@@ -172,7 +172,15 @@ fn read_wrac_metadata(manifest_path: &Path) -> io::Result<WracMetadata> {
             &plugin.standalone_name,
             &mut standalone_names,
         )?;
-        validate_unique("auv2_subtype", &plugin.auv2_subtype, &mut auv2_subtypes)?;
+        if !auv2_ids.insert((plugin.auv2_type.as_str(), plugin.auv2_subtype.as_str())) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "package.metadata.wrac.plugins AUv2 type/subtype must be unique: {}/{}",
+                    plugin.auv2_type, plugin.auv2_subtype
+                ),
+            ));
+        }
     }
     Ok(metadata)
 }


### PR DESCRIPTION
## Summary
- Treat `package.metadata.wrac.plugins` as the product list for wrapper builds
- Generate AUv2 and standalone artifacts by looping over products instead of using a primary-product path
- Move standalone app names into product metadata and require `--plugin-id` for multi-product launch

## Verification
- `cargo fmt`
- `cargo test -p wrac_xtask`
- `cargo check --manifest-path plugins/wrac-gain/src-plugin/Cargo.toml --target-dir target/check-plugin-metadata`
- `git diff --check`
- CMake configure smoke check for N=2 standalone
- CMake configure smoke check for N=1 standalone
- CMake configure smoke check for N=2 AUv2`