### PR TITLE
Build only selected standalone app on launch

### DIFF
--- a/crates/wrac_xtask/src/cli.rs
+++ b/crates/wrac_xtask/src/cli.rs
@@ -197,7 +197,11 @@ pub(crate) struct BuildArgs {
     )]
     pub(crate) target: Vec<Target>,
 
-    #[arg(skip)]
+    #[arg(
+        long = "plugin-id",
+        value_name = "PLUGIN_ID",
+        help = "Standalone plugin ID to build when --target includes standalone."
+    )]
     pub(crate) standalone_plugin_id: Option<String>,
 }
 

--- a/crates/wrac_xtask/src/cli.rs
+++ b/crates/wrac_xtask/src/cli.rs
@@ -196,6 +196,9 @@ pub(crate) struct BuildArgs {
         long_help = "Targets to build, comma-separated. Supported values are clap, vst3, au, aax, and standalone. Defaults to wrac-plugin.toml supported_formats supported on this platform plus standalone."
     )]
     pub(crate) target: Vec<Target>,
+
+    #[arg(skip)]
+    pub(crate) standalone_plugin_id: Option<String>,
 }
 
 #[derive(Debug, Args)]

--- a/crates/wrac_xtask/src/commands.rs
+++ b/crates/wrac_xtask/src/commands.rs
@@ -11,7 +11,7 @@ use serde_json::Value;
 use crate::Result;
 use crate::cli::{InstallScope, UninstallScope};
 use crate::context::Context;
