### PR TITLE
Fix WRAC VST3 resize requests in Audacity

### DIFF
--- a/clap_wrapper_builder/clap-wrapper/src/detail/vst3/plugview.cpp
+++ b/clap_wrapper_builder/clap-wrapper/src/detail/vst3/plugview.cpp
@@ -263,7 +263,17 @@ bool WrappedView::request_resize(uint32_t width, uint32_t height)
   _rect.right = _rect.left + (int32)width;
   _rect.bottom = _rect.top + (int32)height;
 
-  if (_plugFrame && !_plugFrame->resizeView(this, &_rect))
+  if (_plugFrame)
+  {
+    auto result = _plugFrame->resizeView(this, &_rect);
+    // Steinberg uses kResultOk == 0, so this cannot be tested as a boolean failure.
+    if (result != kResultOk)
+    {
+      _rect = oldrect;
+      return false;
+    }
+  }
+  else
   {
     _rect = oldrect;
     return false;

--- a/clap_wrapper_builder/clap-wrapper/src/detail/vst3/plugview.cpp
+++ b/clap_wrapper_builder/clap-wrapper/src/detail/vst3/plugview.cpp
@@ -266,7 +266,9 @@ bool WrappedView::request_resize(uint32_t width, uint32_t height)
   if (_plugFrame)
   {
     auto result = _plugFrame->resizeView(this, &_rect);
-    // Steinberg uses kResultOk == 0, so this cannot be tested as a boolean failure.
+    // VST3 tresult is not a bool: kResultOk is 0. Treating resizeView() with
+    // boolean negation reports successful host resizes as rejected and rolls
+    // back _rect, even after the host has accepted the size via onSize().
     if (result != kResultOk)
     {
       _rect = oldrect;

--- a/clap_wrapper_builder/clap-wrapper/src/wrapasvst3.cpp
+++ b/clap_wrapper_builder/clap-wrapper/src/wrapasvst3.cpp
@@ -1246,10 +1246,15 @@ bool ClapAsVst3::gui_can_resize()
 
 bool ClapAsVst3::gui_request_resize(uint32_t width, uint32_t height)
 {
+  const bool hasMainThreadId = _main_thread_id != std::thread::id{};
+
   // UIs with 65kx65k resolution are not supported
   if ((width > 0xffff) || (height > 0xffff)) return false;
 
-  if (_main_thread_id != std::this_thread::get_id())
+  // This vendored WRAC wrapper can leave _main_thread_id default-constructed. Audacity
+  // macOS VST3 does not drain the deferred onIdle resize path, so treating that unknown
+  // thread state as "not main" prevents GUI-run-loop resizes from reaching resizeView().
+  if (hasMainThreadId && _main_thread_id != std::this_thread::get_id())
   {
     uint32_t newSize = ((width & 0xffff) << 16) | (height & 0xffff);
     _gui_resize_request.store(newSize);

--- a/clap_wrapper_builder/clap-wrapper/src/wrapasvst3.cpp
+++ b/clap_wrapper_builder/clap-wrapper/src/wrapasvst3.cpp
@@ -1251,9 +1251,11 @@ bool ClapAsVst3::gui_request_resize(uint32_t width, uint32_t height)
   // UIs with 65kx65k resolution are not supported
   if ((width > 0xffff) || (height > 0xffff)) return false;
 
-  // This vendored WRAC wrapper can leave _main_thread_id default-constructed. Audacity
-  // macOS VST3 does not drain the deferred onIdle resize path, so treating that unknown
-  // thread state as "not main" prevents GUI-run-loop resizes from reaching resizeView().
+  // CLAP marks gui.request_resize() as thread-safe, but WRAC issues these resize
+  // requests from its GUI run-loop command path. Until the wrapper records a real
+  // main-thread id upstream, do not treat the default-constructed id as "not main":
+  // Audacity macOS VST3 never drains this deferred onIdle path, so deferring here
+  // drops WRAC resize requests before they reach resizeView().
   if (hasMainThreadId && _main_thread_id != std::this_thread::get_id())
   {
     uint32_t newSize = ((width & 0xffff) << 16) | (height & 0xffff);

--- a/clap_wrapper_builder/clap-wrapper/src/wrapasvst3.cpp
+++ b/clap_wrapper_builder/clap-wrapper/src/wrapasvst3.cpp
@@ -1251,11 +1251,17 @@ bool ClapAsVst3::gui_request_resize(uint32_t width, uint32_t height)
   // UIs with 65kx65k resolution are not supported
   if ((width > 0xffff) || (height > 0xffff)) return false;
 
-  // CLAP marks gui.request_resize() as thread-safe, but WRAC issues these resize
-  // requests from its GUI run-loop command path. Until the wrapper records a real
-  // main-thread id upstream, do not treat the default-constructed id as "not main":
-  // Audacity macOS VST3 never drains this deferred onIdle path, so deferring here
-  // drops WRAC resize requests before they reach resizeView().
+  // Deferring this request breaks WRAC resizing in Audacity macOS VST3: Audacity
+  // does not drain the wrapper's onIdle resize queue, so resizeView() is never
+  // reached and the host window falls out of sync with the inner WebView. In this
+  // vendored WRAC subtree, a missing main-thread id therefore falls through to the
+  // direct WrappedView::request_resize() path.
+  //
+  // CLAP defines gui.request_resize() as thread-safe, but WRAC only calls it from
+  // its GUI run-loop command path, so this direct path is valid for WRAC.
+  //
+  // TODO: Remove this workaround once the upstream wrapper records the actual
+  // main-thread id and can reliably choose between the direct and deferred paths.
   if (hasMainThreadId && _main_thread_id != std::this_thread::get_id())
   {
     uint32_t newSize = ((width & 0xffff) << 16) | (height & 0xffff);


### PR DESCRIPTION
## Summary
- Fix WRAC VST3 plugin-initiated resize requests when the vendored wrapper has no recorded main-thread id.
- Preserve the existing deferred resize path when a main-thread id is available, but call resizeView() directly for the default-constructed/unknown state.
- Treat Steinberg kResultOk correctly in WrappedView::request_resize() instead of testing the tresult as a boolean failure.

## Why
Audacity 3.7.7 on macOS VST3 exposed this with WRAC Gain internal resize-handle dragging. Logging showed that WRAC sent resize requests to the vendored VST3 wrapper, but every request saw the wrapper main-thread id as default-constructed and was deferred. In Audacity macOS VST3, the deferred resize queue was not drained via onIdle(), so IPlugFrame::resizeView() was never reached.

After allowing the unknown-thread-id state to use the direct path, the same test reached WrappedView::request_resize(), Audacity called onSize() re-entrantly, and WRAC updated the WebView from the host-confirmed size. The old resize-handle-disabling PR (#99) was closed because disabling the handle is no longer the right approach.

This is a WRAC-local workaround for the vendored wrapper's missing main-thread-id tracking. Once the upstream wrapper records the actual main-thread id and can reliably choose between the direct and deferred resize paths, this workaround should be removed in favor of the upstream behavior.

The follow-up log also showed resizeView() returning raw result 0, which is Steinberg kResultOk. The wrapper previously treated that as failure through boolean negation, so successful host resizes were reported back as rejected. This PR compares the tresult against kResultOk explicitly.

## Tests
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- npm run --prefix plugins/wrac-gain/src-gui build -- --mode development
- cargo xtask build --target=vst3
