### PR TITLE
Clean up commercial plugin metadata

### DIFF
--- a/crates/wrac_clap_adapter/src/abi.rs
+++ b/crates/wrac_clap_adapter/src/abi.rs
@@ -50,8 +50,9 @@ use crate::entry::{
     increment_entry_init_count, reset_entry_init_count,
 };
 use crate::factory::{
-    Auv2FactoryState, ClapPluginFactoryAsAuv2, ClapPluginInfoAsAuv2, auv2_factory_ptr,
-    auv2_factory_state, clap_factory_state, factory_ptr,
+    Auv2FactoryState, ClapPluginFactoryAsAuv2, ClapPluginFactoryAsVst3, ClapPluginInfoAsAuv2,
+    ClapPluginInfoAsVst3, Vst3FactoryState, auv2_factory_ptr, auv2_factory_state,
+    clap_factory_state, factory_ptr, vst3_factory_ptr, vst3_factory_state,
 };
 use crate::host_gui::HostGuiResizeRequest;
 use crate::host_state::HostStateDirtyNotification;
@@ -67,6 +68,9 @@ use crate::{
 // separate AU manufacturer/subtype, it can collide with the generic wrapper identity
 // and cause auval to validate a different, older plugin instead.
 const CLAP_PLUGIN_FACTORY_INFO_AUV2: &CStr = c"clap.plugin-factory-info-as-auv2.draft0";
+// clap-wrapper can infer VST3 metadata from CLAP descriptors, but commercial products
+// need stable VST3 class IDs and explicit host browser categories across wrapper updates.
+const CLAP_PLUGIN_FACTORY_INFO_VST3: &CStr = c"clap.plugin-factory-info-as-vst3/0";
 
 /// Synchronization boundary between a CLAP instance and the Rust core.
 ///
@@ -415,9 +419,33 @@ pub(crate) unsafe extern "C" fn entry_get_factory(
                 .any(|descriptor| descriptor.descriptor().auv2.is_some())
         {
             auv2_factory_ptr(storage)
+        } else if factory_id == CLAP_PLUGIN_FACTORY_INFO_VST3
+            && storage
+                .descriptors
+                .iter()
+                .any(|descriptor| descriptor.descriptor().vst3.is_some())
+        {
+            vst3_factory_ptr(storage)
         } else {
             ptr::null()
         }
+    })
+}
+
+pub(crate) unsafe extern "C" fn vst3_get_info(
+    factory: *const ClapPluginFactoryAsVst3,
+    index: u32,
+) -> *const ClapPluginInfoAsVst3 {
+    ffi_ptr(|| {
+        let Some(Vst3FactoryState { registration, .. }) = vst3_factory_state(factory) else {
+            log::warn!("vst3.get_info: invalid factory pointer");
+            return ptr::null();
+        };
+        let Some(descriptor) = registration.storage().descriptors.get(index as usize) else {
+            log::warn!("vst3.get_info: descriptor not found index={index}");
+            return ptr::null();
+        };
+        descriptor.vst3_info_ptr().unwrap_or(ptr::null())
     })
 }
 

--- a/crates/wrac_clap_adapter/src/descriptor.rs
+++ b/crates/wrac_clap_adapter/src/descriptor.rs
@@ -20,6 +20,8 @@ use clap_sys::plugin_features::{
 };
 use clap_sys::version::CLAP_VERSION;
 
