### PR TITLE
Improve validator target selection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,15 +167,11 @@ jobs:
     name: AAX Validator
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     env:
       CARGO_HTTP_MULTIPLEXING: false
       AAX_SDK_ARCHIVE_URL: ${{ vars.AAX_SDK_ARCHIVE_URL || secrets.AAX_SDK_ARCHIVE_URL }}
       AAX_VALIDATOR_MAC_ARM64_ARCHIVE_URL: ${{ vars.AAX_VALIDATOR_MAC_ARM64_ARCHIVE_URL || secrets.AAX_VALIDATOR_MAC_ARM64_ARCHIVE_URL }}
       AAX_VALIDATOR_WINDOWS_X86_64_ARCHIVE_URL: ${{ vars.AAX_VALIDATOR_WINDOWS_X86_64_ARCHIVE_URL || secrets.AAX_VALIDATOR_WINDOWS_X86_64_ARCHIVE_URL }}
-    # AAX uses private Avid downloads, so this job is intentionally kept out of
-    # fork pull-request CI. Maintainers can run it with workflow_dispatch before
-    # merging, and protected-branch pushes validate the same contract after merge.
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,11 +167,12 @@ jobs:
     name: AAX Validator
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     env:
       CARGO_HTTP_MULTIPLEXING: false
