### PR TITLE
Expose WRAC plugin discovery API

### DIFF
--- a/crates/wrac_xtask/src/context.rs
+++ b/crates/wrac_xtask/src/context.rs
@@ -5,15 +5,7 @@ use cargo_metadata::MetadataCommand;
 use crate::metadata::{PluginMetadata, PluginProductMetadata};
 use crate::profile::BuildProfile;
 use crate::targets::Platform;
-use crate::{Result, XtaskConfig};
-
-#[derive(Debug, Clone)]
-pub(crate) struct PluginPackage {
-    pub(crate) package_name: String,
-    pub(crate) artifact_namespace: String,
-    pub(crate) manifest_path: PathBuf,
-    pub(crate) plugin_root: PathBuf,
-}
+use crate::{Result, WracPluginPackage, XtaskConfig};
 
 pub(crate) struct Context {
     pub(crate) root: PathBuf,
@@ -146,7 +138,7 @@ impl Context {
     }
 }
 
-pub(crate) fn available_packages(config: &XtaskConfig) -> Result<Vec<PluginPackage>> {
+pub(crate) fn available_packages(config: &XtaskConfig) -> Result<Vec<WracPluginPackage>> {
     let metadata = MetadataCommand::new()
         .manifest_path(config.root.join("Cargo.toml"))
         .exec()?;
@@ -194,7 +186,7 @@ pub(crate) fn available_packages(config: &XtaskConfig) -> Result<Vec<PluginPacka
             continue;
         }
         validate_plugin_layout(&package_dir, &plugin_root)?;
-        packages.push(PluginPackage {
+        packages.push(WracPluginPackage {
             package_name: package.name.clone(),
             artifact_namespace,
             manifest_path,
@@ -205,7 +197,7 @@ pub(crate) fn available_packages(config: &XtaskConfig) -> Result<Vec<PluginPacka
     Ok(packages)
 }
 
-fn find_package(config: &XtaskConfig, package_name: &str) -> Result<PluginPackage> {
+fn find_package(config: &XtaskConfig, package_name: &str) -> Result<WracPluginPackage> {
     let packages = available_packages(config)?;
     for package in &packages {
         if package.package_name == package_name {

--- a/crates/wrac_xtask/src/lib.rs
+++ b/crates/wrac_xtask/src/lib.rs
@@ -45,6 +45,23 @@ pub struct XtaskConfig {
     pub target_namespace: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WracPluginPackage {
+    pub package_name: String,
+    pub artifact_namespace: String,
+    pub manifest_path: PathBuf,
+    pub plugin_root: PathBuf,
+}
+
+/// Discovers WRAC plugin packages from workspace metadata.
+///
+/// This is the same package discovery used by `--all` commands, exposed for
+/// repository-local automation that needs to build CI matrices without
+/// duplicating Cargo metadata and WRAC manifest lookup rules.
+pub fn discover_plugin_packages(config: &XtaskConfig) -> Result<Vec<WracPluginPackage>> {
+    available_packages(config)
+}
+
 #[derive(Debug, Clone)]
 pub struct WracWorkspace {
     config: XtaskConfig,


### PR DESCRIPTION
## Summary
- Expose WRAC plugin package discovery as `discover_plugin_packages`
- Add a public `WracPluginPackage` type for downstream automation
- Keep `--all` and external CI helpers on the same discovery path

## Validation
- `cargo test -p wrac_xtask`
- `cargo check -p wrac_xtask --all-targets`
