### PR TITLE
Refine parameter flush event contract

### DIFF
--- a/crates/wrac_clap_adapter/src/api/extensions/latency.rs
+++ b/crates/wrac_clap_adapter/src/api/extensions/latency.rs
@@ -1,5 +1,5 @@
 /// CLAP latency extension.
 pub trait PluginLatencyExtension: Send + Sync + 'static {
-    /// Called from CLAP `latency.get`. `[thread-safe & control-thread]`
+    /// Called from CLAP `latency.get`. `[thread-safe]`
     fn latency_frames(&self) -> u32;
 }

--- a/crates/wrac_clap_adapter/src/api/extensions/params.rs
+++ b/crates/wrac_clap_adapter/src/api/extensions/params.rs
@@ -1,26 +1,28 @@
-use crate::{ParamInfo, ParamValueEvent, PluginResult};
+use crate::{ParamInfo, ParamInputEvents, PluginResult};
 
 /// CLAP params extension.
 ///
 /// Native CLAP marks parameter queries `[main-thread]`, but wrappers may query them
-/// from `[control-thread]`. Query methods are not audio-thread APIs.
+/// from control or realtime workers. Query methods must be realtime-safe.
 pub trait PluginParamsExtension: Send + Sync + 'static {
-    /// Called from CLAP `params.count`. `[thread-safe & control-thread]`
+    /// Called from CLAP `params.count`. `[thread-safe]`
     fn param_count(&self) -> u32;
 
-    /// Called from CLAP `params.get_info`. `[thread-safe & control-thread]`
+    /// Called from CLAP `params.get_info`. `[thread-safe]`
     fn param_info(&self, index: u32) -> Option<ParamInfo>;
 
-    /// Called from CLAP `params.get_value`. `[thread-safe & control-thread]`
+    /// Called from CLAP `params.get_value`. `[thread-safe]`
     fn param_value(&self, param_id: u32) -> PluginResult<f64>;
 
     /// Called from CLAP `params.flush` input parameter events.
     /// `[control-thread,audio-thread]`
     ///
     /// CLAP may call `params.flush` on the audio thread while active, but not
-    /// concurrently with `plugin.process`. Parameter events delivered to
-    /// `plugin.process` are handled by `Processor::process`, not this method.
-    fn apply_param_value(&self, event: ParamValueEvent) -> PluginResult<f64>;
+    /// concurrently with `plugin.process`. The event-list boundary is preserved
+    /// so implementations can handle ordered parameter updates as one callback.
+    /// Parameter events delivered to `plugin.process` are handled by
+    /// `Processor::process`, not this method.
+    fn apply_param_events(&self, events: ParamInputEvents<'_>) -> PluginResult<()>;
 
     /// Called from CLAP `params.value_to_text`. `[thread-safe & control-thread]`
     fn value_to_text(&self, param_id: u32, value: f64) -> PluginResult<String>;

--- a/crates/wrac_clap_adapter/src/api/extensions/render.rs
+++ b/crates/wrac_clap_adapter/src/api/extensions/render.rs
@@ -3,7 +3,7 @@ use crate::{PluginRenderMode, PluginResult};
 /// CLAP render extension.
 pub trait PluginRenderExtension: Send + Sync + 'static {
     /// Called from CLAP `render.has_hard_realtime_requirement`.
-    /// `[thread-safe & control-thread]`
+    /// `[thread-safe]`
     fn has_hard_realtime_requirement(&self) -> bool {
         false
     }

--- a/crates/wrac_clap_adapter/src/api/extensions/tail.rs
+++ b/crates/wrac_clap_adapter/src/api/extensions/tail.rs
@@ -1,5 +1,5 @@
 /// CLAP tail extension.
 pub trait PluginTailExtension: Send + Sync + 'static {
-    /// Called from CLAP `tail.get`. `[control-thread,audio-thread]`
+    /// Called from CLAP `tail.get`. `[thread-safe]`
     fn tail_frames(&self) -> u32;
 }

--- a/crates/wrac_clap_adapter/src/events.rs
+++ b/crates/wrac_clap_adapter/src/events.rs
@@ -105,6 +105,30 @@ impl<'a> InputEvents<'a> {
             _ => None,
         })
     }
+
+    pub fn param_events(&self) -> ParamInputEvents<'a> {
+        ParamInputEvents { input: *self }
+    }
+}
+
+/// View over parameter input events delivered by `params.flush()`.
+///
+/// This preserves the CLAP callback's event-list boundary while exposing only
+/// parameter value events to product code. The underlying host-owned event list is
+/// confined to the callback lifetime.
+#[derive(Clone, Copy)]
+pub struct ParamInputEvents<'a> {
+    input: InputEvents<'a>,
+}
+
+impl<'a> ParamInputEvents<'a> {
+    pub fn values(&self) -> impl Iterator<Item = ParamValueEvent> + '_ {
+        self.input.parameter_values()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.values().next().is_none()
+    }
 }
 
 pub struct InputEventsIter<'a> {