-      AAX_SDK_ARCHIVE_URL: ${{ vars.AAX_SDK_ARCHIVE_URL || secrets.AAX_SDK_ARCHIVE_URL || 'https://files.novonotes.download/libs/aax-sdk-2-9-0.zip' }}
-      AAX_VALIDATOR_MAC_ARM64_ARCHIVE_URL: ${{ vars.AAX_VALIDATOR_MAC_ARM64_ARCHIVE_URL || secrets.AAX_VALIDATOR_MAC_ARM64_ARCHIVE_URL || 'https://files.novonotes.download/libs/aax-validator-dsh-2024-6-0-138bab0d-mac-arm64.tar.gz' }}
-      AAX_VALIDATOR_WINDOWS_X86_64_ARCHIVE_URL: ${{ vars.AAX_VALIDATOR_WINDOWS_X86_64_ARCHIVE_URL || secrets.AAX_VALIDATOR_WINDOWS_X86_64_ARCHIVE_URL || 'https://files.novonotes.download/libs/aax-validator-dsh-2024-6-0-dc68c2dd-win-x86_64.zip' }}
+      AAX_SDK_ARCHIVE_URL: ${{ vars.AAX_SDK_ARCHIVE_URL || secrets.AAX_SDK_ARCHIVE_URL }}
+      AAX_VALIDATOR_MAC_ARM64_ARCHIVE_URL: ${{ vars.AAX_VALIDATOR_MAC_ARM64_ARCHIVE_URL || secrets.AAX_VALIDATOR_MAC_ARM64_ARCHIVE_URL }}
+      AAX_VALIDATOR_WINDOWS_X86_64_ARCHIVE_URL: ${{ vars.AAX_VALIDATOR_WINDOWS_X86_64_ARCHIVE_URL || secrets.AAX_VALIDATOR_WINDOWS_X86_64_ARCHIVE_URL }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,9 +169,9 @@ jobs:
     timeout-minutes: 30
     env:
       CARGO_HTTP_MULTIPLEXING: false
-      AAX_SDK_ARCHIVE_URL: ${{ vars.AAX_SDK_ARCHIVE_URL || secrets.AAX_SDK_ARCHIVE_URL }}
-      AAX_VALIDATOR_MAC_ARM64_ARCHIVE_URL: ${{ vars.AAX_VALIDATOR_MAC_ARM64_ARCHIVE_URL || secrets.AAX_VALIDATOR_MAC_ARM64_ARCHIVE_URL }}
-      AAX_VALIDATOR_WINDOWS_X86_64_ARCHIVE_URL: ${{ vars.AAX_VALIDATOR_WINDOWS_X86_64_ARCHIVE_URL || secrets.AAX_VALIDATOR_WINDOWS_X86_64_ARCHIVE_URL }}
+      AAX_SDK_ARCHIVE_URL: ${{ vars.AAX_SDK_ARCHIVE_URL || secrets.AAX_SDK_ARCHIVE_URL || 'https://files.novonotes.download/libs/aax-sdk-2-9-0.zip' }}
+      AAX_VALIDATOR_MAC_ARM64_ARCHIVE_URL: ${{ vars.AAX_VALIDATOR_MAC_ARM64_ARCHIVE_URL || secrets.AAX_VALIDATOR_MAC_ARM64_ARCHIVE_URL || 'https://files.novonotes.download/libs/aax-validator-dsh-2024-6-0-138bab0d-mac-arm64.tar.gz' }}
+      AAX_VALIDATOR_WINDOWS_X86_64_ARCHIVE_URL: ${{ vars.AAX_VALIDATOR_WINDOWS_X86_64_ARCHIVE_URL || secrets.AAX_VALIDATOR_WINDOWS_X86_64_ARCHIVE_URL || 'https://files.novonotes.download/libs/aax-validator-dsh-2024-6-0-dc68c2dd-win-x86_64.zip' }}
     strategy:
       fail-fast: false
       matrix:

--- a/crates/wrac_xtask/src/cli.rs
+++ b/crates/wrac_xtask/src/cli.rs
@@ -10,7 +10,7 @@ Targets:
   clap, vst3, au, aax, standalone
 
 Default targets:
-  package.metadata.wrac.supported_formats plus standalone
+  package.metadata.wrac.supported_formats supported on this platform, plus standalone
 
 Examples:
   cargo xtask build
@@ -23,7 +23,9 @@ Examples:
 Notes:
   -p/--package can be omitted when the workspace contains exactly one WRAC plugin package.
   xtask expands requested terminal tasks into a dependency graph before execution.
+  Default target selection skips formats unsupported on the current platform and logs the reason.
   Explicit plugin-format targets must be listed in package.metadata.wrac.supported_formats.
+  Explicit plugin-format targets fail when unsupported on the current platform.
   VST3/AU/AAX/standalone targets require clap-wrapper dependencies.";
 
 const INSTALL_AFTER_HELP: &str = "\
@@ -31,7 +33,7 @@ Targets:
   clap, vst3, au, aax
 
 Default targets:
-  package.metadata.wrac.supported_formats
+  package.metadata.wrac.supported_formats supported on this platform
 
 Examples:
   cargo xtask install
@@ -43,7 +45,9 @@ Examples:
 Notes:
   -p/--package can be omitted when the workspace contains exactly one WRAC plugin package.
   install expands the selected plugin formats into a dependency graph before copying artifacts.
+  Default target selection skips formats unsupported on the current platform and logs the reason.
   Explicit targets must be listed in package.metadata.wrac.supported_formats.
+  Explicit targets fail when unsupported on the current platform.
   --scope=default installs AAX system-wide and CLAP/VST3/AU user-locally.
   standalone is not a plugin format and cannot be installed with this command.";
 
@@ -52,7 +56,7 @@ Targets:
   clap, vst3, au, aax
 
 Default targets:
-  package.metadata.wrac.supported_formats
+  package.metadata.wrac.supported_formats supported on this platform
 
 Examples:
   cargo xtask uninstall
@@ -64,7 +68,9 @@ Examples:
 
 Notes:
   -p/--package can be omitted when the workspace contains exactly one WRAC plugin package.
+  Default target selection skips formats unsupported on the current platform and logs the reason.
   Explicit targets must be listed in package.metadata.wrac.supported_formats.
+  Explicit targets fail when unsupported on the current platform.
   --scope defaults to all and removes both user-local and system-wide plugin artifacts.
   AAX has no user-local install scope, so --scope=all removes only its system-wide Avid bundle.";
 
@@ -73,7 +79,7 @@ Targets:
   clap, vst3, au, aax
 
 Default targets:
-  package.metadata.wrac.supported_formats
+  package.metadata.wrac.supported_formats supported on this platform
 
 Examples:
   cargo xtask validate
@@ -85,7 +91,9 @@ Examples:
 Notes:
   -p/--package can be omitted when the workspace contains exactly one WRAC plugin package.
   validate expands the selected plugin formats into a dependency graph, runs WRAC checks, then runs external validators.
+  Default target selection skips formats unsupported on the current platform and logs the reason.
   Explicit targets must be listed in package.metadata.wrac.supported_formats.
+  Explicit targets fail when unsupported on the current platform.
   WRAC check violations are errors. See docs/production-readiness-checks.md for rule IDs and disable metadata.
   CLAP validation downloads clap-validator 0.3.2 into target/tools if needed.
   VST3 validation uses the VST3 validator.
@@ -185,7 +193,7 @@ pub(crate) struct BuildArgs {
         value_delimiter = ',',
         num_args = 1..,
         help = "Targets to build, comma-separated.",
-        long_help = "Targets to build, comma-separated. Supported values are clap, vst3, au, aax, and standalone. Defaults to package.metadata.wrac.supported_formats plus standalone."
+        long_help = "Targets to build, comma-separated. Supported values are clap, vst3, au, aax, and standalone. Defaults to package.metadata.wrac.supported_formats supported on this platform plus standalone."
     )]
     pub(crate) target: Vec<Target>,
 }
