### PR TITLE
Fix hosted GUI lifecycle issues

### DIFF
--- a/clap_wrapper_builder/clap-wrapper/src/detail/auv2/auv2_shared.h
+++ b/clap_wrapper_builder/clap-wrapper/src/detail/auv2/auv2_shared.h
@@ -32,7 +32,7 @@ typedef struct ui_connection
   uint32_t *_canary = nullptr;       // a canary in the Windows class
   std::function<void(clap_window_t *, uint32_t *)> _registerWindow = nullptr;
   std::function<void()> _createWindow = nullptr;
-  std::function<void()> _destroyWindow = nullptr;
+  std::function<void(const char *)> _destroyWindow = nullptr;
 } ui_connection;
 
 }  // namespace free_audio::auv2_wrapper

--- a/clap_wrapper_builder/clap-wrapper/src/detail/auv2/wrappedview.asinclude.mm
+++ b/clap_wrapper_builder/clap-wrapper/src/detail/auv2/wrappedview.asinclude.mm
@@ -31,6 +31,8 @@
 
 - (id)initWithAUv2:(free_audio::auv2_wrapper::ui_connection *)cont preferredSize:(NSSize)size;
 - (void)doIdle;
+- (void)startIdleTimer;
+- (void)stopIdleTimer;
 - (void)dealloc;
 - (void)setFrame:(NSRect)newSize;
 
@@ -86,7 +88,7 @@ void CLAP_WRAPPER_TIMER_CALLBACK(CFRunLoopTimerRef timer, void *info)
 
 - (id)initWithAUv2:(free_audio::auv2_wrapper::ui_connection *)cont preferredSize:(NSSize)size
 {
-  LOGINFO("[clap-wrapper] creating NSView");
+  LOGINFO("[clap-wrapper] creating NSView self={}", (void *)self);
 
   ui = *cont;
   canary = 0xbeebbeeb;
@@ -135,12 +137,7 @@ void CLAP_WRAPPER_TIMER_CALLBACK(CFRunLoopTimerRef timer, void *info)
   }
 
   idleTimer = nil;
-  CFTimeInterval TIMER_INTERVAL = .05;  // In SurgeGUISynthesizer.h it uses 50 ms
-  CFRunLoopTimerContext TimerContext = {0, self, NULL, NULL, NULL};
-  CFAbsoluteTime FireTime = CFAbsoluteTimeGetCurrent() + TIMER_INTERVAL;
-  idleTimer = CFRunLoopTimerCreate(kCFAllocatorDefault, FireTime, TIMER_INTERVAL, 0, 0,
-                                   CLAP_WRAPPER_TIMER_CALLBACK, &TimerContext);
-  if (idleTimer) CFRunLoopAddTimer(CFRunLoopGetMain(), idleTimer, kCFRunLoopCommonModes);
+  [self startIdleTimer];
 
   return self;
 }
@@ -149,37 +146,50 @@ void CLAP_WRAPPER_TIMER_CALLBACK(CFRunLoopTimerRef timer, void *info)
 {
   // auto gui = ui._plugin->_ext._gui;
 }
+- (void)startIdleTimer
+{
+  if (idleTimer) return;
+
+  CFTimeInterval TIMER_INTERVAL = .05;  // In SurgeGUISynthesizer.h it uses 50 ms
+  CFRunLoopTimerContext TimerContext = {0, self, NULL, NULL, NULL};
+  CFAbsoluteTime FireTime = CFAbsoluteTimeGetCurrent() + TIMER_INTERVAL;
+  idleTimer = CFRunLoopTimerCreate(kCFAllocatorDefault, FireTime, TIMER_INTERVAL, 0, 0,
+                                   CLAP_WRAPPER_TIMER_CALLBACK, &TimerContext);
+  if (idleTimer) CFRunLoopAddTimer(CFRunLoopGetMain(), idleTimer, kCFRunLoopCommonModes);
+}
+- (void)stopIdleTimer
+{
+  if (idleTimer)
+  {
+    CFRunLoopTimerInvalidate(idleTimer);
+    idleTimer = 0;
+  }
+}
 - (void)viewDidMoveToWindow
 {
   if ([self window] == nil)
   {
-    LOGINFO("[clap-wrapper] - view removed from a window");
-    if (idleTimer)
-    {
-      CFRunLoopTimerInvalidate(idleTimer);
-      idleTimer = 0;
-    }
-    if (canary)
-    {
-      ui._destroyWindow();
-
-      assert(canary == 0);
-    }
+    LOGINFO("[clap-wrapper] - view removed from a window; keeping CLAP GUI alive until dealloc self={}",
+            (void *)self);
+    [self stopIdleTimer];
+  }
+  else
+  {
+    LOGINFO("[clap-wrapper] - view attached to a window self={} window={}", (void *)self,
+            (void *)[self window]);
+    [self startIdleTimer];
   }
   [super viewDidMoveToWindow];
 }
 
 - (void)dealloc
 {
-  LOGINFO("[clap-wrapper] NS View dealloc");
-  if (idleTimer)
-  {
-    CFRunLoopTimerInvalidate(idleTimer);
-  }
+  LOGINFO("[clap-wrapper] NS View dealloc self={} canary={}", (void *)self, canary);
+  [self stopIdleTimer];
   if (canary)
   {
     LOGINFO("[clap-wrapper] the host did not call viewDidMoveWindow with a nil window");
-    ui._destroyWindow();
+    ui._destroyWindow("CLAP_WRAPPER_COCOA_CLASS_NSVIEW::dealloc");
   }
   [super dealloc];
 }