-use crate::metadata::PluginMetadata;
+use crate::metadata::{PluginMetadata, PluginProductMetadata};
 use crate::profile::BuildProfile;
 use crate::targets::{Platform, PluginFormat, PluginTarget, Target, ValidateTarget};
 use crate::util::{
@@ -487,9 +487,10 @@ pub(crate) fn build_wrapper_target(
     profile: BuildProfile,
     build: WrapperBuild,
     target: WrapperTarget,
+    standalone_plugin_id: Option<&str>,
 ) -> Result<()> {
     let build_dir = ctx.cmake_dir(build.purpose(), profile);
-    for cmake_target in cmake_wrapper_targets(ctx, build, target) {
+    for cmake_target in cmake_wrapper_targets(ctx, build, target, standalone_plugin_id)? {
         // Build the concrete CMake target for this DAG node instead of ALL_BUILD.
         // That keeps dry-run output aligned with the actual work and lets
         // independent format tasks fail or pass separately.
@@ -544,7 +545,8 @@ pub(crate) fn build_wrapper_target(
             }
         }
         WrapperTarget::Standalone => {
-            for artifact in ctx.standalone_artifacts(profile) {
+            for (_, plugin) in standalone_products(ctx, standalone_plugin_id)? {
+                let artifact = ctx.standalone_artifact_for(profile, plugin);
                 ensure_exists(&artifact, "standalone artifact")?;
                 if ctx.platform == Platform::Macos {
                     // Apply the same Gatekeeper/loader treatment to the standalone app as to plugin bundles.
@@ -565,20 +567,39 @@ pub(crate) enum WrapperTarget {
     Standalone,
 }
 
-fn cmake_wrapper_targets(ctx: &Context, build: WrapperBuild, target: WrapperTarget) -> Vec<String> {
+fn cmake_wrapper_targets(
+    ctx: &Context,
+    build: WrapperBuild,
+    target: WrapperTarget,
+    standalone_plugin_id: Option<&str>,
+) -> Result<Vec<String>> {
     let base = build.target_name_base(ctx);
-    match target {
+    Ok(match target {
         WrapperTarget::Vst3 => vec![format!("{base}_vst3")],
         WrapperTarget::Aax => vec![format!("{base}_aax")],
         WrapperTarget::Au => vec![format!("{base}_auv2")],
-        WrapperTarget::Standalone => ctx
+        WrapperTarget::Standalone => standalone_products(ctx, standalone_plugin_id)?
+            .iter()
+            .map(|(index, _)| format!("{base}_product_{index}_standalone"))
+            .collect::<Vec<_>>(),
+    })
+}
+
+fn standalone_products<'a>(
+    ctx: &'a Context,
+    plugin_id: Option<&str>,
+) -> Result<Vec<(usize, &'a PluginProductMetadata)>> {
+    if let Some(plugin_id) = plugin_id {
+        return ctx
             .metadata
             .plugins
             .iter()
             .enumerate()
-            .map(|(index, _)| format!("{base}_product_{index}_standalone"))
-            .collect::<Vec<_>>(),
+            .find(|(_, plugin)| plugin.plugin_id == plugin_id)
+            .map(|(index, plugin)| vec![(index, plugin)])
+            .ok_or_else(|| format!("plugin ID not found in WRAC metadata: {plugin_id}").into());
     }
+    Ok(ctx.metadata.plugins.iter().enumerate().collect())
 }
 
 fn push_cmake_arg(args: &mut Vec<OsString>, arg: impl Into<OsString>) {
@@ -1835,7 +1856,12 @@ fn env_path(ctx: &Context, key: &str) -> Result<Option<PathBuf>> {
     }
 }
 
-pub(crate) fn print_outputs(ctx: &Context, profile: BuildProfile, targets: &[Target]) {
+pub(crate) fn print_outputs(
+    ctx: &Context,
+    profile: BuildProfile,
+    targets: &[Target],
+    standalone_plugin_id: Option<&str>,
+) -> Result<()> {
     for target in targets {
         match target {
             Target::Clap => println!("CLAP: {}", ctx.clap_bundle(profile).display()),
@@ -1847,12 +1873,14 @@ pub(crate) fn print_outputs(ctx: &Context, profile: BuildProfile, targets: &[Tar
                 }
             }
             Target::Standalone => {
-                for artifact in ctx.standalone_artifacts(profile) {
+                for (_, plugin) in standalone_products(ctx, standalone_plugin_id)? {
+                    let artifact = ctx.standalone_artifact_for(profile, plugin);
                     println!("Standalone: {}", artifact.display());
                 }
             }
         }
     }
+    Ok(())
 }
 
 fn macos_clap_info_plist(metadata: &PluginMetadata) -> String {

--- a/crates/wrac_xtask/src/context.rs
+++ b/crates/wrac_xtask/src/context.rs
@@ -136,14 +136,6 @@ impl Context {
             .join(self.metadata.au_bundle_name())
     }
 
-    pub(crate) fn standalone_artifacts(&self, profile: BuildProfile) -> Vec<PathBuf> {
-        self.metadata
-            .plugins
-            .iter()
-            .map(|plugin| self.standalone_artifact_for(profile, plugin))
-            .collect()
-    }
-
     pub(crate) fn standalone_artifact_for(
         &self,
         profile: BuildProfile,

--- a/crates/wrac_xtask/src/lib.rs
+++ b/crates/wrac_xtask/src/lib.rs
@@ -69,6 +69,7 @@ pub struct BuildOptions {
     pub dry_run: bool,
     pub continue_on_error: bool,
     pub target: Vec<Target>,
+    pub plugin_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -180,7 +181,7 @@ impl WracWorkspace {
             dry_run: options.dry_run,
             continue_on_error: options.continue_on_error,
             target: options.target,
-            standalone_plugin_id: None,
+            standalone_plugin_id: options.plugin_id,
         };
         // Keep build/install logic scoped to one plugin package at a time. A package may
         // export multiple plugin products; the shared Context is still the correct unit for
@@ -326,6 +327,7 @@ impl From<cli::Commands> for WracCommand {
                 dry_run: args.dry_run,
                 continue_on_error: args.continue_on_error,
                 target: args.target,
+                plugin_id: args.standalone_plugin_id,
             }),
             cli::Commands::Install(args) => Self::Install(InstallOptions {
                 package: args.package,

--- a/crates/wrac_xtask/src/lib.rs
+++ b/crates/wrac_xtask/src/lib.rs
@@ -180,6 +180,7 @@ impl WracWorkspace {
             dry_run: options.dry_run,
             continue_on_error: options.continue_on_error,
             target: options.target,
+            standalone_plugin_id: None,
         };
         // Keep build/install logic scoped to one plugin package at a time. A package may
         // export multiple plugin products; the shared Context is still the correct unit for
@@ -444,6 +445,7 @@ fn args_for_launch_build(args: &cli::LaunchArgs) -> cli::BuildArgs {
         dry_run: false,
         continue_on_error: false,
         target: vec![targets::Target::Standalone],
+        standalone_plugin_id: args.plugin_id.clone(),
     }
 }
 

--- a/crates/wrac_xtask/src/plan.rs
+++ b/crates/wrac_xtask/src/plan.rs
@@ -83,7 +83,9 @@ enum TaskKind {
     BuildVst3Bundle,
     BuildAuBundle,
     BuildAaxBundle,
-    BuildStandaloneBundle,
+    BuildStandaloneBundle {
+        plugin_id: Option<String>,
+    },
     CheckInstallScope {
         target: PluginTarget,
         scope: crate::cli::InstallScope,
@@ -128,7 +130,10 @@ impl TaskKind {
             Self::BuildVst3Bundle => "build VST3 bundle".to_string(),
             Self::BuildAuBundle => "build AU bundle".to_string(),
             Self::BuildAaxBundle => "build AAX bundle".to_string(),
-            Self::BuildStandaloneBundle => "build standalone artifact".to_string(),
+            Self::BuildStandaloneBundle { plugin_id } => match plugin_id {
+                Some(plugin_id) => format!("build standalone artifact ({plugin_id})"),
+                None => "build standalone artifact".to_string(),
+            },
             Self::CheckInstallScope { target, scope } => {
                 format!("check install scope for {} ({scope:?})", target.display())
             }
@@ -251,7 +256,14 @@ pub(crate) fn run_build(ctx: &Context, args: &BuildArgs) -> Result<()> {
     let targets = resolve_build_targets_from_metadata(ctx, &args.target)?;
     // The command only chooses terminal build tasks. The graph builder expands
     // those into Rust, wrapper-configure, and format-specific build tasks.
-    let graph = build_graph(ctx, CommandKind::Build, &targets, args.clean, None)?;
+    let graph = build_graph(
+        ctx,
+        CommandKind::Build,
+        &targets,
+        args.clean,
+        None,
+        args.standalone_plugin_id.clone(),
+    )?;
     execute_plan(
         ctx,
         profile,
@@ -260,7 +272,7 @@ pub(crate) fn run_build(ctx: &Context, args: &BuildArgs) -> Result<()> {
         failure_policy(args.continue_on_error),
     )?;
     if !args.dry_run {
-        print_outputs(ctx, profile, &targets);
+        print_outputs(ctx, profile, &targets, args.standalone_plugin_id.as_deref())?;
     }
     Ok(())
 }
@@ -281,6 +293,7 @@ pub(crate) fn run_install(ctx: &Context, args: &InstallArgs) -> Result<()> {
             targets,
             scope: args.scope,
         }),
+        None,
     )?;
     execute_plan(
         ctx,
@@ -340,6 +353,7 @@ pub(crate) fn run_validate(ctx: &Context, args: &ValidateArgs) -> Result<()> {
                 .collect(),
             scope: crate::cli::InstallScope::Default,
         }),
+        None,
     )?;
     execute_plan(
         ctx,
@@ -362,6 +376,7 @@ fn build_graph(
     targets: &[Target],
     clean_first: bool,
     install_selection: Option<InstallSelection>,
+    standalone_plugin_id: Option<String>,
 ) -> Result<TaskGraph> {
     let mut graph = TaskGraph::new();
     // Install scope validation is modeled as a task, not an upfront global
@@ -534,7 +549,9 @@ fn build_graph(
         );
         let standalone = graph.task(
             package_task_id(ctx, "build-standalone"),
-            TaskKind::BuildStandaloneBundle,
+            TaskKind::BuildStandaloneBundle {
+                plugin_id: standalone_plugin_id,
+            },
         );
         graph.depends_on(standalone, configure);
         build_by_target.insert(Target::Standalone, standalone);
@@ -708,6 +725,7 @@ fn run_task(ctx: &Context, profile: BuildProfile, kind: &TaskKind) -> Result<()>
                 au: false,
             },
             WrapperTarget::Vst3,
+            None,
         ),
         TaskKind::BuildAuBundle => build_wrapper_target(
             ctx,
@@ -717,15 +735,17 @@ fn run_task(ctx: &Context, profile: BuildProfile, kind: &TaskKind) -> Result<()>
                 au: true,
             },
             WrapperTarget::Au,
+            None,
         ),
         TaskKind::BuildAaxBundle => {
-            build_wrapper_target(ctx, profile, WrapperBuild::Aax, WrapperTarget::Aax)
+            build_wrapper_target(ctx, profile, WrapperBuild::Aax, WrapperTarget::Aax, None)
         }
-        TaskKind::BuildStandaloneBundle => build_wrapper_target(
+        TaskKind::BuildStandaloneBundle { plugin_id } => build_wrapper_target(
             ctx,
             profile,
             WrapperBuild::Standalone,
             WrapperTarget::Standalone,
+            plugin_id.as_deref(),
         ),
         TaskKind::CheckInstallScope { target, scope } => {
             install_dir(ctx, *scope, target.format()).map(|_| ())


### PR DESCRIPTION
## Summary
- limit standalone CMake builds for `xtask launch --plugin-id` to the selected product
- add `xtask build --target standalone --plugin-id` for debugger/preLaunchTask workflows that need a selected standalone artifact without launching it
- keep regular `xtask build --target standalone` behavior building all standalone products
- print and sign only the selected standalone app when a product is selected

## Verification
- `cargo test -p wrac_xtask`
- from novonotes-products: `cargo xtask launch --package pulsus_builtin_device_plugin --plugin-id dev.pulsus.device.gain.v1` built only `pulsus_builtin_device_plugin_standalone_product_0_standalone`
- from novonotes-products: `cargo xtask build --package pulsus_builtin_device_plugin --target=standalone --plugin-id dev.pulsus.device.gain.v1` built only `pulsus_builtin_device_plugin_standalone_product_0_standalone`