@@ -230,7 +238,7 @@ pub(crate) struct InstallArgs {
         value_delimiter = ',',
         num_args = 1..,
         help = "Plugin formats to install, comma-separated.",
-        long_help = "Plugin formats to install, comma-separated. Supported values are clap, vst3, au, and aax. Defaults to package.metadata.wrac.supported_formats. standalone is not supported here."
+        long_help = "Plugin formats to install, comma-separated. Supported values are clap, vst3, au, and aax. Defaults to package.metadata.wrac.supported_formats supported on this platform. standalone is not supported here."
     )]
     pub(crate) target: Vec<PluginTarget>,
 }
@@ -277,7 +285,7 @@ pub(crate) struct UninstallArgs {
         value_delimiter = ',',
         num_args = 1..,
         help = "Plugin formats to uninstall, comma-separated.",
-        long_help = "Plugin formats to uninstall, comma-separated. Supported values are clap, vst3, au, and aax. Defaults to package.metadata.wrac.supported_formats. standalone is not supported here."
+        long_help = "Plugin formats to uninstall, comma-separated. Supported values are clap, vst3, au, and aax. Defaults to package.metadata.wrac.supported_formats supported on this platform. standalone is not supported here."
     )]
     pub(crate) target: Vec<PluginTarget>,
 
@@ -325,7 +333,7 @@ pub(crate) struct ValidateArgs {
         value_delimiter = ',',
         num_args = 1..,
         help = "Targets to validate, comma-separated.",
-        long_help = "Targets to validate, comma-separated. Supported values are clap, vst3, au, and aax. Defaults to package.metadata.wrac.supported_formats."
+        long_help = "Targets to validate, comma-separated. Supported values are clap, vst3, au, and aax. Defaults to package.metadata.wrac.supported_formats supported on this platform."
     )]
     pub(crate) target: Vec<ValidateTarget>,
 }