+use crate::factory::ClapPluginInfoAsVst3;
+
 #[derive(Debug, Clone, Copy)]
 pub struct PluginDescriptor {
     pub id: &'static str,
@@ -32,6 +34,7 @@ pub struct PluginDescriptor {
     pub description: &'static str,
     pub features: &'static [PluginFeature],
     pub auv2: Option<Auv2Descriptor>,
+    pub vst3: Option<Vst3Descriptor>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -131,6 +134,14 @@ pub struct Auv2Descriptor {
     pub plugin_subtype: [u8; 4],
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct Vst3Descriptor {
+    /// VST3 PClassInfo2 subCategories string, such as `Fx|Tools`.
+    pub subcategories: &'static str,
+    /// Stable VST3 class ID. Changing this after release breaks host project recall.
+    pub component_id: [u8; 16],
+}
+
 // `clap_plugin_descriptor` holds only C string pointers, so the owners of the CString
 // and feature pointer arrays are placed in the same storage to keep their lifetimes
 // aligned with the descriptor pointer.
@@ -147,6 +158,11 @@ pub(crate) struct ClapDescriptorStorage {
     _feature_ptrs: Vec<*const c_char>,
     auv2_manufacturer_code: Option<CString>,
     auv2_manufacturer_name: Option<CString>,
+    // `vst3_info` exposes raw pointers to these owners through clap-wrapper's
+    // factory extension; keep them in the same storage as the descriptor.
+    _vst3_subcategories: Option<CString>,
+    _vst3_component_id: Option<Box<[u8; 16]>>,
+    vst3_info: Option<ClapPluginInfoAsVst3>,
     clap_descriptor: clap_plugin_descriptor,
 }
 
@@ -178,6 +194,18 @@ impl ClapDescriptorStorage {
             .auv2
             .map(|auv2| CString::new(auv2.manufacturer_code).expect("four char code"));
         let auv2_manufacturer_name = descriptor.auv2.map(|auv2| cstring(auv2.manufacturer_name));
+        let vst3_subcategories = descriptor.vst3.map(|vst3| cstring(vst3.subcategories));
+        let vst3_component_id = descriptor.vst3.map(|vst3| Box::new(vst3.component_id));
+        let vst3_info = descriptor.vst3.map(|_| ClapPluginInfoAsVst3 {
+            vendor: vendor.as_ptr(),
+            component_id: vst3_component_id
+                .as_deref()
+                .map_or(ptr::null(), |value| value as *const [u8; 16]),
+            features: vst3_subcategories
+                .as_ref()
+                .map(|value| value.as_ptr())
+                .unwrap_or(ptr::null()),
+        });
 
         let clap_descriptor = clap_plugin_descriptor {
             clap_version: CLAP_VERSION,
@@ -205,12 +233,23 @@ impl ClapDescriptorStorage {
             _feature_ptrs: feature_ptrs,
             auv2_manufacturer_code,
             auv2_manufacturer_name,
+            _vst3_subcategories: vst3_subcategories,
+            _vst3_component_id: vst3_component_id,
+            vst3_info,
             clap_descriptor,
         }
     }
 
     pub(crate) fn clap_descriptor(&self) -> *const clap_plugin_descriptor {
         &self.clap_descriptor
+    }
+
+    pub(crate) fn vendor_ptr(&self) -> *const c_char {
+        self.clap_descriptor.vendor
+    }
+
+    pub(crate) fn url_ptr(&self) -> *const c_char {
+        self.clap_descriptor.url
     }
 
     pub(crate) fn auv2_manufacturer_code_ptr(&self) -> Option<*const c_char> {
@@ -223,6 +262,12 @@ impl ClapDescriptorStorage {
         self.auv2_manufacturer_name
             .as_ref()
             .map(|value| value.as_ptr())
+    }
+
+    pub(crate) fn vst3_info_ptr(&self) -> Option<*const ClapPluginInfoAsVst3> {
+        self.vst3_info
+            .as_ref()
+            .map(|value| value as *const ClapPluginInfoAsVst3)
     }
 
     pub(crate) fn descriptor(&self) -> PluginDescriptor {

--- a/crates/wrac_clap_adapter/src/factory.rs
+++ b/crates/wrac_clap_adapter/src/factory.rs
@@ -9,6 +9,7 @@ use crate::entry::EntryRegistration;
 pub(crate) struct PluginRegistrationStorage {
     pub clap_factory: ClapFactoryState,
     pub auv2_factory: Auv2FactoryState,
+    pub vst3_factory: Vst3FactoryState,
     pub descriptors: Vec<ClapDescriptorStorage>,
 }
 
@@ -53,6 +54,21 @@ impl PluginRegistrationStorage {
                 },
                 registration,
             },
+            vst3_factory: Vst3FactoryState {
+                factory: ClapPluginFactoryAsVst3 {
+                    vendor: descriptors
+                        .first()
+                        .map(ClapDescriptorStorage::vendor_ptr)
+                        .unwrap_or(ptr::null()),
+                    vendor_url: descriptors
+                        .first()
+                        .map(ClapDescriptorStorage::url_ptr)
+                        .unwrap_or(ptr::null()),
+                    email_contact: ptr::null(),
+                    get_vst3_info: Some(crate::abi::vst3_get_info),
+                },
+                registration,
+            },
             descriptors,
         }
     }
@@ -79,6 +95,15 @@ unsafe impl Sync for Auv2FactoryState {}
 unsafe impl Send for Auv2FactoryState {}
 
 #[repr(C)]
+pub(crate) struct Vst3FactoryState {
+    pub factory: ClapPluginFactoryAsVst3,
+    pub registration: &'static EntryRegistration,
+}
+
+unsafe impl Sync for Vst3FactoryState {}
+unsafe impl Send for Vst3FactoryState {}
+
+#[repr(C)]
 pub(crate) struct ClapPluginInfoAsAuv2 {
     pub au_type: [c_char; 5],
     pub au_subt: [c_char; 5],
@@ -100,6 +125,32 @@ pub(crate) struct ClapPluginFactoryAsAuv2 {
 unsafe impl Sync for ClapPluginFactoryAsAuv2 {}
 unsafe impl Send for ClapPluginFactoryAsAuv2 {}
 
+#[repr(C)]
+pub(crate) struct ClapPluginInfoAsVst3 {
+    pub vendor: *const c_char,
+    pub component_id: *const [u8; 16],
+    pub features: *const c_char,
+}
+
+unsafe impl Sync for ClapPluginInfoAsVst3 {}
+unsafe impl Send for ClapPluginInfoAsVst3 {}
+
+#[repr(C)]
+pub(crate) struct ClapPluginFactoryAsVst3 {
+    pub vendor: *const c_char,
+    pub vendor_url: *const c_char,
+    pub email_contact: *const c_char,
+    pub get_vst3_info: Option<
+        unsafe extern "C" fn(
+            factory: *const ClapPluginFactoryAsVst3,
+            index: u32,
+        ) -> *const ClapPluginInfoAsVst3,
+    >,
+}
+
+unsafe impl Sync for ClapPluginFactoryAsVst3 {}
+unsafe impl Send for ClapPluginFactoryAsVst3 {}
+
 pub(crate) fn clap_factory_state(
     factory: *const clap_plugin_factory,
 ) -> Option<&'static ClapFactoryState> {
@@ -118,10 +169,23 @@ pub(crate) fn auv2_factory_state(
     Some(unsafe { &*(factory as *const Auv2FactoryState) })
 }
 
+pub(crate) fn vst3_factory_state(
+    factory: *const ClapPluginFactoryAsVst3,
+) -> Option<&'static Vst3FactoryState> {
+    if factory.is_null() {
+        return None;
+    }
+    Some(unsafe { &*(factory as *const Vst3FactoryState) })
+}
+
 pub(crate) fn factory_ptr(storage: &'static PluginRegistrationStorage) -> *const c_void {
     &storage.clap_factory.factory as *const clap_plugin_factory as *const c_void
 }
 
 pub(crate) fn auv2_factory_ptr(storage: &'static PluginRegistrationStorage) -> *const c_void {
     &storage.auv2_factory.factory as *const ClapPluginFactoryAsAuv2 as *const c_void
+}
+
+pub(crate) fn vst3_factory_ptr(storage: &'static PluginRegistrationStorage) -> *const c_void {
+    &storage.vst3_factory.factory as *const ClapPluginFactoryAsVst3 as *const c_void
 }

--- a/crates/wrac_clap_adapter/src/lib.rs
+++ b/crates/wrac_clap_adapter/src/lib.rs
@@ -27,7 +27,7 @@ pub use api::{
     PluginResult, PluginStateExtension, PluginTailExtension, ProcessContext, ProcessStatus,
     Processor, State,
 };
-pub use descriptor::{Auv2Descriptor, PluginDescriptor, PluginFeature};
+pub use descriptor::{Auv2Descriptor, PluginDescriptor, PluginFeature, Vst3Descriptor};
 pub use entry::{EntryContext, PluginEntry, PluginFactory};
 pub use events::{
     InputEvent, InputEvents, Midi2Event, MidiEvent, MidiSysexEvent, NoteEvent, NoteExpressionEvent,

--- a/crates/wrac_xtask/src/commands.rs
+++ b/crates/wrac_xtask/src/commands.rs
@@ -933,8 +933,12 @@ fn print_outputs(ctx: &Context, profile: BuildProfile, targets: &[Target]) {
 
 fn macos_clap_info_plist(metadata: &PluginMetadata) -> String {
     let plugin_name = &metadata.bundle_name;
-    let plugin_id = &metadata.bundle_identity_plugin().plugin_id;
+    // A CLAP bundle has one CFBundleIdentifier even when the factory exposes
+    // multiple products. Keep macOS bundle identity separate from product IDs so
+    // adding another product does not silently change the installed bundle.
+    let bundle_identifier = &metadata.bundle_identifier;
     let version = &metadata.version;
+    let copyright = &metadata.copyright;
     format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -945,7 +949,7 @@ fn macos_clap_info_plist(metadata: &PluginMetadata) -> String {
     <key>CFBundleIconFile</key>
     <string></string>
     <key>CFBundleIdentifier</key>
-    <string>{plugin_id}</string>
+    <string>{bundle_identifier}</string>
     <key>CFBundleName</key>
     <string>{plugin_name}</string>
     <key>CFBundleDisplayName</key>
@@ -959,7 +963,7 @@ fn macos_clap_info_plist(metadata: &PluginMetadata) -> String {
     <key>CFBundleVersion</key>
     <string>{version}</string>
     <key>NSHumanReadableCopyright</key>
-    <string></string>
+    <string>{copyright}</string>
     <key>NSHighResolutionCapable</key>
     <true/>
   </dict>

--- a/crates/wrac_xtask/src/metadata.rs
+++ b/crates/wrac_xtask/src/metadata.rs
@@ -40,6 +40,8 @@ pub(crate) struct PluginProductMetadata {
     pub(crate) plugin_id: String,
     pub(crate) plugin_name: String,
     pub(crate) clap_features: Vec<String>,
+    pub(crate) vst3_subcategories: String,
+    pub(crate) vst3_component_id: String,
     pub(crate) standalone_name: String,
     pub(crate) auv2_type: String,
     pub(crate) auv2_subtype: String,
@@ -132,6 +134,14 @@ impl PluginMetadata {
                 validate_clap_feature(feature)?;
             }
             validate_required(
+                "package.metadata.wrac.plugins.vst3_subcategories",
+                &plugin.vst3_subcategories,
+            )?;
+            validate_uuid(
+                "package.metadata.wrac.plugins.vst3_component_id",
+                &plugin.vst3_component_id,
+            )?;
+            validate_required(
                 "package.metadata.wrac.plugins.standalone_name",
                 &plugin.standalone_name,
             )?;
@@ -198,6 +208,15 @@ fn validate_four_ascii(key: &str, value: &str) -> Result<()> {
         Ok(())
     } else {
         Err(format!("package.metadata.wrac.{key} must be exactly 4 ASCII bytes").into())
+    }
+}
+
+fn validate_uuid(label: &str, value: &str) -> Result<()> {
+    let hex = value.replace('-', "");
+    if hex.len() == 32 && hex.as_bytes().iter().all(u8::is_ascii_hexdigit) {
+        Ok(())
+    } else {
+        Err(format!("{label} must be a UUID").into())
     }
 }
 

--- a/crates/wrac_xtask/src/metadata.rs
+++ b/crates/wrac_xtask/src/metadata.rs
@@ -14,6 +14,12 @@ pub(crate) struct PluginMetadata {
     pub(crate) company_name: String,
     pub(crate) auv2_manufacturer_code: String,
     pub(crate) bundle_name: String,
+    pub(crate) bundle_identifier: String,
+    pub(crate) homepage_url: String,
+    pub(crate) manual_url: String,
+    pub(crate) support_url: String,
+    pub(crate) description: String,
+    pub(crate) copyright: String,
     pub(crate) plugins: Vec<PluginProductMetadata>,
     pub(crate) validation: ValidationMetadata,
 }
@@ -33,6 +39,7 @@ pub(crate) struct DisabledValidationRule {
 pub(crate) struct PluginProductMetadata {
     pub(crate) plugin_id: String,
     pub(crate) plugin_name: String,
+    pub(crate) clap_features: Vec<String>,
     pub(crate) standalone_name: String,
     pub(crate) auv2_type: String,
     pub(crate) auv2_subtype: String,
@@ -55,6 +62,12 @@ impl PluginMetadata {
             company_name: wrac.company_name,
             auv2_manufacturer_code: wrac.auv2_manufacturer_code,
             bundle_name: wrac.bundle_name,
+            bundle_identifier: wrac.bundle_identifier,
+            homepage_url: wrac.homepage_url,
+            manual_url: wrac.manual_url,
+            support_url: wrac.support_url,
+            description: wrac.description,
+            copyright: wrac.copyright,
             plugins: wrac.plugins,
             validation: wrac.validation.unwrap_or_default(),
         };
@@ -88,11 +101,20 @@ impl PluginMetadata {
         validate_required("package.name", &self.package_name)?;
         validate_required("package.version", &self.version)?;
         validate_required("package.metadata.wrac.company_name", &self.company_name)?;
+        validate_four_ascii("auv2_manufacturer_code", &self.auv2_manufacturer_code)?;
         validate_required("package.metadata.wrac.bundle_name", &self.bundle_name)?;
+        validate_required(
+            "package.metadata.wrac.bundle_identifier",
+            &self.bundle_identifier,
+        )?;
+        validate_required("package.metadata.wrac.homepage_url", &self.homepage_url)?;
+        validate_required("package.metadata.wrac.manual_url", &self.manual_url)?;
+        validate_required("package.metadata.wrac.support_url", &self.support_url)?;
+        validate_required("package.metadata.wrac.description", &self.description)?;
+        validate_required("package.metadata.wrac.copyright", &self.copyright)?;
         if self.plugins.is_empty() {
             return Err("package.metadata.wrac.plugins must contain at least one plugin".into());
         }
-        validate_four_ascii("auv2_manufacturer_code", &self.auv2_manufacturer_code)?;
         let mut plugin_ids = HashSet::new();
         let mut standalone_names = HashSet::new();
         let mut auv2_ids = HashSet::new();
@@ -102,6 +124,13 @@ impl PluginMetadata {
                 "package.metadata.wrac.plugins.plugin_name",
                 &plugin.plugin_name,
             )?;
+            if plugin.clap_features.is_empty() {
+                return Err("package.metadata.wrac.plugins.clap_features must not be empty".into());
+            }
+            for feature in &plugin.clap_features {
+                validate_required("package.metadata.wrac.plugins.clap_features", feature)?;
+                validate_clap_feature(feature)?;
+            }
             validate_required(
                 "package.metadata.wrac.plugins.standalone_name",
                 &plugin.standalone_name,
@@ -137,6 +166,22 @@ impl PluginMetadata {
             )?;
         }
         Ok(())
+    }
+}
+
+fn validate_clap_feature(feature: &str) -> Result<()> {
+    match feature {
+        "audio-effect" | "analyzer" | "ambisonic" | "chorus" | "compressor" | "de-esser"
+        | "delay" | "instrument" | "note-effect" | "note-detector" | "drum" | "drum-machine"
+        | "equalizer" | "expander" | "filter" | "flanger" | "frequency-shifter" | "gate"
+        | "glitch" | "granular" | "distortion" | "limiter" | "mastering" | "mixing" | "mono"
+        | "multi-effects" | "phaser" | "phase-vocoder" | "pitch-correction" | "pitch-shifter"
+        | "restoration" | "reverb" | "sampler" | "stereo" | "surround" | "synthesizer"
+        | "transient-shaper" | "tremolo" | "utility" => Ok(()),
+        _ => Err(format!(
+            "unsupported package.metadata.wrac.plugins.clap_features value: {feature}"
+        )
+        .into()),
     }
 }
 
@@ -180,6 +225,12 @@ struct WracMetadata {
     company_name: String,
     auv2_manufacturer_code: String,
     bundle_name: String,
+    bundle_identifier: String,
+    homepage_url: String,
+    manual_url: String,
+    support_url: String,
+    description: String,
+    copyright: String,
     #[serde(default)]
     plugins: Vec<PluginProductMetadata>,
     validation: Option<ValidationMetadata>,

--- a/crates/wrac_xtask/src/validation/checks.rs
+++ b/crates/wrac_xtask/src/validation/checks.rs
@@ -265,6 +265,54 @@ fn template_placeholder_violations(
         &mut violations,
         &subject,
         location,
+        "package.metadata.wrac.auv2_manufacturer_code",
+        &metadata.auv2_manufacturer_code,
+        "YrCo",
+    );
+    check_template_placeholder(
+        &mut violations,
+        &subject,
+        location,
+        "package.metadata.wrac.bundle_identifier",
+        &metadata.bundle_identifier,
+        "com.your-company",
+    );
+    check_template_placeholder(
+        &mut violations,
+        &subject,
+        location,
+        "package.metadata.wrac.homepage_url",
+        &metadata.homepage_url,
+        "example.com",
+    );
+    check_template_placeholder(
+        &mut violations,
+        &subject,
+        location,
+        "package.metadata.wrac.manual_url",
+        &metadata.manual_url,
+        "example.com",
+    );
+    check_template_placeholder(
+        &mut violations,
+        &subject,
+        location,
+        "package.metadata.wrac.support_url",
+        &metadata.support_url,
+        "example.com",
+    );
+    check_template_placeholder(
+        &mut violations,
+        &subject,
+        location,
+        "package.metadata.wrac.copyright",
+        &metadata.copyright,
+        "Your Company",
+    );
+    check_template_placeholder(
+        &mut violations,
+        &subject,
+        location,
         "package.metadata.wrac.bundle_name",
         &metadata.bundle_name,
         "WRAC Gain",
@@ -493,9 +541,20 @@ mod tests {
             company_name: "Example".to_string(),
             auv2_manufacturer_code: "ExCo".to_string(),
             bundle_name: "Test Plugin".to_string(),
+            bundle_identifier: "com.example.test-plugin".to_string(),
+            homepage_url: "https://example.com/test-plugin".to_string(),
+            manual_url: "https://example.com/test-plugin/manual".to_string(),
+            support_url: "https://example.com/support".to_string(),
+            description: "Test plugin".to_string(),
+            copyright: "Copyright 2026 Example".to_string(),
             plugins: vec![PluginProductMetadata {
                 plugin_id: "com.example.test".to_string(),
                 plugin_name: "Test Plugin".to_string(),
+                clap_features: vec![
+                    "audio-effect".to_string(),
+                    "utility".to_string(),
+                    "stereo".to_string(),
+                ],
                 standalone_name: "Test Plugin Standalone".to_string(),
                 auv2_type: "aufx".to_string(),
                 auv2_subtype: "TstP".to_string(),

--- a/crates/wrac_xtask/src/validation/checks.rs
+++ b/crates/wrac_xtask/src/validation/checks.rs
@@ -350,6 +350,22 @@ fn template_placeholder_violations(
             &plugin.auv2_subtype,
             "WtGn",
         );
+        check_template_placeholder(
+            &mut violations,
+            &subject,
+            location,
+            "package.metadata.wrac.plugins.vst3_component_id",
+            &plugin.vst3_component_id,
+            "822011ca-37ec-5cef-92d7-ec7e67207195",
+        );
+        check_template_placeholder(
+            &mut violations,
+            &subject,
+            location,
+            "package.metadata.wrac.plugins.vst3_component_id",
+            &plugin.vst3_component_id,
+            "ffff664c-b963-53e6-87cc-2a7ceb29674b",
+        );
     }
     violations
 }
@@ -555,6 +571,8 @@ mod tests {
                     "utility".to_string(),
                     "stereo".to_string(),
                 ],
+                vst3_subcategories: "Fx|Tools".to_string(),
+                vst3_component_id: "5c65bb45-6f84-527b-915a-a51a30ea5854".to_string(),
                 standalone_name: "Test Plugin Standalone".to_string(),
                 auv2_type: "aufx".to_string(),
                 auv2_subtype: "TstP".to_string(),

--- a/docs/production-readiness-checks-ja.md
+++ b/docs/production-readiness-checks-ja.md
@@ -80,6 +80,6 @@ reason = "This product does not support Fender Studio Pro generic editor workflo
 
 **理由:** テンプレート由来の値は、製品作成時に手作業で置き換える必要があるため、見落としが起きやすいです。
 
-**エラー条件:** manifest metadata に `Your Company`、`YrCo`、`com.your-company`、`example.com`、`WRAC Gain`、`wrac_gain_plugin`、`WtGn`、テンプレートリポジトリ URL などの placeholder が残っている。このルールはテンプレートリポジトリ自体では skipped されます。
+**エラー条件:** manifest metadata に `Your Company`、`YrCo`、`com.your-company`、`example.com`、`WRAC Gain`、`wrac_gain_plugin`、`WtGn`、template VST3 component UUID、テンプレートリポジトリ URL などの placeholder が残っている。このルールはテンプレートリポジトリ自体では skipped されます。
 
 **修正方法:** テンプレート由来の metadata を製品固有の metadata に置き換えてください。テンプレートまたは example repository として意図的に残す場合は、reason を書いてルールを無効化してください。

--- a/docs/production-readiness-checks-ja.md
+++ b/docs/production-readiness-checks-ja.md
@@ -80,6 +80,6 @@ reason = "This product does not support Fender Studio Pro generic editor workflo
 
 **理由:** テンプレート由来の値は、製品作成時に手作業で置き換える必要があるため、見落としが起きやすいです。
 
-**エラー条件:** manifest metadata に `Your Company`、`com.your-company`、`WRAC Gain`、`wrac_gain_plugin`、`WtGn`、テンプレートリポジトリ URL などの placeholder が残っている。このルールはテンプレートリポジトリ自体では skipped されます。
+**エラー条件:** manifest metadata に `Your Company`、`YrCo`、`com.your-company`、`example.com`、`WRAC Gain`、`wrac_gain_plugin`、`WtGn`、テンプレートリポジトリ URL などの placeholder が残っている。このルールはテンプレートリポジトリ自体では skipped されます。
 
 **修正方法:** テンプレート由来の metadata を製品固有の metadata に置き換えてください。テンプレートまたは example repository として意図的に残す場合は、reason を書いてルールを無効化してください。

--- a/docs/production-readiness-checks.md
+++ b/docs/production-readiness-checks.md
@@ -80,6 +80,6 @@ When adding a rule, complete the following:
 
 **Reason:** Template-derived values must be replaced manually when creating a product, so they are easy to miss.
 
-**Error condition:** Manifest metadata still contains template placeholders such as `Your Company`, `YrCo`, `com.your-company`, `example.com`, `WRAC Gain`, `wrac_gain_plugin`, `WtGn`, or the template repository URL. This rule is skipped in the template repository itself.
+**Error condition:** Manifest metadata still contains template placeholders such as `Your Company`, `YrCo`, `com.your-company`, `example.com`, `WRAC Gain`, `wrac_gain_plugin`, `WtGn`, the template VST3 component UUID, or the template repository URL. This rule is skipped in the template repository itself.
 
 **Fix:** Replace template metadata with product-specific metadata, or disable the rule with a documented reason when the repository is intentionally a template or example.

--- a/docs/production-readiness-checks.md
+++ b/docs/production-readiness-checks.md
@@ -80,6 +80,6 @@ When adding a rule, complete the following:
 
 **Reason:** Template-derived values must be replaced manually when creating a product, so they are easy to miss.
 
-**Error condition:** Manifest metadata still contains template placeholders such as `Your Company`, `com.your-company`, `WRAC Gain`, `wrac_gain_plugin`, `WtGn`, or the template repository URL. This rule is skipped in the template repository itself.
+**Error condition:** Manifest metadata still contains template placeholders such as `Your Company`, `YrCo`, `com.your-company`, `example.com`, `WRAC Gain`, `wrac_gain_plugin`, `WtGn`, or the template repository URL. This rule is skipped in the template repository itself.
 
 **Fix:** Replace template metadata with product-specific metadata, or disable the rule with a documented reason when the repository is intentionally a template or example.

--- a/docs/setup-ja.md
+++ b/docs/setup-ja.md
@@ -59,10 +59,19 @@ VST3 / AU、開発用 standalone app、または VST3 / AU の検証を行う場
 company_name = "Your Company"
 auv2_manufacturer_code = "YrCo"
 bundle_name = "My Plugin"
+bundle_identifier = "com.your-company.my-plugin"
+homepage_url = "https://example.com/my-plugin"
+manual_url = "https://example.com/my-plugin/manual"
+support_url = "https://example.com/support"
+description = "My plugin description"
+copyright = "Copyright 2026 Your Company"
 
 [[package.metadata.wrac.plugins]]
 plugin_id = "com.your-company.my-plugin"
 plugin_name = "My Plugin"
+clap_features = ["audio-effect", "utility", "stereo"]
+vst3_subcategories = "Fx|Tools"
+vst3_component_id = "ffff664c-b963-53e6-87cc-2a7ceb29674b"
 standalone_name = "My Plugin Standalone"
 auv2_type = "aufx"
 auv2_subtype = "MyPl"
@@ -70,6 +79,9 @@ auv2_subtype = "MyPl"
 
 > **重要:** プラグイン ID はグローバルに一意である必要があります。一度公開したら変更できません。
 > AUv2 の `auv2_type`、`auv2_subtype`、`auv2_manufacturer_code` は、それぞれ 4 byte の ASCII にしてください。
+> `clap_features` は実際の audio/MIDI 挙動と一致させてください。CLAP host が直接読みます。
+> `vst3_subcategories` は VST3 host browser category を制御します。`Fx|Dynamics` のような Steinberg 形式の `|` 区切り値を指定してください。
+> `vst3_component_id` は安定した UUID にしてください。release 前に一度生成し、同じ製品では変更しないでください。
 
 ### 3. 残りの識別子を一括置換
 

--- a/docs/setup-ja.md
+++ b/docs/setup-ja.md
@@ -52,30 +52,7 @@ VST3 / AU、開発用 standalone app、または VST3 / AU の検証を行う場
 ### 2. プラグインの識別情報を設定する
 
 プラグインの識別情報は、プラグインパッケージの manifest に集約しています。初期状態では `plugins/wrac-gain/src-plugin/Cargo.toml` です。
-まず `[package.metadata.wrac]` を編集してください。
-
-```toml
-[package.metadata.wrac]
-company_name = "Your Company"
-auv2_manufacturer_code = "YrCo"
-bundle_name = "My Plugin"
-bundle_identifier = "com.your-company.my-plugin"
-homepage_url = "https://example.com/my-plugin"
-manual_url = "https://example.com/my-plugin/manual"
-support_url = "https://example.com/support"
-description = "My plugin description"
-copyright = "Copyright 2026 Your Company"
-
-[[package.metadata.wrac.plugins]]
-plugin_id = "com.your-company.my-plugin"
-plugin_name = "My Plugin"
-clap_features = ["audio-effect", "utility", "stereo"]
-vst3_subcategories = "Fx|Tools"
-vst3_component_id = "ffff664c-b963-53e6-87cc-2a7ceb29674b"
-standalone_name = "My Plugin Standalone"
-auv2_type = "aufx"
-auv2_subtype = "MyPl"
-```
+この guide に別の manifest sample を複製するのではなく、そこにあるコメント付きの `[package.metadata.wrac]` と `[[package.metadata.wrac.plugins]]` を直接編集してください。
 
 > **重要:** プラグイン ID はグローバルに一意である必要があります。一度公開したら変更できません。
 > AUv2 の `auv2_type`、`auv2_subtype`、`auv2_manufacturer_code` は、それぞれ 4 byte の ASCII にしてください。

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -52,30 +52,7 @@ The SDK submodules used by clap-wrapper are required when building VST3 / AU, bu
 ### 2. Configure Plugin Identity
 
 Plugin identity is centralized in the plugin package manifest, initially `plugins/wrac-gain/src-plugin/Cargo.toml`.
-Edit `[package.metadata.wrac]` first.
-
-```toml
-[package.metadata.wrac]
-company_name = "Your Company"
-auv2_manufacturer_code = "YrCo"
-bundle_name = "My Plugin"
-bundle_identifier = "com.your-company.my-plugin"
-homepage_url = "https://example.com/my-plugin"
-manual_url = "https://example.com/my-plugin/manual"
-support_url = "https://example.com/support"
-description = "My plugin description"
-copyright = "Copyright 2026 Your Company"
-
-[[package.metadata.wrac.plugins]]
-plugin_id = "com.your-company.my-plugin"
-plugin_name = "My Plugin"
-clap_features = ["audio-effect", "utility", "stereo"]
-vst3_subcategories = "Fx|Tools"
-vst3_component_id = "ffff664c-b963-53e6-87cc-2a7ceb29674b"
-standalone_name = "My Plugin Standalone"
-auv2_type = "aufx"
-auv2_subtype = "MyPl"
-```
+Edit the commented `[package.metadata.wrac]` and `[[package.metadata.wrac.plugins]]` sections there instead of copying a separate manifest sample from this guide.
 
 > **Important:** The plugin ID must be globally unique. It cannot be changed once published.
 > AUv2 `auv2_type`, `auv2_subtype`, and `auv2_manufacturer_code` must each be exactly 4 ASCII bytes.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -59,10 +59,19 @@ Edit `[package.metadata.wrac]` first.
 company_name = "Your Company"
 auv2_manufacturer_code = "YrCo"
 bundle_name = "My Plugin"
+bundle_identifier = "com.your-company.my-plugin"
+homepage_url = "https://example.com/my-plugin"
+manual_url = "https://example.com/my-plugin/manual"
+support_url = "https://example.com/support"
+description = "My plugin description"
+copyright = "Copyright 2026 Your Company"
 
 [[package.metadata.wrac.plugins]]
 plugin_id = "com.your-company.my-plugin"
 plugin_name = "My Plugin"
+clap_features = ["audio-effect", "utility", "stereo"]
+vst3_subcategories = "Fx|Tools"
+vst3_component_id = "ffff664c-b963-53e6-87cc-2a7ceb29674b"
 standalone_name = "My Plugin Standalone"
 auv2_type = "aufx"
 auv2_subtype = "MyPl"
@@ -70,6 +79,9 @@ auv2_subtype = "MyPl"
 
 > **Important:** The plugin ID must be globally unique. It cannot be changed once published.
 > AUv2 `auv2_type`, `auv2_subtype`, and `auv2_manufacturer_code` must each be exactly 4 ASCII bytes.
+> `clap_features` must match the plugin's real audio/MIDI behavior because CLAP hosts read it directly.
+> `vst3_subcategories` controls VST3 host browser categories; use Steinberg-style `|`-separated values such as `Fx|Dynamics`.
+> `vst3_component_id` must be a stable UUID. Generate it once before release and never change it for the same product.
 
 ### 3. Bulk Replace Remaining Identifiers
 

--- a/plugins/wrac-gain/src-plugin/Cargo.toml
+++ b/plugins/wrac-gain/src-plugin/Cargo.toml
@@ -8,15 +8,25 @@ repository = "https://github.com/novonotes/wrac-plugin-template"
 publish = false
 build = "build.rs"
 
-# WRAC metadata is the single source of truth for descriptors, GUI metadata,
-# bundle names, wrapper arguments, AUv2 registration, WebView data dirs, and logs.
+# WRAC metadata is the single source of truth for host-visible descriptors,
+# GUI About metadata, bundle names, wrapper arguments, AUv2 registration,
+# WebView data dirs, and logs. Set these explicitly before shipping; changing
+# public IDs or FourCC values after release can break host project recall.
 [package.metadata.wrac]
 # User-visible vendor name shown by hosts and the template GUI.
 company_name = "Your Company"
-# AUv2 manufacturer code. Use the same 4-byte ASCII code across your plugin catalog.
+# AUv2 manufacturer code. Use the same 4-byte ASCII code across your AUv2 plugin catalog.
 auv2_manufacturer_code = "YrCo"
-# User-visible bundle name.
+# Shared CLAP/VST3 bundle name. Product-specific AU bundles use plugin_name below.
 bundle_name = "WRAC Gain"
+# Reverse-DNS bundle identifier used by macOS bundles. Keep it stable.
+bundle_identifier = "com.your-company.wrac-gain"
+# Commercial metadata shown by hosts and About views where supported.
+homepage_url = "https://example.com/wrac-gain"
+manual_url = "https://example.com/wrac-gain/manual"
+support_url = "https://example.com/support"
+description = "Simple gain plugin"
+copyright = "Copyright 2026 Your Company"
 
 [package.metadata.wrac.validation.disabled_rules.fender-studio-pro-generic-editor-single-knob]
 reason = "WRAC Gain is a minimal one-knob starter example. Products that support Fender Studio Pro should add a second real visible control instead of shipping this exception."
@@ -26,6 +36,8 @@ reason = "WRAC Gain is a minimal one-knob starter example. Products that support
 plugin_id = "com.your-company.wrac-gain"
 # User-visible plugin name shown by hosts and the template GUI.
 plugin_name = "WRAC Gain"
+# CLAP feature identifiers used in the generated CLAP descriptor.
+clap_features = ["audio-effect", "utility", "stereo"]
 # User-visible standalone app name.
 standalone_name = "WRAC Gain Standalone"
 # AUv2 component type. Audio effects usually use "aufx"; instruments usually use "aumu".

--- a/plugins/wrac-gain/src-plugin/Cargo.toml
+++ b/plugins/wrac-gain/src-plugin/Cargo.toml
@@ -38,6 +38,12 @@ plugin_id = "com.your-company.wrac-gain"
 plugin_name = "WRAC Gain"
 # CLAP feature identifiers used in the generated CLAP descriptor.
 clap_features = ["audio-effect", "utility", "stereo"]
+# VST3 PClassInfo2 subCategories string. Keep this explicit because CLAP
+# features do not always map cleanly to commercial host browser categories.
+vst3_subcategories = "Fx|Tools"
+# VST3 component ID. Generate a UUID once before release and keep it stable;
+# changing it makes hosts treat the plugin as a different VST3.
+vst3_component_id = "822011ca-37ec-5cef-92d7-ec7e67207195"
 # User-visible standalone app name.
 standalone_name = "WRAC Gain Standalone"
 # AUv2 component type. Audio effects usually use "aufx"; instruments usually use "aumu".

--- a/plugins/wrac-gain/src-plugin/build.rs
+++ b/plugins/wrac-gain/src-plugin/build.rs
@@ -71,18 +71,33 @@ fn write_plugin_products(metadata: &WracMetadata, out_dir: &Path) -> io::Result<
         "pub(crate) const AUV2_MANUFACTURER_CODE: [u8; 4] = {};\n",
         four_ascii_array_literal(&metadata.auv2_manufacturer_code)
     ));
+    // CLAP hosts read feature strings during discovery. Generate them from the
+    // manifest so the production-readiness checks and runtime descriptor cannot
+    // drift after a product rename or capability change.
+    for (index, plugin) in metadata.plugins.iter().enumerate() {
+        rust.push_str(&format!(
+            "const PLUGIN_{index}_FEATURES: &[PluginFeature] = &{};\n",
+            plugin_feature_array_literal(&plugin.clap_features)?
+        ));
+    }
     rust.push_str("pub(crate) const PLUGIN_DESCRIPTORS: &[PluginDescriptor] = &[\n");
-    for plugin in &metadata.plugins {
+    for (index, plugin) in metadata.plugins.iter().enumerate() {
         rust.push_str("    PluginDescriptor {\n");
         rust.push_str(&format!("        id: {:?},\n", plugin.plugin_id));
         rust.push_str(&format!("        name: {:?},\n", plugin.plugin_name));
         rust.push_str("        vendor: COMPANY_NAME,\n");
-        rust.push_str("        url: \"\",\n");
-        rust.push_str("        manual_url: \"\",\n");
-        rust.push_str("        support_url: \"\",\n");
+        rust.push_str(&format!("        url: {:?},\n", metadata.homepage_url));
+        rust.push_str(&format!("        manual_url: {:?},\n", metadata.manual_url));
+        rust.push_str(&format!(
+            "        support_url: {:?},\n",
+            metadata.support_url
+        ));
         rust.push_str("        version: env!(\"CARGO_PKG_VERSION\"),\n");
-        rust.push_str("        description: \"Simple gain plugin\",\n");
-        rust.push_str("        features: PLUGIN_FEATURES,\n");
+        rust.push_str(&format!(
+            "        description: {:?},\n",
+            metadata.description
+        ));
+        rust.push_str(&format!("        features: PLUGIN_{index}_FEATURES,\n"));
         rust.push_str("        auv2: Some(Auv2Descriptor {\n");
         rust.push_str("            manufacturer_code: AUV2_MANUFACTURER_CODE,\n");
         rust.push_str("            manufacturer_name: COMPANY_NAME,\n");
@@ -106,6 +121,62 @@ fn four_ascii_array_literal(value: &str) -> String {
     format!("[{}, {}, {}, {}]", bytes[0], bytes[1], bytes[2], bytes[3])
 }
 
+fn plugin_feature_array_literal(features: &[String]) -> io::Result<String> {
+    let mut items = Vec::new();
+    for feature in features {
+        items.push(plugin_feature_literal(feature)?);
+    }
+    Ok(format!("[{}]", items.join(", ")))
+}
+
+fn plugin_feature_literal(feature: &str) -> io::Result<&'static str> {
+    match feature {
+        "audio-effect" => Ok("PluginFeature::AudioEffect"),
+        "analyzer" => Ok("PluginFeature::Analyzer"),
+        "ambisonic" => Ok("PluginFeature::Ambisonic"),
+        "chorus" => Ok("PluginFeature::Chorus"),
+        "compressor" => Ok("PluginFeature::Compressor"),
+        "de-esser" => Ok("PluginFeature::DeEsser"),
+        "delay" => Ok("PluginFeature::Delay"),
+        "instrument" => Ok("PluginFeature::Instrument"),
+        "note-effect" => Ok("PluginFeature::NoteEffect"),
+        "note-detector" => Ok("PluginFeature::NoteDetector"),
+        "drum" => Ok("PluginFeature::Drum"),
+        "drum-machine" => Ok("PluginFeature::DrumMachine"),
+        "equalizer" => Ok("PluginFeature::Equalizer"),
+        "expander" => Ok("PluginFeature::Expander"),
+        "filter" => Ok("PluginFeature::Filter"),
+        "flanger" => Ok("PluginFeature::Flanger"),
+        "frequency-shifter" => Ok("PluginFeature::FrequencyShifter"),
+        "gate" => Ok("PluginFeature::Gate"),
+        "glitch" => Ok("PluginFeature::Glitch"),
+        "granular" => Ok("PluginFeature::Granular"),
+        "distortion" => Ok("PluginFeature::Distortion"),
+        "limiter" => Ok("PluginFeature::Limiter"),
+        "mastering" => Ok("PluginFeature::Mastering"),
+        "mixing" => Ok("PluginFeature::Mixing"),
+        "mono" => Ok("PluginFeature::Mono"),
+        "multi-effects" => Ok("PluginFeature::MultiEffects"),
+        "phaser" => Ok("PluginFeature::Phaser"),
+        "phase-vocoder" => Ok("PluginFeature::PhaseVocoder"),
+        "pitch-correction" => Ok("PluginFeature::PitchCorrection"),
+        "pitch-shifter" => Ok("PluginFeature::PitchShifter"),
+        "restoration" => Ok("PluginFeature::Restoration"),
+        "reverb" => Ok("PluginFeature::Reverb"),
+        "sampler" => Ok("PluginFeature::Sampler"),
+        "stereo" => Ok("PluginFeature::Stereo"),
+        "surround" => Ok("PluginFeature::Surround"),
+        "synthesizer" => Ok("PluginFeature::Synthesizer"),
+        "transient-shaper" => Ok("PluginFeature::TransientShaper"),
+        "tremolo" => Ok("PluginFeature::Tremolo"),
+        "utility" => Ok("PluginFeature::Utility"),
+        _ => Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("unsupported package.metadata.wrac.plugins.clap_features value: {feature}"),
+        )),
+    }
+}
+
 #[derive(Debug, Deserialize)]
 struct CargoManifest {
     package: CargoPackage,
@@ -125,6 +196,12 @@ struct PackageMetadata {
 struct WracMetadata {
     company_name: String,
     auv2_manufacturer_code: String,
+    bundle_identifier: String,
+    homepage_url: String,
+    manual_url: String,
+    support_url: String,
+    description: String,
+    copyright: String,
     plugins: Vec<WracPluginMetadata>,
 }
 
@@ -132,6 +209,7 @@ struct WracMetadata {
 struct WracPluginMetadata {
     plugin_id: String,
     plugin_name: String,
+    clap_features: Vec<String>,
     standalone_name: String,
     auv2_type: String,
     auv2_subtype: String,
@@ -147,7 +225,17 @@ fn read_wrac_metadata(manifest_path: &Path) -> io::Result<WracMetadata> {
         .ok_or_else(missing_wrac_metadata)?
         .wrac
         .ok_or_else(missing_wrac_metadata)?;
+    validate_required("package.metadata.wrac.company_name", &metadata.company_name)?;
     validate_four_ascii("auv2_manufacturer_code", &metadata.auv2_manufacturer_code)?;
+    validate_required(
+        "package.metadata.wrac.bundle_identifier",
+        &metadata.bundle_identifier,
+    )?;
+    validate_required("package.metadata.wrac.homepage_url", &metadata.homepage_url)?;
+    validate_required("package.metadata.wrac.manual_url", &metadata.manual_url)?;
+    validate_required("package.metadata.wrac.support_url", &metadata.support_url)?;
+    validate_required("package.metadata.wrac.description", &metadata.description)?;
+    validate_required("package.metadata.wrac.copyright", &metadata.copyright)?;
     if metadata.plugins.is_empty() {
         return Err(missing_metadata("plugins"));
     }
@@ -160,6 +248,13 @@ fn read_wrac_metadata(manifest_path: &Path) -> io::Result<WracMetadata> {
             "package.metadata.wrac.plugins.plugin_name",
             &plugin.plugin_name,
         )?;
+        validate_non_empty_list(
+            "package.metadata.wrac.plugins.clap_features",
+            &plugin.clap_features,
+        )?;
+        for feature in &plugin.clap_features {
+            plugin_feature_literal(feature)?;
+        }
         validate_required(
             "package.metadata.wrac.plugins.standalone_name",
             &plugin.standalone_name,
@@ -183,6 +278,19 @@ fn read_wrac_metadata(manifest_path: &Path) -> io::Result<WracMetadata> {
         }
     }
     Ok(metadata)
+}
+
+fn validate_non_empty_list(key: &str, values: &[String]) -> io::Result<()> {
+    if values.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("{key} must not be empty"),
+        ));
+    }
+    for value in values {
+        validate_required(key, value)?;
+    }
+    Ok(())
 }
 
 fn missing_metadata(key: &str) -> io::Error {

--- a/plugins/wrac-gain/src-plugin/build.rs
+++ b/plugins/wrac-gain/src-plugin/build.rs
@@ -110,6 +110,16 @@ fn write_plugin_products(metadata: &WracMetadata, out_dir: &Path) -> io::Result<
             four_ascii_array_literal(&plugin.auv2_subtype)
         ));
         rust.push_str("        }),\n");
+        rust.push_str("        vst3: Some(Vst3Descriptor {\n");
+        rust.push_str(&format!(
+            "            subcategories: {:?},\n",
+            plugin.vst3_subcategories
+        ));
+        rust.push_str(&format!(
+            "            component_id: {},\n",
+            uuid_array_literal(&plugin.vst3_component_id)?
+        ));
+        rust.push_str("        }),\n");
         rust.push_str("    },\n");
     }
     rust.push_str("];\n");
@@ -210,6 +220,8 @@ struct WracPluginMetadata {
     plugin_id: String,
     plugin_name: String,
     clap_features: Vec<String>,
+    vst3_subcategories: String,
+    vst3_component_id: String,
     standalone_name: String,
     auv2_type: String,
     auv2_subtype: String,
@@ -255,6 +267,11 @@ fn read_wrac_metadata(manifest_path: &Path) -> io::Result<WracMetadata> {
         for feature in &plugin.clap_features {
             plugin_feature_literal(feature)?;
         }
+        validate_required(
+            "package.metadata.wrac.plugins.vst3_subcategories",
+            &plugin.vst3_subcategories,
+        )?;
+        uuid_array_literal(&plugin.vst3_component_id)?;
         validate_required(
             "package.metadata.wrac.plugins.standalone_name",
             &plugin.standalone_name,
@@ -327,6 +344,27 @@ fn validate_four_ascii(key: &str, value: &str) -> io::Result<()> {
             format!("package.metadata.wrac.{key} must be exactly 4 ASCII bytes"),
         ))
     }
+}
+
+fn uuid_array_literal(value: &str) -> io::Result<String> {
+    let hex = value.replace('-', "");
+    if hex.len() != 32 || !hex.as_bytes().iter().all(u8::is_ascii_hexdigit) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("package.metadata.wrac.plugins.vst3_component_id must be a UUID: {value}"),
+        ));
+    }
+    let mut bytes = [0_u8; 16];
+    for (index, byte) in bytes.iter_mut().enumerate() {
+        let start = index * 2;
+        *byte = u8::from_str_radix(&hex[start..start + 2], 16).map_err(|error| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("package.metadata.wrac.plugins.vst3_component_id must be a UUID: {error}"),
+            )
+        })?;
+    }
+    Ok(format!("{bytes:?}"))
 }
 
 fn validate_unique<'a>(key: &str, value: &'a str, seen: &mut HashSet<&'a str>) -> io::Result<()> {

--- a/plugins/wrac-gain/src-plugin/src/plugin.rs
+++ b/plugins/wrac-gain/src-plugin/src/plugin.rs
@@ -29,7 +29,7 @@ use wrac_clap_adapter::{
     ActivateContext, Auv2Descriptor, PluginAudioPortsExtension,
     PluginConfigurableAudioPortsExtension, PluginCore, PluginCoreContext, PluginDescriptor,
     PluginEntry, PluginFactory, PluginFeature, PluginGuiExtension, PluginParamsExtension,
-    PluginResult, PluginStateExtension, Processor,
+    PluginResult, PluginStateExtension, Processor, Vst3Descriptor,
 };
 use wrac_wxp_gui::WxpGuiController;
 

--- a/plugins/wrac-gain/src-plugin/src/plugin.rs
+++ b/plugins/wrac-gain/src-plugin/src/plugin.rs
@@ -37,12 +37,6 @@ use crate::audio::WracGainAudioProcessor;
 use crate::gui::create_gui_integration;
 use crate::state::{ProjectStateStore, SharedState};
 
-const PLUGIN_FEATURES: &[PluginFeature] = &[
-    PluginFeature::AudioEffect,
-    PluginFeature::Utility,
-    PluginFeature::Stereo,
-];
-
 // Generated from [package.metadata.wrac] in src-plugin/Cargo.toml. The manifest is
 // the single source of truth for product identity across descriptors, GUI metadata,
 // wrapper arguments, AUv2 registration, WebView data dirs, and logs.


### PR DESCRIPTION
## Summary
- expand WRAC metadata with explicit host-visible URLs, bundle identifier, copyright, and CLAP features
- generate CLAP descriptors from manifest metadata instead of hard-coded URL/feature defaults
- update template placeholder checks and docs for the expanded metadata fields

## Verification
- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace