### PR TITLE
Keep AUv2 GUI alive through cleanup

### DIFF
--- a/clap_wrapper_builder/clap-wrapper/src/detail/auv2/auv2_shared.h
+++ b/clap_wrapper_builder/clap-wrapper/src/detail/auv2/auv2_shared.h
@@ -32,7 +32,7 @@ typedef struct ui_connection
   uint32_t *_canary = nullptr;       // a canary in the Windows class
   std::function<void(clap_window_t *, uint32_t *)> _registerWindow = nullptr;
   std::function<void()> _createWindow = nullptr;
-  std::function<void(const char *)> _destroyWindow = nullptr;
+  std::function<bool(clap_window_t *, uint32_t *, const char *)> _destroyWindow = nullptr;
 } ui_connection;
 
 }  // namespace free_audio::auv2_wrapper

--- a/clap_wrapper_builder/clap-wrapper/src/detail/auv2/auv2_shared.h
+++ b/clap_wrapper_builder/clap-wrapper/src/detail/auv2/auv2_shared.h
@@ -32,7 +32,7 @@ typedef struct ui_connection
   uint32_t *_canary = nullptr;       // a canary in the Windows class
   std::function<void(clap_window_t *, uint32_t *)> _registerWindow = nullptr;
   std::function<void()> _createWindow = nullptr;
-  std::function<void()> _destroyWindow = nullptr;
+  std::function<void(const char *)> _destroyWindow = nullptr;
 } ui_connection;
 
 }  // namespace free_audio::auv2_wrapper

--- a/clap_wrapper_builder/clap-wrapper/src/detail/auv2/wrappedview.asinclude.mm
+++ b/clap_wrapper_builder/clap-wrapper/src/detail/auv2/wrappedview.asinclude.mm
@@ -189,9 +189,11 @@ void CLAP_WRAPPER_TIMER_CALLBACK(CFRunLoopTimerRef timer, void *info)
   if (canary)
   {
     // Dealloc is the point where Cocoa proves the editor view itself is going away. Tie CLAP GUI
-    // teardown to this lifetime rather than to transient detach/Cleanup callbacks.
-    LOGINFO("[clap-wrapper] the host did not call viewDidMoveWindow with a nil window");
-    ui._destroyWindow("CLAP_WRAPPER_COCOA_CLASS_NSVIEW::dealloc");
+    // teardown to this lifetime rather than to transient detach/Cleanup callbacks. The wrapper
+    // still verifies ownership because a host may create a replacement view before releasing this
+    // detached one.
+    LOGINFO("[clap-wrapper] NS View dealloc requests CLAP GUI teardown");
+    ui._destroyWindow((clap_window_t *)self, &canary, "CLAP_WRAPPER_COCOA_CLASS_NSVIEW::dealloc");
   }
   [super dealloc];
 }

--- a/clap_wrapper_builder/clap-wrapper/src/detail/auv2/wrappedview.asinclude.mm
+++ b/clap_wrapper_builder/clap-wrapper/src/detail/auv2/wrappedview.asinclude.mm
@@ -31,6 +31,8 @@
 
 - (id)initWithAUv2:(free_audio::auv2_wrapper::ui_connection *)cont preferredSize:(NSSize)size;
 - (void)doIdle;
+- (void)startIdleTimer;
+- (void)stopIdleTimer;
 - (void)dealloc;
 - (void)setFrame:(NSRect)newSize;
 
@@ -86,7 +88,7 @@ void CLAP_WRAPPER_TIMER_CALLBACK(CFRunLoopTimerRef timer, void *info)
 
 - (id)initWithAUv2:(free_audio::auv2_wrapper::ui_connection *)cont preferredSize:(NSSize)size
 {
-  LOGINFO("[clap-wrapper] creating NSView");
+  LOGINFO("[clap-wrapper] creating NSView self={}", (void *)self);
 
   ui = *cont;
   canary = 0xbeebbeeb;
@@ -135,12 +137,7 @@ void CLAP_WRAPPER_TIMER_CALLBACK(CFRunLoopTimerRef timer, void *info)
   }
 
   idleTimer = nil;
-  CFTimeInterval TIMER_INTERVAL = .05;  // In SurgeGUISynthesizer.h it uses 50 ms
-  CFRunLoopTimerContext TimerContext = {0, self, NULL, NULL, NULL};
-  CFAbsoluteTime FireTime = CFAbsoluteTimeGetCurrent() + TIMER_INTERVAL;
-  idleTimer = CFRunLoopTimerCreate(kCFAllocatorDefault, FireTime, TIMER_INTERVAL, 0, 0,
-                                   CLAP_WRAPPER_TIMER_CALLBACK, &TimerContext);
-  if (idleTimer) CFRunLoopAddTimer(CFRunLoopGetMain(), idleTimer, kCFRunLoopCommonModes);
+  [self startIdleTimer];
 
   return self;
 }
@@ -149,37 +146,50 @@ void CLAP_WRAPPER_TIMER_CALLBACK(CFRunLoopTimerRef timer, void *info)
 {
   // auto gui = ui._plugin->_ext._gui;
 }
+- (void)startIdleTimer
+{
+  if (idleTimer) return;
+
+  CFTimeInterval TIMER_INTERVAL = .05;  // In SurgeGUISynthesizer.h it uses 50 ms
+  CFRunLoopTimerContext TimerContext = {0, self, NULL, NULL, NULL};
+  CFAbsoluteTime FireTime = CFAbsoluteTimeGetCurrent() + TIMER_INTERVAL;
+  idleTimer = CFRunLoopTimerCreate(kCFAllocatorDefault, FireTime, TIMER_INTERVAL, 0, 0,
+                                   CLAP_WRAPPER_TIMER_CALLBACK, &TimerContext);
+  if (idleTimer) CFRunLoopAddTimer(CFRunLoopGetMain(), idleTimer, kCFRunLoopCommonModes);
+}
+- (void)stopIdleTimer
+{
+  if (idleTimer)
+  {
+    CFRunLoopTimerInvalidate(idleTimer);
+    idleTimer = 0;
+  }
+}
 - (void)viewDidMoveToWindow
 {
   if ([self window] == nil)
   {
-    LOGINFO("[clap-wrapper] - view removed from a window");
-    if (idleTimer)
-    {
-      CFRunLoopTimerInvalidate(idleTimer);
-      idleTimer = 0;
-    }
-    if (canary)
-    {
-      ui._destroyWindow();
-
-      assert(canary == 0);
-    }
+    LOGINFO("[clap-wrapper] - view removed from a window; keeping CLAP GUI alive until dealloc self={}",
+            (void *)self);
+    [self stopIdleTimer];
+  }
+  else
+  {
+    LOGINFO("[clap-wrapper] - view attached to a window self={} window={}", (void *)self,
+            (void *)[self window]);
+    [self startIdleTimer];
   }
   [super viewDidMoveToWindow];
 }
 
 - (void)dealloc
 {
-  LOGINFO("[clap-wrapper] NS View dealloc");
-  if (idleTimer)
-  {
-    CFRunLoopTimerInvalidate(idleTimer);
-  }
+  LOGINFO("[clap-wrapper] NS View dealloc self={} canary={}", (void *)self, canary);
+  [self stopIdleTimer];
   if (canary)
   {
     LOGINFO("[clap-wrapper] the host did not call viewDidMoveWindow with a nil window");
-    ui._destroyWindow();
+    ui._destroyWindow("CLAP_WRAPPER_COCOA_CLASS_NSVIEW::dealloc");
   }
   [super dealloc];
 }