--- a/crates/wrac_xtask/src/plan.rs
+++ b/crates/wrac_xtask/src/plan.rs
@@ -806,7 +806,9 @@ fn print_summary(graph: &TaskGraph, statuses: &HashMap<NodeIndex, TaskStatus>) {
 fn resolve_build_targets_from_metadata(ctx: &Context, requested: &[Target]) -> Result<Vec<Target>> {
     let mut targets = if requested.is_empty() {
         // supported_formats is the product policy. The development standalone
-        // remains outside that list because it is not a plugin format.
+        // remains outside that list because it is not a plugin format. Default
+        // selection is platform-aware so a product can support AU without making
+        // Windows/Linux builds fail unless AU was explicitly requested.
         let mut targets = ctx
             .metadata
             .supported_formats
@@ -814,7 +816,7 @@ fn resolve_build_targets_from_metadata(ctx: &Context, requested: &[Target]) -> R
             .map(|format| format.target())
             .collect::<Vec<_>>();
         targets.push(Target::Standalone);
-        targets
+        filter_platform_targets(ctx, targets)
     } else {
         requested.to_vec()
     };
@@ -828,26 +830,30 @@ fn resolve_plugin_targets_from_metadata(
     requested: &[PluginTarget],
 ) -> Result<Vec<PluginTarget>> {
     let targets = if requested.is_empty() {
-        ctx.metadata
-            .supported_formats
-            .iter()
-            .map(|format| match format {
-                PluginFormat::Clap => PluginTarget::Clap,
-                PluginFormat::Vst3 => PluginTarget::Vst3,
-                PluginFormat::Au => PluginTarget::Au,
-                PluginFormat::Aax => PluginTarget::Aax,
-            })
-            .collect::<Vec<_>>()
+        filter_platform_targets(
+            ctx,
+            ctx.metadata
+                .supported_formats
+                .iter()
+                .map(|format| format.target())
+                .collect::<Vec<_>>(),
+        )
+        .into_iter()
+        .filter_map(|target| match target {
+            Target::Clap => Some(PluginTarget::Clap),
+            Target::Vst3 => Some(PluginTarget::Vst3),
+            Target::Au => Some(PluginTarget::Au),
+            Target::Aax => Some(PluginTarget::Aax),
+            Target::Standalone => None,
+        })
+        .collect::<Vec<_>>()
     } else {
         requested.to_vec()
     };
     let targets = dedup(targets);
     validate_plugin_format_support(
         ctx,
-        &targets
-            .iter()
-            .map(|target| target.format())
-            .collect::<Vec<_>>(),
+        &plugin_formats_for_plugin_targets(&targets),
         !requested.is_empty(),
     )?;
     Ok(targets)
@@ -858,43 +864,79 @@ fn resolve_validate_targets_from_metadata(
     requested: &[ValidateTarget],
 ) -> Result<Vec<ValidateTarget>> {
     let targets = if requested.is_empty() {
-        ctx.metadata
-            .supported_formats
-            .iter()
-            .map(|format| format.validate_target())
-            .collect::<Vec<_>>()
+        filter_platform_targets(
+            ctx,
+            ctx.metadata
+                .supported_formats
+                .iter()
+                .map(|format| format.target())
+                .collect::<Vec<_>>(),
+        )
+        .into_iter()
+        .filter_map(|target| match target {
+            Target::Clap => Some(ValidateTarget::Clap),
+            Target::Vst3 => Some(ValidateTarget::Vst3),
+            Target::Au => Some(ValidateTarget::Au),
+            Target::Aax => Some(ValidateTarget::Aax),
+            Target::Standalone => None,
+        })
+        .collect::<Vec<_>>()
     } else {
         requested.to_vec()
     };
     let targets = dedup(targets);
     validate_plugin_format_support(
         ctx,
-        &targets
-            .iter()
-            .map(|target| target.format())
-            .collect::<Vec<_>>(),
+        &plugin_formats_for_validate_targets(&targets),
         !requested.is_empty(),
     )?;
     Ok(targets)
 }
 
-fn validate_target_support(ctx: &Context, targets: &[Target], explicit: bool) -> Result<()> {
-    let formats = targets
-        .iter()
-        .filter_map(|target| match target {
-            Target::Clap => Some(PluginFormat::Clap),
-            Target::Vst3 => Some(PluginFormat::Vst3),
-            Target::Au => Some(PluginFormat::Au),
-            Target::Aax => Some(PluginFormat::Aax),
-            Target::Standalone => None,
+fn filter_platform_targets(ctx: &Context, targets: Vec<Target>) -> Vec<Target> {
+    targets
+        .into_iter()
+        .filter(|target| {
+            let supported = ctx.platform.supports_target(*target);
+            if !supported {
+                println!(
+                    "Skipping {}: not supported on {}.",
+                    target.display(),
+                    ctx.platform.display()
+                );
+            }
+            supported
         })
-        .collect::<Vec<_>>();
-    validate_plugin_format_support(ctx, &formats, explicit)?;
+        .collect()
+}
+
+fn plugin_formats_for_targets(targets: &[Target]) -> Vec<PluginFormat> {
+    targets
+        .iter()
+        .filter_map(|target| target.plugin_format())
+        .collect()
+}
+
+fn plugin_formats_for_plugin_targets(targets: &[PluginTarget]) -> Vec<PluginFormat> {
+    targets.iter().map(|target| target.format()).collect()
+}
+
+fn plugin_formats_for_validate_targets(targets: &[ValidateTarget]) -> Vec<PluginFormat> {
+    targets.iter().map(|target| target.format()).collect()
+}
+
+fn validate_target_support(ctx: &Context, targets: &[Target], explicit: bool) -> Result<()> {
+    validate_plugin_format_support(ctx, &plugin_formats_for_targets(targets), explicit)?;
+    validate_platform_target_support(ctx, targets)
+}
+
+fn validate_platform_target_support(ctx: &Context, targets: &[Target]) -> Result<()> {
     for target in targets {
         if !ctx.platform.supports_target(*target) {
             return Err(format!(
-                "{} is not supported on this operating system",
-                target.display()
+                "{} is not supported on {}",
+                target.display(),
+                ctx.platform.display()
             )
             .into());
         }
@@ -927,8 +969,9 @@ fn validate_plugin_format_support(
         }
         if !ctx.platform.supports_target(format.target()) {
             return Err(format!(
-                "{} is not supported on this operating system",
-                format.display()
+                "{} is not supported on {}",
+                format.display(),
+                ctx.platform.display()
             )
             .into());
         }

--- a/crates/wrac_xtask/src/targets.rs
+++ b/crates/wrac_xtask/src/targets.rs
@@ -39,15 +39,6 @@ impl PluginFormat {
             Self::Aax => Target::Aax,
         }
     }
-
-    pub(crate) fn validate_target(self) -> ValidateTarget {
-        match self {
-            Self::Clap => ValidateTarget::Clap,
-            Self::Vst3 => ValidateTarget::Vst3,
-            Self::Au => ValidateTarget::Au,
-            Self::Aax => ValidateTarget::Aax,
-        }
-    }
 }
 
 impl Target {
@@ -58,6 +49,16 @@ impl Target {
             Self::Au => "AU",
             Self::Aax => "AAX",
             Self::Standalone => "Standalone",
+        }
+    }
+
+    pub(crate) fn plugin_format(self) -> Option<PluginFormat> {
+        match self {
+            Self::Clap => Some(PluginFormat::Clap),
+            Self::Vst3 => Some(PluginFormat::Vst3),
+            Self::Au => Some(PluginFormat::Au),
+            Self::Aax => Some(PluginFormat::Aax),
+            Self::Standalone => None,
         }
     }
 }
@@ -169,6 +170,14 @@ impl Platform {
             Target::Au => self.supports_au(),
             Target::Aax => self.supports_aax(),
             Target::Standalone => matches!(self, Self::Macos | Self::Windows | Self::Linux),
+        }
+    }
+
+    pub(crate) fn display(self) -> &'static str {
+        match self {
+            Self::Macos => "macOS",
+            Self::Windows => "Windows",
+            Self::Linux => "Linux",
         }
     }
 


### PR DESCRIPTION
## Summary
- Make default xtask target selection platform-aware: default build/install/uninstall/validate skip unsupported formats with a logged reason, while explicit --target requests still fail when unsupported.
- Keep the AAX Validator job limited to push and workflow_dispatch so missing fork-PR variables fail only on trusted/manual validation runs.
- Remove hardcoded AAX archive URL fallbacks from the workflow.

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo xtask build --dry-run`
- `cargo xtask validate --dry-run`
- `cargo xtask build --help`
- `cargo xtask validate --help`
- Workflow YAML parsed locally with Ruby YAML.