--- a/crates/wrac_clap_adapter/src/lib.rs
+++ b/crates/wrac_clap_adapter/src/lib.rs
@@ -33,8 +33,8 @@ pub use descriptor::{
 pub use entry::{EntryContext, PluginEntry, PluginFactory};
 pub use events::{
     InputEvent, InputEvents, Midi2Event, MidiEvent, MidiSysexEvent, NoteEvent, NoteExpressionEvent,
-    OutputEvent, OutputEvents, ParamGestureEvent, ParamModEvent, ProcessEvents, TransportEvent,
-    TransportFlags, UnknownEvent,
+    OutputEvent, OutputEvents, ParamGestureEvent, ParamInputEvents, ParamModEvent, ProcessEvents,
+    TransportEvent, TransportFlags, UnknownEvent,
 };
 pub use process_buffer::{
     AudioBufferError, AudioChannelPair, AudioPairedChannels, AudioPortChannels, AudioPortPair,

--- a/crates/wrac_clap_adapter/src/params.rs
+++ b/crates/wrac_clap_adapter/src/params.rs
@@ -33,14 +33,8 @@ impl ParameterEditQueue {
         parameters: &dyn PluginParamsExtension,
         events: &InputEvents<'_>,
     ) {
-        for event in events.parameter_values() {
-            if let Err(error) = parameters.apply_param_value(event) {
-                wrac_log::rtwarn!(
-                    "parameter_edits.apply_input: parameter apply failed param_id={} value={} error={error}",
-                    event.param_id,
-                    event.value
-                );
-            }
+        if let Err(error) = parameters.apply_param_events(events.param_events()) {
+            wrac_log::rtwarn!("parameter_edits.apply_input: parameter apply failed: {error}");
         }
     }
 

--- a/plugins/wrac-gain/src-plugin/src/plugin/params.rs
+++ b/plugins/wrac-gain/src-plugin/src/plugin/params.rs
@@ -143,10 +143,25 @@ impl PluginParamsExtension for WracGainParamsExtension {
     /// Called when parameter values arrive from the host as input events.
     fn apply_param_events(&self, events: ParamInputEvents<'_>) -> PluginResult<()> {
         for event in events.values() {
-            let plain_value = parameter_host_input_to_plain(event.param_id, event.value)?;
-            self.shared
+            let Ok(plain_value) = parameter_host_input_to_plain(event.param_id, event.value) else {
+                wrac_log::rtwarn!(
+                    "params.flush: ignoring invalid parameter input param_id={} value={}",
+                    event.param_id,
+                    event.value
+                );
+                continue;
+            };
+            if self
+                .shared
                 .set_parameter_value(event.param_id, plain_value)
-                .ok_or(PluginError::InvalidParameter)?;
+                .is_none()
+            {
+                wrac_log::rtwarn!(
+                    "params.flush: ignoring unknown parameter input param_id={} value={}",
+                    event.param_id,
+                    event.value
+                );
+            }
         }
         Ok(())
     }

--- a/plugins/wrac-gain/src-plugin/src/plugin/params.rs
+++ b/plugins/wrac-gain/src-plugin/src/plugin/params.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use wrac_clap_adapter::{
-    ParamFlags, ParamInfo, ParamValueEvent, PluginError, PluginParamsExtension, PluginResult,
+    ParamFlags, ParamInfo, ParamInputEvents, PluginError, PluginParamsExtension, PluginResult,
 };
 
 use crate::state::SharedState;
@@ -140,14 +140,15 @@ impl PluginParamsExtension for WracGainParamsExtension {
         Ok(plain_to_host(spec, value))
     }
 
-    /// Called when a parameter value arrives from the host as an input event.
-    fn apply_param_value(&self, event: ParamValueEvent) -> PluginResult<f64> {
-        let plain_value = parameter_host_input_to_plain(event.param_id, event.value)?;
-        let applied = self
-            .shared
-            .set_parameter_value(event.param_id, plain_value)
-            .ok_or(PluginError::InvalidParameter)?;
-        parameter_host_value(event.param_id, applied)
+    /// Called when parameter values arrive from the host as input events.
+    fn apply_param_events(&self, events: ParamInputEvents<'_>) -> PluginResult<()> {
+        for event in events.values() {
+            let plain_value = parameter_host_input_to_plain(event.param_id, event.value)?;
+            self.shared
+                .set_parameter_value(event.param_id, plain_value)
+                .ok_or(PluginError::InvalidParameter)?;
+        }
+        Ok(())
     }
 
     /// Converts a host-domain value to a display string. Example: 0.5 -> "0.0 dB".


### PR DESCRIPTION
## Summary
- Replace `PluginParamsExtension::apply_param_value` with batch-oriented `apply_param_events`
- Add `ParamInputEvents` to preserve the `params.flush` input event-list boundary
- Remove the unused applied-value return from the parameter flush path
- Promote selected query annotations to `[thread-safe]`

## Verification
- `cargo check --workspace --all-targets`
- `cargo test -p wrac_clap_adapter -p wrac_gain_plugin`