### PR TITLE
Fix AAX insert crashes for audio-only plugins

### DIFF
--- a/clap_wrapper_builder/clap-wrapper/src/detail/aax/process.cpp
+++ b/clap_wrapper_builder/clap-wrapper/src/detail/aax/process.cpp
@@ -241,7 +241,7 @@ void AAXProcessAdapter::process(SAAX_Wrapper_AlgorithmicContext *context)
   }
 
   // check MIDI IN
-  if (context->mInputNode)
+  if (_midi_first_portid != CLAP_INVALID_ID && context->mInputNode)
   {
     auto midiInputStream = context->mInputNode->GetNodeBuffer();
     const AAX_CMidiPacket *midiInPacketPtr = midiInputStream->mBuffer;

--- a/clap_wrapper_builder/clap-wrapper/src/detail/aax/wrapper.h
+++ b/clap_wrapper_builder/clap-wrapper/src/detail/aax/wrapper.h
@@ -141,7 +141,7 @@ class AAXProcessAdapter
                                                               uint32_t index);
 
   // MIDI
-  uint32_t _midi_first_portid = 0;
+  uint32_t _midi_first_portid = CLAP_INVALID_ID;
   bool _midi_prefer_mididialect = true;
 };
 
@@ -281,7 +281,7 @@ class ClapAsAAX : public AAX_CEffectParameters,
 
   std::vector<clap_audio_port_configuration_request> _configuration_requests;
 
-  uint32_t _midi_first_portid = 0;
+  uint32_t _midi_first_portid = CLAP_INVALID_ID;
   bool _midi_prefer_mididialect = true;
 
   ParamChangeQueue _paramsToProcess;

--- a/crates/wrac_clap_adapter/src/abi.rs
+++ b/crates/wrac_clap_adapter/src/abi.rs
@@ -123,7 +123,6 @@ pub(crate) struct PluginCapabilities {
     gui: bool,
     render: bool,
     tail: bool,
-    latency: bool,
 }
 
 // Safety: CLAP shares the same opaque plugin pointer across callbacks. Adapter state is
@@ -184,7 +183,6 @@ impl PluginInstance {
             gui: gui.is_some(),
             render: render.is_some(),
             tail: tail.is_some(),
-            latency: latency.is_some(),
         };
         let storage = registration.storage();
 
@@ -825,7 +823,10 @@ unsafe extern "C" fn plugin_get_extension(
             &render_extension::RENDER as *const _ as *const c_void
         } else if id == CLAP_EXT_TAIL && instance.capabilities.tail {
             &tail_extension::TAIL as *const _ as *const c_void
-        } else if id == CLAP_EXT_LATENCY && instance.capabilities.latency {
+        } else if id == CLAP_EXT_LATENCY {
+            // Some wrappers query latency unconditionally during activation. Exposing a
+            // zero-latency fallback keeps optional product support from becoming a null
+            // extension pointer at the wrapper boundary.
             &latency_extension::LATENCY as *const _ as *const c_void
         } else {
             ptr::null()


### PR DESCRIPTION
## Summary
- expose a zero-latency CLAP latency extension fallback from the Rust adapter for AAX wrapper activation
- guard AAX MIDI input processing so audio-only plugins do not treat private wrapper data as an AAX MIDI node
- keep the wrapper subtree change isolated from the Rust adapter commit

## Verification
- git diff --check
- cargo fmt --check
- cargo test -p wrac_clap_adapter
- cargo clippy -p wrac_clap_adapter --all-targets -- -D warnings
- cargo xtask install --target=aax