--- a/clap_wrapper_builder/clap-wrapper/src/detail/auv2/wrappedview.asinclude.mm
+++ b/clap_wrapper_builder/clap-wrapper/src/detail/auv2/wrappedview.asinclude.mm
@@ -88,7 +88,7 @@ void CLAP_WRAPPER_TIMER_CALLBACK(CFRunLoopTimerRef timer, void *info)
 
 - (id)initWithAUv2:(free_audio::auv2_wrapper::ui_connection *)cont preferredSize:(NSSize)size
 {
-  LOGINFO("[clap-wrapper] creating NSView self={}", (void *)self);
+  LOGINFO("[clap-wrapper] creating NSView");
 
   ui = *cont;
   canary = 0xbeebbeeb;
@@ -169,14 +169,14 @@ void CLAP_WRAPPER_TIMER_CALLBACK(CFRunLoopTimerRef timer, void *info)
 {
   if ([self window] == nil)
   {
-    LOGINFO("[clap-wrapper] - view removed from a window; keeping CLAP GUI alive until dealloc self={}",
-            (void *)self);
+    // Some AUv2 hosts temporarily detach the editor view while the plugin instance remains
+    // active. Destroying the CLAP GUI here leaves the host-owned NSView alive with no child
+    // WebView to redraw, which shows up as a blank editor on the next transport transition.
+    LOGINFO("[clap-wrapper] - view removed from a window; keeping CLAP GUI alive until dealloc");
     [self stopIdleTimer];
   }
   else
   {
-    LOGINFO("[clap-wrapper] - view attached to a window self={} window={}", (void *)self,
-            (void *)[self window]);
     [self startIdleTimer];
   }
   [super viewDidMoveToWindow];
@@ -184,10 +184,12 @@ void CLAP_WRAPPER_TIMER_CALLBACK(CFRunLoopTimerRef timer, void *info)
 
 - (void)dealloc
 {
-  LOGINFO("[clap-wrapper] NS View dealloc self={} canary={}", (void *)self, canary);
+  LOGINFO("[clap-wrapper] NS View dealloc");
   [self stopIdleTimer];
   if (canary)
   {
+    // Dealloc is the point where Cocoa proves the editor view itself is going away. Tie CLAP GUI
+    // teardown to this lifetime rather than to transient detach/Cleanup callbacks.
     LOGINFO("[clap-wrapper] the host did not call viewDidMoveWindow with a nil window");
     ui._destroyWindow("CLAP_WRAPPER_COCOA_CLASS_NSVIEW::dealloc");
   }

--- a/clap_wrapper_builder/clap-wrapper/src/wrapasauv2.cpp
+++ b/clap_wrapper_builder/clap-wrapper/src/wrapasauv2.cpp
@@ -640,10 +640,11 @@ OSStatus WrapAsAUV2::Stop()
 }
 void WrapAsAUV2::Cleanup()
 {
-  LOGINFO("[clap-wrapper] Cleaning up Plugin uiIsOpened={} canary={}", this->_uiIsOpened,
-          (void *)this->_uiconn._canary);
+  LOGINFO("[clap-wrapper] Cleaning up Plugin uiIsOpened={}", this->_uiIsOpened);
   auto guarantee_mainthread = _plugin->AlwaysMainThread();
-  LOGINFO("[clap-wrapper] AUv2 Cleanup keeps CLAP GUI alive; Cocoa view/destructor own GUI teardown");
+  // AudioUnit hosts can call Cleanup while the Cocoa editor view is still alive. The NSView
+  // dealloc/destructor paths own CLAP GUI teardown; doing it here can leave a live host view with a
+  // destroyed child WebView.
   deactivateCLAP();
   Base::Cleanup();
 }

--- a/clap_wrapper_builder/clap-wrapper/src/wrapasauv2.cpp
+++ b/clap_wrapper_builder/clap-wrapper/src/wrapasauv2.cpp
@@ -162,6 +162,7 @@ WrapAsAUV2::~WrapAsAUV2()
       *_uiconn._canary = 0;       // notify the view
       _uiconn._canary = nullptr;  // disable the canary reference
 
+      LOGINFO("[clap-wrapper] AUv2 destroying CLAP GUI: reason=WrapAsAUV2::~WrapAsAUV2");
       // close destroy the gui ourselves
       _plugin->_ext._gui->destroy(_plugin->_plugin);
       _uiIsOpened = false;
@@ -639,22 +640,10 @@ OSStatus WrapAsAUV2::Stop()
 }
 void WrapAsAUV2::Cleanup()
 {
-  LOGINFO("[clap-wrapper] Cleaning up Plugin");
+  LOGINFO("[clap-wrapper] Cleaning up Plugin uiIsOpened={} canary={}", this->_uiIsOpened,
+          (void *)this->_uiconn._canary);
   auto guarantee_mainthread = _plugin->AlwaysMainThread();
-  if (this->_uiIsOpened)
-  {
-    LOGINFO("[clap-wrapper] !! UI still open, destroying UI and disconnecting view");
-    if (_uiconn._canary)
-    {
-      *_uiconn._canary = 0;       // reset the canary
-      _uiconn._canary = nullptr;  // and disconnect it
-      if (_plugin->_plugin && _plugin->_ext._gui)
-      {
-        this->_uiconn._destroyWindow();
-        this->_plugin->_ext._gui->destroy(_plugin->_plugin);
-      }
-    }
-  }
+  LOGINFO("[clap-wrapper] AUv2 Cleanup keeps CLAP GUI alive; Cocoa view/destructor own GUI teardown");
   deactivateCLAP();
   Base::Cleanup();
 }
@@ -809,8 +798,10 @@ OSStatus WrapAsAUV2::GetProperty(AudioUnitPropertyID inID, AudioUnitScope inScop
           this->_uiIsOpened = true;
           _plugin->_ext._gui->create(_plugin->_plugin, CLAP_WINDOW_API_COCOA, false);
         };
-        _uiconn._destroyWindow = [this]
+        _uiconn._destroyWindow = [this](const char *reason)
         {
+          LOGINFO("[clap-wrapper] AUv2 destroying CLAP GUI: reason={}",
+                  reason ? reason : "unknown");
           // this must exist
           _plugin->_ext._gui->destroy(_plugin->_plugin);
 

--- a/crates/wrac_clap_adapter/src/abi/gui_extension.rs
+++ b/crates/wrac_clap_adapter/src/abi/gui_extension.rs
@@ -87,6 +87,10 @@ unsafe extern "C" fn gui_create(
     is_floating: bool,
 ) -> bool {
     ffi_bool(|| {
+        log::debug!(
+            "gui.create: called api={} is_floating={is_floating}",
+            gui_api_name(api)
+        );
         let Some(gui) = (unsafe { plugin_gui_mutation(plugin, "create") }) else {
             return false;
         };
@@ -95,7 +99,10 @@ unsafe extern "C" fn gui_create(
             return false;
         };
         match gui.create(GuiConfig { api, is_floating }) {
-            Ok(()) => true,
+            Ok(()) => {
+                log::debug!("gui.create: completed");
+                true
+            }
             Err(error) => {
                 log::warn!("gui.create: plugin create failed: {error}");
                 false
@@ -106,10 +113,12 @@ unsafe extern "C" fn gui_create(
 
 unsafe extern "C" fn gui_destroy(plugin: *const clap_plugin) {
     ffi_unit(|| {
+        log::debug!("gui.destroy: called");
         let Some(gui) = (unsafe { plugin_gui_mutation(plugin, "destroy") }) else {
             return;
         };
         gui.destroy();
+        log::debug!("gui.destroy: completed");
     });
 }
 
@@ -254,6 +263,16 @@ unsafe extern "C" fn gui_set_parent(
     window: *const clap_window,
 ) -> bool {
     ffi_bool(|| {
+        let window_api = if window.is_null() {
+            "<null>".to_string()
+        } else {
+            unsafe { gui_api_name((*window).api) }
+        };
+        log::debug!(
+            "gui.set_parent: called window_is_null={} api={}",
+            window.is_null(),
+            window_api
+        );
         if window.is_null() {
             log::warn!("gui.set_parent: null window pointer");
             return false;
@@ -266,7 +285,10 @@ unsafe extern "C" fn gui_set_parent(
             return false;
         };
         match gui.set_parent(parent) {
-            Ok(()) => true,
+            Ok(()) => {
+                log::debug!("gui.set_parent: completed");
+                true
+            }
             Err(error) => {
                 log::warn!("gui.set_parent: plugin set_parent failed: {error}");
                 false
@@ -295,11 +317,15 @@ unsafe extern "C" fn gui_suggest_title(plugin: *const clap_plugin, _title: *cons
 
 unsafe extern "C" fn gui_show(plugin: *const clap_plugin) -> bool {
     ffi_bool(|| {
+        log::debug!("gui.show: called");
         let Some(gui) = (unsafe { plugin_gui_mutation(plugin, "show") }) else {
             return false;
         };
         match gui.show() {
-            Ok(()) => true,
+            Ok(()) => {
+                log::debug!("gui.show: completed");
+                true
+            }
             Err(error) => {
                 log::warn!("gui.show: plugin show failed: {error}");
                 false
@@ -310,11 +336,15 @@ unsafe extern "C" fn gui_show(plugin: *const clap_plugin) -> bool {
 
 unsafe extern "C" fn gui_hide(plugin: *const clap_plugin) -> bool {
     ffi_bool(|| {
+        log::debug!("gui.hide: called");
         let Some(gui) = (unsafe { plugin_gui_mutation(plugin, "hide") }) else {
             return false;
         };
         match gui.hide() {
-            Ok(()) => true,
+            Ok(()) => {
+                log::debug!("gui.hide: completed");
+                true
+            }
             Err(error) => {
                 log::warn!("gui.hide: plugin hide failed: {error}");
                 false
@@ -409,4 +439,13 @@ fn gui_api_cstr(api: GuiApi) -> &'static CStr {
         GuiApi::Win32 => CLAP_WINDOW_API_WIN32,
         GuiApi::X11 => CLAP_WINDOW_API_X11,
     }
+}
+
+fn gui_api_name(api: *const c_char) -> String {
+    if api.is_null() {
+        return "<null>".to_string();
+    }
+    unsafe { CStr::from_ptr(api) }
+        .to_string_lossy()
+        .into_owned()
 }

--- a/crates/wrac_wxp_gui/src/controller.rs
+++ b/crates/wrac_wxp_gui/src/controller.rs
@@ -8,10 +8,11 @@ use wrac_clap_adapter::{
     GuiApi, GuiConfig, GuiResizeHints, GuiSize, HostGuiResizeRequester, HostWindow, PluginError,
     PluginGuiExtension, PluginResult,
 };
-use wrac_host_context::{HostContext, HostFamily, PluginFormat};
+use wrac_host_context::HostContext;
 use wxp::{WebViewDispatch, dpi::LogicalSize};
 
 use crate::dpi::{DpiConverter, HostGuiSizeUnit};
+use crate::host_policy::HostGuiPolicy;
 use crate::runtime::{
     GuiRuntimeHandle, GuiThreadLease, WxpGuiFactory, create_gui_runtime_handle, is_gui_thread,
 };
@@ -36,7 +37,7 @@ pub struct WxpGuiController {
     layout: Arc<HostGuiLayout>,
     scale: Arc<Mutex<f64>>,
     runtime: Arc<Mutex<GuiRuntimeState>>,
-    host_context: HostContext,
+    host_policy: HostGuiPolicy,
 }
 
 struct HostGuiLayout {
@@ -117,7 +118,8 @@ impl WxpGuiController {
         resize_handle: WxpGuiResizeHandle,
         host_context: HostContext,
     ) -> Self {
-        resize_handle.set_host_size_unit(host_gui_size_unit_for_context(&host_context));
+        let host_policy = HostGuiPolicy::new(host_context);
+        resize_handle.set_host_size_unit(host_policy.host_size_unit());
         Self {
             factory: Arc::new(factory),
             layout: resize_handle.layout.clone(),
@@ -131,16 +133,23 @@ impl WxpGuiController {
                 pending_creation_generation: None,
                 destroy_requested_while_creating: false,
             })),
-            host_context,
+            host_policy,
         }
     }
 
-    fn destroy_gui_session(&self) {
-        log::debug!("wxp controller: destroy_gui_session requested");
+    fn force_destroy_gui_session(&self) {
+        log::debug!(
+            "wxp controller: destroy_gui_session requested state={}",
+            self.runtime_state_summary()
+        );
         {
             let mut state = self.runtime.lock();
             if state.is_creating_runtime {
-                log::debug!("wxp controller: destroy_gui_session deferred during runtime creation");
+                log::debug!(
+                    "wxp controller: destroy_gui_session deferred during runtime creation: generation={} creating_generation={:?}",
+                    state.generation,
+                    state.creating_generation
+                );
                 let session = state.session.take();
                 state.generation = state.generation.wrapping_add(1);
                 state.destroy_requested_while_creating = true;
@@ -155,15 +164,18 @@ impl WxpGuiController {
         if drop_session(session) {
             self.note_runtime_destroyed();
         }
-        log::debug!("wxp controller: destroy_gui_session completed");
+        log::debug!(
+            "wxp controller: destroy_gui_session completed state={}",
+            self.runtime_state_summary()
+        );
     }
 
     fn should_async_resync_bounds_after_set_size(&self) -> bool {
-        is_cubase_vst3(&self.host_context)
+        self.host_policy.should_async_resync_bounds_after_set_size()
     }
 
     fn correct_host_scale(&self, scale: f64, parent: Option<StoredParentWindow>) -> f64 {
-        if !is_cubase_vst3(&self.host_context) {
+        if !self.host_policy.needs_cubase_vst3_scale_correction() {
             return scale;
         }
         // Cubase 10 on Windows has been observed to report integer VST3 scale factors
@@ -171,7 +183,7 @@ impl WxpGuiController {
         // HWND is the closest source of truth for the actual size conversion.
         let corrected = corrected_scale_for_parent(parent).unwrap_or(scale);
         if (corrected - scale).abs() > f64::EPSILON {
-            log::info!(
+            log::debug!(
                 "wxp controller: corrected Cubase VST3 host scale from {scale} to {corrected}"
             );
         }
@@ -183,6 +195,10 @@ impl WxpGuiController {
     }
 
     fn schedule_runtime_creation(&self, generation: u64) -> PluginResult<()> {
+        log::debug!(
+            "wxp controller: schedule_runtime_creation requested generation={generation} state={}",
+            self.runtime_state_summary()
+        );
         schedule_runtime_creation(
             self.factory.clone(),
             self.runtime.clone(),
@@ -190,27 +206,36 @@ impl WxpGuiController {
             generation,
         )
     }
-}
 
-fn is_cubase_vst3(host_context: &HostContext) -> bool {
-    host_context.host.family == HostFamily::SteinbergCubase
-        && host_context.plugin_format == PluginFormat::Vst3
-}
-
-fn host_gui_size_unit_for_context(host_context: &HostContext) -> HostGuiSizeUnit {
-    // macOS wrapper formats expose Cocoa/NSView geometry at the CLAP GUI boundary.
-    // Treating those logical coordinates as physical pixels would divide the child
-    // WebView bounds by the scale factor and clip the editor to the top-left area.
-    if cfg!(target_os = "macos")
-        && matches!(
-            host_context.plugin_format,
-            PluginFormat::Vst3 | PluginFormat::Au | PluginFormat::Aax
-        )
-    {
-        HostGuiSizeUnit::LogicalPoints
-    } else {
-        HostGuiSizeUnit::PhysicalPixels
+    fn runtime_state_summary(&self) -> String {
+        let state = self.runtime.lock();
+        runtime_state_summary(&state)
     }
+}
+
+fn runtime_state_summary(state: &GuiRuntimeState) -> String {
+    let session = match state.session.as_ref() {
+        Some(session) => format!(
+            "session=Some(generation={}, has_parent={}, has_parent_lease={}, has_handle={}, visible={}, scale={}, config={:?})",
+            session.generation,
+            session.parent.is_some(),
+            session.parent_lease.is_some(),
+            session.handle.is_some(),
+            session.visible,
+            session.scale,
+            session.configuration
+        ),
+        None => "session=None".to_string(),
+    };
+    format!(
+        "generation={} {session} is_creating_runtime={} creating_generation={:?} pending_creation_generation={:?} destroy_requested_while_creating={} last_runtime_destroyed_at_present={}",
+        state.generation,
+        state.is_creating_runtime,
+        state.creating_generation,
+        state.pending_creation_generation,
+        state.destroy_requested_while_creating,
+        state.last_runtime_destroyed_at.is_some()
+    )
 }
 
 fn schedule_runtime_creation(
@@ -227,18 +252,24 @@ fn schedule_runtime_creation(
         let mut state = runtime.lock();
         if state.is_creating_runtime {
             log::debug!(
-                "wxp controller: runtime creation pending while another creation is in progress: generation={generation}"
+                "wxp controller: runtime creation pending while another creation is in progress: generation={generation} state={}",
+                runtime_state_summary(&state)
             );
             state.pending_creation_generation = Some(generation);
             return Ok(());
         }
         let session = state.session.as_ref().ok_or(PluginError::InvalidState)?;
         if session.generation != generation {
+            log::debug!(
+                "wxp controller: runtime creation rejected stale generation: requested={generation} state={}",
+                runtime_state_summary(&state)
+            );
             return Err(PluginError::InvalidState);
         }
         if session.handle.is_some() {
             log::debug!(
-                "wxp controller: runtime creation skipped; runtime already exists: generation={generation}"
+                "wxp controller: runtime creation skipped; runtime already exists: generation={generation} state={}",
+                runtime_state_summary(&state)
             );
             return Ok(());
         }
@@ -255,7 +286,9 @@ fn schedule_runtime_creation(
         (configuration, parent)
     };
 
-    log::debug!("wxp controller: posting runtime creation: generation={generation}");
+    log::debug!(
+        "wxp controller: posting runtime creation: generation={generation} parent={parent:?} configuration={configuration:?}"
+    );
     let factory_for_callback = factory.clone();
     let runtime_for_callback = runtime.clone();
     let layout_for_callback = layout.clone();
@@ -348,6 +381,10 @@ fn schedule_runtime_creation(
 
         let mut state = runtime_for_callback.lock();
         let Some(session) = state.session.as_mut() else {
+            log::debug!(
+                "wxp controller: posted runtime creation has no session after create: generation={generation} state={}",
+                runtime_state_summary(&state)
+            );
             drop(state);
             handle.destroy();
             runtime_for_callback.lock().last_runtime_destroyed_at = Some(Instant::now());
@@ -359,6 +396,10 @@ fn schedule_runtime_creation(
             return;
         };
         if session.generation != generation {
+            let actual_generation = session.generation;
+            log::debug!(
+                "wxp controller: posted runtime creation session generation changed: requested={generation} actual={actual_generation}"
+            );
             drop(state);
             handle.destroy();
             runtime_for_callback.lock().last_runtime_destroyed_at = Some(Instant::now());
@@ -389,7 +430,10 @@ fn schedule_runtime_creation(
             );
             state.pending_creation_generation = None;
         }
-        log::debug!("wxp controller: posted runtime creation completed: generation={generation}");
+        log::debug!(
+            "wxp controller: posted runtime creation completed: generation={generation} state={}",
+            runtime_state_summary(&state)
+        );
         drop(state);
         schedule_pending_runtime_creation(
             factory_for_callback,
@@ -861,12 +905,15 @@ impl PluginGuiExtension for WxpGuiController {
     }
 
     fn create(&self, configuration: GuiConfig) -> PluginResult<()> {
-        log::debug!("wxp controller: create called: configuration={configuration:?}");
+        log::debug!(
+            "wxp controller: create called: configuration={configuration:?} state={}",
+            self.runtime_state_summary()
+        );
         if !self.is_api_supported(configuration.api, configuration.is_floating) {
             log::debug!("wxp controller: create rejected unsupported configuration");
             return Err(PluginError::Message("unsupported GUI configuration"));
         }
-        self.destroy_gui_session();
+        self.force_destroy_gui_session();
         let scale = *self.scale.lock();
         let generation = {
             let mut state = self.runtime.lock();
@@ -886,14 +933,23 @@ impl PluginGuiExtension for WxpGuiController {
             });
             generation
         };
-        log::debug!("wxp controller: create completed: generation={generation}");
+        log::debug!(
+            "wxp controller: create completed: generation={generation} state={}",
+            self.runtime_state_summary()
+        );
         Ok(())
     }
 
     fn destroy(&self) {
-        log::debug!("wxp controller: destroy called");
-        self.destroy_gui_session();
-        log::debug!("wxp controller: destroy completed");
+        log::debug!(
+            "wxp controller: destroy called state={}",
+            self.runtime_state_summary()
+        );
+        self.force_destroy_gui_session();
+        log::debug!(
+            "wxp controller: destroy completed state={}",
+            self.runtime_state_summary()
+        );
     }
 
     fn set_scale(&self, scale: f64) -> PluginResult<()> {
@@ -977,11 +1033,20 @@ impl PluginGuiExtension for WxpGuiController {
     }
 
     fn set_parent(&self, window: HostWindow) -> PluginResult<()> {
-        log::debug!("wxp controller: set_parent called");
+        log::debug!(
+            "wxp controller: set_parent called state={}",
+            self.runtime_state_summary()
+        );
         let parent = StoredParentWindow::from_host_window(window);
         let (generation, needs_parent_lease) = {
             let state = self.runtime.lock();
-            let session = state.session.as_ref().ok_or(PluginError::InvalidState)?;
+            let Some(session) = state.session.as_ref() else {
+                log::debug!(
+                    "wxp controller: set_parent rejected with no session: parent={parent:?} state={}",
+                    runtime_state_summary(&state)
+                );
+                return Err(PluginError::InvalidState);
+            };
             let needs_parent_lease = if session.parent.is_some() {
                 if !is_gui_thread() {
                     log::debug!("wxp controller: set_parent rejected non-GUI thread reparent");
@@ -1029,7 +1094,15 @@ impl PluginGuiExtension for WxpGuiController {
             }
         }
         let mut state = self.runtime.lock();
-        let session = state.session.as_mut().ok_or(PluginError::InvalidState)?;
+        let Some(session) = state.session.as_mut() else {
+            log::debug!(
+                "wxp controller: set_parent lost session before storing parent: parent={parent:?} state={}",
+                runtime_state_summary(&state)
+            );
+            drop(state);
+            drop(parent_lease);
+            return Err(PluginError::InvalidState);
+        };
         if session.generation != generation {
             drop(state);
             drop(parent_lease);
@@ -1048,15 +1121,27 @@ impl PluginGuiExtension for WxpGuiController {
         // On failure, leave the session without a runtime and let a subsequent
         // show/set_parent reschedule it.
         self.schedule_runtime_creation(generation)?;
-        log::debug!("wxp controller: set_parent completed");
+        log::debug!(
+            "wxp controller: set_parent completed parent={parent:?} state={}",
+            self.runtime_state_summary()
+        );
         Ok(())
     }
 
     fn show(&self) -> PluginResult<()> {
-        log::debug!("wxp controller: show called");
+        log::debug!(
+            "wxp controller: show called state={}",
+            self.runtime_state_summary()
+        );
         let action = {
             let state = self.runtime.lock();
-            let session = state.session.as_ref().ok_or(PluginError::InvalidState)?;
+            let Some(session) = state.session.as_ref() else {
+                log::debug!(
+                    "wxp controller: show rejected with no session: state={}",
+                    runtime_state_summary(&state)
+                );
+                return Err(PluginError::InvalidState);
+            };
             if let Some(handle) = session.handle.clone() {
                 ShowAction::ShowExisting {
                     handle,
@@ -1073,35 +1158,52 @@ impl PluginGuiExtension for WxpGuiController {
 
         match action {
             ShowAction::ShowExisting { handle, generation } => {
-                log::debug!("wxp controller: show existing runtime");
+                log::debug!("wxp controller: show existing runtime generation={generation}");
                 handle.show()?;
                 if let Some(session) = &mut self.runtime.lock().session
                     && session.generation == generation
                 {
                     session.visible = true;
                 }
-                log::debug!("wxp controller: show completed on existing runtime");
+                log::debug!(
+                    "wxp controller: show completed on existing runtime state={}",
+                    self.runtime_state_summary()
+                );
                 Ok(())
             }
             ShowAction::Create { generation } => {
-                log::debug!("wxp controller: show scheduling runtime creation");
+                log::debug!(
+                    "wxp controller: show scheduling runtime creation generation={generation}"
+                );
                 self.schedule_runtime_creation(generation)?;
                 if let Some(session) = &mut self.runtime.lock().session
                     && session.generation == generation
                 {
                     session.visible = true;
                 }
-                log::debug!("wxp controller: show completed by scheduled runtime creation");
+                log::debug!(
+                    "wxp controller: show completed by scheduled runtime creation state={}",
+                    self.runtime_state_summary()
+                );
                 Ok(())
             }
         }
     }
 
     fn hide(&self) -> PluginResult<()> {
-        log::debug!("wxp controller: hide called");
+        log::debug!(
+            "wxp controller: hide called state={}",
+            self.runtime_state_summary()
+        );
         let (generation, handle) = {
             let state = self.runtime.lock();
-            let session = state.session.as_ref().ok_or(PluginError::InvalidState)?;
+            let Some(session) = state.session.as_ref() else {
+                log::debug!(
+                    "wxp controller: hide rejected with no session: state={}",
+                    runtime_state_summary(&state)
+                );
+                return Err(PluginError::InvalidState);
+            };
             (session.generation, session.handle.clone())
         };
         if let Some(handle) = handle {
@@ -1112,7 +1214,10 @@ impl PluginGuiExtension for WxpGuiController {
         {
             session.visible = false;
         }
-        log::debug!("wxp controller: hide completed");
+        log::debug!(
+            "wxp controller: hide completed state={}",
+            self.runtime_state_summary()
+        );
         Ok(())
     }
 }
@@ -1145,7 +1250,7 @@ fn clamp_size_with_limits(size: GuiSize, limits: GuiSizeLimits) -> GuiSize {
 
 impl Drop for WxpGuiController {
     fn drop(&mut self) {
-        self.destroy_gui_session();
+        self.force_destroy_gui_session();
     }
 }
 
@@ -1179,7 +1284,7 @@ fn default_gui_configuration() -> GuiConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use wrac_host_context::DetectedHost;
+    use wrac_host_context::{DetectedHost, HostFamily, PluginFormat};
 
     #[test]
     fn clamps_logical_resize_request_in_physical_pixels() {
@@ -1228,7 +1333,8 @@ mod tests {
             } else {
                 HostGuiSizeUnit::PhysicalPixels
             };
-            assert_eq!(host_gui_size_unit_for_context(&context), expected);
+            let policy = HostGuiPolicy::new(context);
+            assert_eq!(policy.host_size_unit(), expected);
         }
     }
 }

--- a/crates/wrac_wxp_gui/src/host_policy.rs
+++ b/crates/wrac_wxp_gui/src/host_policy.rs
@@ -1,0 +1,85 @@
+use wrac_host_context::{HostContext, HostFamily, PluginFormat};
+
+use crate::dpi::HostGuiSizeUnit;
+
+#[derive(Debug, Clone)]
+pub(crate) struct HostGuiPolicy {
+    context: HostContext,
+}
+
+impl HostGuiPolicy {
+    pub(crate) fn new(context: HostContext) -> Self {
+        Self { context }
+    }
+
+    pub(crate) fn should_async_resync_bounds_after_set_size(&self) -> bool {
+        self.context.host.family == HostFamily::SteinbergCubase
+            && self.context.plugin_format == PluginFormat::Vst3
+    }
+
+    pub(crate) fn needs_cubase_vst3_scale_correction(&self) -> bool {
+        self.context.host.family == HostFamily::SteinbergCubase
+            && self.context.plugin_format == PluginFormat::Vst3
+    }
+
+    pub(crate) fn host_size_unit(&self) -> HostGuiSizeUnit {
+        // macOS wrapper formats expose Cocoa/NSView geometry at the CLAP GUI boundary.
+        // Treating those logical coordinates as physical pixels would divide the child
+        // WebView bounds by the scale factor and clip the editor to the top-left area.
+        if cfg!(target_os = "macos")
+            && matches!(
+                self.context.plugin_format,
+                PluginFormat::Vst3 | PluginFormat::Au | PluginFormat::Aax
+            )
+        {
+            HostGuiSizeUnit::LogicalPoints
+        } else {
+            HostGuiSizeUnit::PhysicalPixels
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use wrac_host_context::{DetectedHost, HostContext, HostFamily, PluginFormat};
+
+    use super::*;
+
+    fn context(family: HostFamily, plugin_format: PluginFormat) -> HostContext {
+        HostContext {
+            host: DetectedHost {
+                family,
+                display_name: "Test Host".to_string(),
+                process_name: "Test Host".to_string(),
+                process_path: String::new(),
+                version: None,
+            },
+            plugin_format,
+        }
+    }
+
+    #[test]
+    fn cubase_vst3_policy_is_scoped_to_cubase_vst3() {
+        let cubase_vst3 =
+            HostGuiPolicy::new(context(HostFamily::SteinbergCubase, PluginFormat::Vst3));
+        assert!(cubase_vst3.should_async_resync_bounds_after_set_size());
+        assert!(cubase_vst3.needs_cubase_vst3_scale_correction());
+
+        let cubase_au = HostGuiPolicy::new(context(HostFamily::SteinbergCubase, PluginFormat::Au));
+        assert!(!cubase_au.should_async_resync_bounds_after_set_size());
+        assert!(!cubase_au.needs_cubase_vst3_scale_correction());
+    }
+
+    #[test]
+    fn host_size_unit_uses_logical_points_for_macos_wrappers() {
+        let policy = HostGuiPolicy::new(context(HostFamily::Unknown, PluginFormat::Au));
+        assert_eq!(
+            policy.host_size_unit(),
+            if cfg!(target_os = "macos") {
+                HostGuiSizeUnit::LogicalPoints
+            } else {
+                HostGuiSizeUnit::PhysicalPixels
+            }
+        );
+    }
+}

--- a/crates/wrac_wxp_gui/src/lib.rs
+++ b/crates/wrac_wxp_gui/src/lib.rs
@@ -7,6 +7,7 @@
 mod controller;
 mod cursor;
 mod dpi;
+mod host_policy;
 mod pointer;
 mod resize_drag;
 mod runtime;

--- a/crates/wrac_wxp_gui/src/session.rs
+++ b/crates/wrac_wxp_gui/src/session.rs
@@ -68,10 +68,13 @@ impl WxpWebViewSession {
         command_handler: Rc<WxpCommandHandler>,
     ) -> PluginResult<Self> {
         log::debug!(
-            "creating wxp WebView session: plugin_id={}, width={}, height={}",
+            "creating wxp WebView session: plugin_id={}, width={}, height={}, parent={:?}, devtools={}, host_size_unit={:?}",
             config.plugin_id,
             config.initial_size.width,
-            config.initial_size.height
+            config.initial_size.height,
+            config.parent,
+            config.devtools,
+            config.host_size_unit
         );
 
         let data_dir = webview_data_dir(config.plugin_id);
@@ -114,7 +117,10 @@ impl WxpWebViewSession {
                 }
             }
             WxpFrontendSource::Zip { scheme, url, bytes } => {
-                log::debug!("configuring wxp WebView session zip frontend: url={url}");
+                log::debug!(
+                    "configuring wxp WebView session zip frontend: scheme={scheme}, url={url}, bytes={}",
+                    bytes.len()
+                );
                 WxpWebViewBuilder::new(&mut wxp_context)
                     .with_command_handler(command_handler.clone())
                     .with_devtools(config.devtools)
@@ -126,6 +132,13 @@ impl WxpWebViewSession {
             }
         };
 
+        log::debug!(
+            "building wxp WebView child: host_width={}, host_height={}, logical_width={}, logical_height={}",
+            host_size.width,
+            host_size.height,
+            logical_size.width,
+            logical_size.height
+        );
         let web_view = builder
             .build_as_child(&config.parent)
             .map_err(|_| PluginError::Message("failed to build webview"))?;
@@ -165,7 +178,10 @@ impl WxpWebViewSession {
     }
 
     pub fn show(&mut self) -> PluginResult<()> {
-        log::debug!("showing wxp WebView session");
+        log::debug!(
+            "showing wxp WebView session: web_view_active={}",
+            self.web_view.is_some()
+        );
         if let Some(web_view) = &self.web_view {
             web_view
                 .dispatch()
@@ -176,7 +192,10 @@ impl WxpWebViewSession {
     }
 
     pub fn hide(&mut self) -> PluginResult<()> {
-        log::debug!("hiding wxp WebView session");
+        log::debug!(
+            "hiding wxp WebView session: web_view_active={}",
+            self.web_view.is_some()
+        );
         if let Some(web_view) = &self.web_view {
             web_view
                 .dispatch()
@@ -188,6 +207,11 @@ impl WxpWebViewSession {
 
     fn apply_bounds(&self) -> PluginResult<()> {
         if let Some(web_view) = &self.web_view {
+            log::debug!(
+                "applying wxp WebView bounds: logical_width={}, logical_height={}",
+                self.logical_size.width,
+                self.logical_size.height
+            );
             // Use the same dispatch path as command handlers and close handling so a closing
             // WebView's native owner is not kept alive by direct access.
             web_view
@@ -201,7 +225,11 @@ impl WxpWebViewSession {
 
 impl Drop for WxpWebViewSession {
     fn drop(&mut self) {
-        log::debug!("dropping wxp WebView session");
+        log::debug!(
+            "dropping wxp WebView session: web_view_active={} web_context_active={}",
+            self.web_view.is_some(),
+            self.wxp_context.is_some()
+        );
         self.web_view = None;
         log::debug!("dropping wxp WebView session: webview dropped");
         self.wxp_context = None;

--- a/crates/wrac_xtask/src/commands.rs
+++ b/crates/wrac_xtask/src/commands.rs
@@ -16,7 +16,7 @@ use crate::profile::BuildProfile;
 use crate::targets::{Platform, PluginFormat, PluginTarget, Target, ValidateTarget};
 use crate::util::{
     common_program_files, copy_path, ensure_exists, env_value_or, home_dir, local_app_data, on_off,
-    remove_if_exists, run,
+    remove_if_exists, run, run_output,
 };
 use crate::validation::validate_wrac_rules;
 
@@ -936,6 +936,7 @@ pub(crate) fn validate_plugin_target(
             ensure_exists(&vst3, "VST3 artifact")?;
             let validator = ensure_vst3_validator(ctx)?;
             run(Command::new(validator).arg(&vst3).current_dir(&ctx.root))?;
+            validate_vst3_component_ids(ctx, &vst3)?;
         }
         ValidateTarget::Au => {
             ensure_no_system_au_conflict(ctx)?;
@@ -967,6 +968,52 @@ pub(crate) fn validate_plugin_target(
         }
     }
     Ok(())
+}
+
+fn validate_vst3_component_ids(ctx: &Context, vst3: &Path) -> Result<()> {
+    let moduleinfotool = ensure_vst3_moduleinfotool(ctx)?;
+    let output = run_output(
+        Command::new(moduleinfotool)
+            .args(["-create", "-version", &ctx.metadata.version, "-path"])
+            .arg(vst3)
+            .current_dir(&ctx.root),
+    )?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let actual = parse_moduleinfo_cids(&stdout);
+    let expected = ctx
+        .metadata
+        .plugins
+        .iter()
+        .map(|plugin| normalize_vst3_cid(&plugin.vst3_component_id))
+        .collect::<Vec<_>>();
+
+    if actual != expected {
+        return Err(format!(
+            "VST3 component ID mismatch for {}: metadata={expected:?}, moduleinfo={actual:?}",
+            vst3.display()
+        )
+        .into());
+    }
+
+    println!("VST3 component IDs match package.metadata.wrac.plugins.vst3_component_id");
+    Ok(())
+}
+
+fn parse_moduleinfo_cids(output: &str) -> Vec<String> {
+    output
+        .lines()
+        .filter_map(|line| line.split_once("\"CID\": \""))
+        .filter_map(|(_, rest)| rest.split_once('"'))
+        .map(|(cid, _)| normalize_vst3_cid(cid))
+        .collect()
+}
+
+fn normalize_vst3_cid(value: &str) -> String {
+    value
+        .chars()
+        .filter(|character| character.is_ascii_hexdigit())
+        .flat_map(char::to_uppercase)
+        .collect()
 }
 
 fn run_aax_validator(ctx: &Context, aax: &Path) -> Result<()> {
@@ -1593,6 +1640,43 @@ fn ensure_vst3_validator(ctx: &Context) -> Result<PathBuf> {
     }
 }
 
+fn ensure_vst3_moduleinfotool(ctx: &Context) -> Result<PathBuf> {
+    ensure_vst3_sdk_input(ctx)?;
+
+    let executable = if ctx.platform == Platform::Windows {
+        "moduleinfotool.exe"
+    } else {
+        "moduleinfotool"
+    };
+    let moduleinfotool_bin_dir = ctx.target_dir.join("vst3sdk-validator").join("bin");
+    let moduleinfotool = moduleinfotool_bin_dir.join("Debug").join(executable);
+    let moduleinfotool_without_config = moduleinfotool_bin_dir.join(executable);
+
+    if moduleinfotool.exists() {
+        return Ok(moduleinfotool);
+    }
+    if moduleinfotool_without_config.exists() {
+        return Ok(moduleinfotool_without_config);
+    }
+
+    let build_dir = ctx.target_dir.join("vst3sdk-validator");
+    run(Command::new("cmake")
+        .arg("--build")
+        .arg(&build_dir)
+        .arg("--target")
+        .arg("moduleinfotool")
+        .arg("--config")
+        .arg("Debug")
+        .current_dir(&ctx.root))?;
+
+    if moduleinfotool.exists() {
+        Ok(moduleinfotool)
+    } else {
+        ensure_exists(&moduleinfotool_without_config, "VST3 moduleinfotool")?;
+        Ok(moduleinfotool_without_config)
+    }
+}
+
 pub(crate) fn clean(ctx: &Context) -> Result<()> {
     remove_if_exists(&ctx.wrac_dir())?;
     Ok(())
@@ -1756,4 +1840,35 @@ fn codesign_nested_macos_bundle(bundle: &Path) -> Result<()> {
     }
     codesign(bundle)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_vst3_moduleinfo_cids_from_logged_output() {
+        let output = r#"
+clap-wrapper log before JSON
+{
+  "Classes": [
+    {
+      "CID": "822011CA37EC5CEF92D7EC7E67207195",
+      "Name": "WRAC Gain",
+    },
+    {
+      "CID": "ffff664c-b963-53e6-87cc-2a7ceb29674b",
+    },
+  ],
+}
+"#;
+
+        assert_eq!(
+            parse_moduleinfo_cids(output),
+            vec![
+                "822011CA37EC5CEF92D7EC7E67207195".to_string(),
+                "FFFF664CB96353E687CC2A7CEB29674B".to_string(),
+            ]
+        );
+    }
 }

--- a/crates/wrac_xtask/src/commands.rs
+++ b/crates/wrac_xtask/src/commands.rs
@@ -936,6 +936,10 @@ pub(crate) fn validate_plugin_target(
             ensure_exists(&vst3, "VST3 artifact")?;
             let validator = ensure_vst3_validator(ctx)?;
             run(Command::new(validator).arg(&vst3).current_dir(&ctx.root))?;
+            // The VST3 validator checks format behavior but does not prove that the
+            // host-visible class IDs match package metadata. moduleinfotool reads the built
+            // bundle metadata, so this catches build.rs/wrapper byte-order regressions at the
+            // artifact boundary instead of adding a product-policy readiness rule.
             validate_vst3_component_ids(ctx, &vst3)?;
         }
         ValidateTarget::Au => {

--- a/crates/wrac_xtask/src/util.rs
+++ b/crates/wrac_xtask/src/util.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Output};
 
 use crate::Result;
 
@@ -53,6 +53,22 @@ pub(crate) fn run(command: &mut Command) -> Result<()> {
         .into());
     }
     Ok(())
+}
+
+pub(crate) fn run_output(command: &mut Command) -> Result<Output> {
+    println!();
+    println!("========== Running command ==========");
+    println!("$ {}", format_command(command));
+    let output = command.output()?;
+    if !output.status.success() {
+        return Err(format!(
+            "command failed with status {}: {}",
+            output.status,
+            format_command(command)
+        )
+        .into());
+    }
+    Ok(output)
 }
 
 fn format_command(command: &Command) -> String {

--- a/plugins/wrac-gain/src-plugin/build.rs
+++ b/plugins/wrac-gain/src-plugin/build.rs
@@ -567,6 +567,13 @@ fn uuid_array_literal(value: &str) -> io::Result<String> {
             )
         })?;
     }
+    // clap-wrapper applies Steinberg's COM-compatible TUID byte flip before exposing
+    // the VST3 class ID. Store the inverse form here so the host-visible CID matches
+    // the UUID written in package.metadata.wrac.plugins.vst3_component_id.
+    bytes.swap(0, 3);
+    bytes.swap(1, 2);
+    bytes.swap(4, 5);
+    bytes.swap(6, 7);
     Ok(format!("{bytes:?}"))
 }
 


### PR DESCRIPTION
## Summary
- Fix VST3 component ID byte order and validate host-visible CIDs with moduleinfotool.
- Keep AUv2 CLAP GUI instances alive across AudioUnit cleanup so Cocoa view ownership controls teardown.
- Centralize host GUI policy decisions and keep lifecycle diagnostics at debug level.

## Verification
- cargo fmt --all --check
- cargo check -p wrac_clap_adapter -p wrac_wxp_gui -p wrac_xtask -p wrac_gain_plugin
- cargo test -p wrac_wxp_gui -p wrac_xtask -p wrac_gain_plugin --lib
- cargo clippy --workspace --all-targets -- -D warnings
- cargo xtask install
- cargo xtask validate