--- a/clap_wrapper_builder/clap-wrapper/src/detail/auv2/wrappedview.asinclude.mm
+++ b/clap_wrapper_builder/clap-wrapper/src/detail/auv2/wrappedview.asinclude.mm
@@ -88,7 +88,7 @@ void CLAP_WRAPPER_TIMER_CALLBACK(CFRunLoopTimerRef timer, void *info)
 
 - (id)initWithAUv2:(free_audio::auv2_wrapper::ui_connection *)cont preferredSize:(NSSize)size
 {
-  LOGINFO("[clap-wrapper] creating NSView self={}", (void *)self);
+  LOGINFO("[clap-wrapper] creating NSView");
 
   ui = *cont;
   canary = 0xbeebbeeb;
@@ -169,14 +169,14 @@ void CLAP_WRAPPER_TIMER_CALLBACK(CFRunLoopTimerRef timer, void *info)
 {
   if ([self window] == nil)
   {
-    LOGINFO("[clap-wrapper] - view removed from a window; keeping CLAP GUI alive until dealloc self={}",
-            (void *)self);
+    // Some AUv2 hosts temporarily detach the editor view while the plugin instance remains
+    // active. Destroying the CLAP GUI here leaves the host-owned NSView alive with no child
+    // WebView to redraw, which shows up as a blank editor on the next transport transition.
+    LOGINFO("[clap-wrapper] - view removed from a window; keeping CLAP GUI alive until dealloc");
     [self stopIdleTimer];
   }
   else
   {
-    LOGINFO("[clap-wrapper] - view attached to a window self={} window={}", (void *)self,
-            (void *)[self window]);
     [self startIdleTimer];
   }
   [super viewDidMoveToWindow];
@@ -184,10 +184,12 @@ void CLAP_WRAPPER_TIMER_CALLBACK(CFRunLoopTimerRef timer, void *info)
 
 - (void)dealloc
 {
-  LOGINFO("[clap-wrapper] NS View dealloc self={} canary={}", (void *)self, canary);
+  LOGINFO("[clap-wrapper] NS View dealloc");
   [self stopIdleTimer];
   if (canary)
   {
+    // Dealloc is the point where Cocoa proves the editor view itself is going away. Tie CLAP GUI
+    // teardown to this lifetime rather than to transient detach/Cleanup callbacks.
     LOGINFO("[clap-wrapper] the host did not call viewDidMoveWindow with a nil window");
     ui._destroyWindow("CLAP_WRAPPER_COCOA_CLASS_NSVIEW::dealloc");
   }

--- a/clap_wrapper_builder/clap-wrapper/src/wrapasauv2.cpp
+++ b/clap_wrapper_builder/clap-wrapper/src/wrapasauv2.cpp
@@ -640,10 +640,11 @@ OSStatus WrapAsAUV2::Stop()
 }
 void WrapAsAUV2::Cleanup()
 {
-  LOGINFO("[clap-wrapper] Cleaning up Plugin uiIsOpened={} canary={}", this->_uiIsOpened,
-          (void *)this->_uiconn._canary);
+  LOGINFO("[clap-wrapper] Cleaning up Plugin uiIsOpened={}", this->_uiIsOpened);
   auto guarantee_mainthread = _plugin->AlwaysMainThread();
-  LOGINFO("[clap-wrapper] AUv2 Cleanup keeps CLAP GUI alive; Cocoa view/destructor own GUI teardown");
+  // AudioUnit hosts can call Cleanup while the Cocoa editor view is still alive. The NSView
+  // dealloc/destructor paths own CLAP GUI teardown; doing it here can leave a live host view with a
+  // destroyed child WebView.
   deactivateCLAP();
   Base::Cleanup();
 }

--- a/clap_wrapper_builder/clap-wrapper/src/wrapasauv2.cpp
+++ b/clap_wrapper_builder/clap-wrapper/src/wrapasauv2.cpp
@@ -796,11 +796,25 @@ OSStatus WrapAsAUV2::GetProperty(AudioUnitPropertyID inID, AudioUnitScope inScop
         };
         _uiconn._createWindow = [this]
         {
+          // A host may replace the Cocoa view after a transient detach. The CLAP GUI remains alive
+          // across that detach so the new view should reparent it, not create a second GUI instance.
+          if (this->_uiIsOpened)
+          {
+            LOGINFO("[clap-wrapper] AUv2 reusing CLAP GUI for replacement Cocoa view");
+            return;
+          }
           this->_uiIsOpened = true;
           _plugin->_ext._gui->create(_plugin->_plugin, CLAP_WINDOW_API_COCOA, false);
         };
-        _uiconn._destroyWindow = [this](const char *reason)
+        _uiconn._destroyWindow = [this](clap_window_t *window, uint32_t *canary, const char *reason)
         {
+          if (this->_uiconn._window != window || this->_uiconn._canary != canary)
+          {
+            LOGINFO("[clap-wrapper] AUv2 ignoring stale CLAP GUI destroy: reason={}",
+                    reason ? reason : "unknown");
+            return false;
+          }
+
           LOGINFO("[clap-wrapper] AUv2 destroying CLAP GUI: reason={}",
                   reason ? reason : "unknown");
           // this must exist
@@ -810,7 +824,10 @@ OSStatus WrapAsAUV2::GetProperty(AudioUnitPropertyID inID, AudioUnitScope inScop
           if (this->_uiconn._canary)
           {
             *(this->_uiconn._canary) = 0;
+            this->_uiconn._canary = nullptr;
           }
+          this->_uiconn._window = nullptr;
+          return true;
         };
         *static_cast<ui_connection *>(outData) = _uiconn;
         return noErr;

--- a/clap_wrapper_builder/clap-wrapper/src/wrapasauv2.cpp
+++ b/clap_wrapper_builder/clap-wrapper/src/wrapasauv2.cpp
@@ -162,6 +162,7 @@ WrapAsAUV2::~WrapAsAUV2()
       *_uiconn._canary = 0;       // notify the view
       _uiconn._canary = nullptr;  // disable the canary reference
 
+      LOGINFO("[clap-wrapper] AUv2 destroying CLAP GUI: reason=WrapAsAUV2::~WrapAsAUV2");
       // close destroy the gui ourselves
       _plugin->_ext._gui->destroy(_plugin->_plugin);
       _uiIsOpened = false;
@@ -639,22 +640,10 @@ OSStatus WrapAsAUV2::Stop()
 }
 void WrapAsAUV2::Cleanup()
 {
-  LOGINFO("[clap-wrapper] Cleaning up Plugin");
+  LOGINFO("[clap-wrapper] Cleaning up Plugin uiIsOpened={} canary={}", this->_uiIsOpened,
+          (void *)this->_uiconn._canary);
   auto guarantee_mainthread = _plugin->AlwaysMainThread();
-  if (this->_uiIsOpened)
-  {
-    LOGINFO("[clap-wrapper] !! UI still open, destroying UI and disconnecting view");
-    if (_uiconn._canary)
-    {
-      *_uiconn._canary = 0;       // reset the canary
-      _uiconn._canary = nullptr;  // and disconnect it
-      if (_plugin->_plugin && _plugin->_ext._gui)
-      {
-        this->_uiconn._destroyWindow();
-        this->_plugin->_ext._gui->destroy(_plugin->_plugin);
-      }
-    }
-  }
+  LOGINFO("[clap-wrapper] AUv2 Cleanup keeps CLAP GUI alive; Cocoa view/destructor own GUI teardown");
   deactivateCLAP();
   Base::Cleanup();
 }
@@ -809,8 +798,10 @@ OSStatus WrapAsAUV2::GetProperty(AudioUnitPropertyID inID, AudioUnitScope inScop
           this->_uiIsOpened = true;
           _plugin->_ext._gui->create(_plugin->_plugin, CLAP_WINDOW_API_COCOA, false);
         };
-        _uiconn._destroyWindow = [this]
+        _uiconn._destroyWindow = [this](const char *reason)
         {
+          LOGINFO("[clap-wrapper] AUv2 destroying CLAP GUI: reason={}",
+                  reason ? reason : "unknown");
           // this must exist
           _plugin->_ext._gui->destroy(_plugin->_plugin);
 


### PR DESCRIPTION
## Summary
- Keep the CLAP GUI alive when AUv2 Cleanup runs while the Cocoa editor view is still owned by the host.
- Move GUI teardown ownership to the NSView dealloc/destructor path and document why transient detach/Cleanup callbacks must not destroy the WebView.

## Verification
- cargo xtask validate --target=au