### PR TITLE
Split GUI query and main-thread contracts

### DIFF
--- a/crates/wrac_clap_adapter/src/abi.rs
+++ b/crates/wrac_clap_adapter/src/abi.rs
@@ -8,6 +8,7 @@ use std::ffi::{CStr, c_char, c_void};
 use std::ptr;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread::ThreadId;
 
 use clap_sys::ext::audio_ports::CLAP_EXT_AUDIO_PORTS;
 use clap_sys::ext::configurable_audio_ports::{
@@ -110,6 +111,10 @@ pub(crate) struct PluginInstanceState {
     // Re-entry guard for GUI mutation callbacks. Fails immediately on re-entry to avoid
     // deadlock (GUI query callbacks do not go through this guard).
     gui_callback_busy: Mutex<()>,
+    // Defensive owner check for CLAP GUI [main-thread] callbacks. The adapter cannot
+    // identify the OS UI thread portably here, but it can reject lifecycle callbacks
+    // that move between host threads within one GUI session.
+    gui_lifecycle_thread: Mutex<Option<ThreadId>>,
     host_params: Arc<HostParamsProxy>,
     // To preserve soundness even when a wrapper violates thread/lifecycle annotations,
     // the RT path never takes a lock — only a callback that wins the atomic guard
@@ -228,6 +233,7 @@ impl PluginInstanceState {
             latency,
             host_context,
             gui_callback_busy: Mutex::new(()),
+            gui_lifecycle_thread: Mutex::new(None),
             host_params,
             inactive_processor: UnsafeCell::new(Some(inactive_processor)),
             processor: UnsafeCell::new(None),
@@ -406,6 +412,28 @@ impl PluginInstanceState {
             // stale adapter state.
             std::thread::yield_now();
         }
+    }
+
+    pub(crate) fn enter_gui_lifecycle_thread(&self, callback_name: &'static str) -> bool {
+        let current = std::thread::current().id();
+        let mut owner = self.gui_lifecycle_thread.lock();
+        match *owner {
+            Some(expected) if expected != current => {
+                log::error!(
+                    "rejecting CLAP GUI main-thread callback from a different thread: callback={callback_name} expected={expected:?} current={current:?}"
+                );
+                false
+            }
+            Some(_) => true,
+            None => {
+                *owner = Some(current);
+                true
+            }
+        }
+    }
+
+    pub(crate) fn clear_gui_lifecycle_thread(&self) {
+        *self.gui_lifecycle_thread.lock() = None;
     }
 }
 
@@ -737,7 +765,10 @@ unsafe extern "C" fn plugin_destroy(plugin: *const clap_plugin) {
 
         if let Some(gui) = &instance.gui {
             if let Some(_gui_callback) = instance.gui_callback_busy.try_lock() {
-                gui.destroy();
+                if instance.enter_gui_lifecycle_thread("destroy") {
+                    gui.main_thread().destroy();
+                    instance.clear_gui_lifecycle_thread();
+                }
             } else {
                 log::error!(
                     "skipping GUI destroy during plugin destruction because another GUI callback is active"

--- a/crates/wrac_clap_adapter/src/abi/gui_extension.rs
+++ b/crates/wrac_clap_adapter/src/abi/gui_extension.rs
@@ -47,7 +47,7 @@ unsafe extern "C" fn gui_is_api_supported(
             log::warn!("gui.is_api_supported: invalid API pointer");
             return false;
         };
-        gui.is_api_supported(api, is_floating)
+        gui.query().is_api_supported(api, is_floating)
     })
 }
 
@@ -68,7 +68,7 @@ unsafe extern "C" fn gui_get_preferred_api(
         let Some(gui) = (unsafe { plugin_gui_query(plugin) }) else {
             return false;
         };
-        let Some(configuration) = gui.preferred_api() else {
+        let Some(configuration) = gui.query().preferred_api() else {
             log::debug!("gui.get_preferred_api: plugin has no preferred API");
             return false;
         };
@@ -94,7 +94,7 @@ unsafe extern "C" fn gui_create(
             log::warn!("gui.create: invalid API pointer");
             return false;
         };
-        match gui.create(GuiConfig { api, is_floating }) {
+        match gui.main_thread().create(GuiConfig { api, is_floating }) {
             Ok(()) => true,
             Err(error) => {
                 log::warn!("gui.create: plugin create failed: {error}");
@@ -109,7 +109,8 @@ unsafe extern "C" fn gui_destroy(plugin: *const clap_plugin) {
         let Some(gui) = (unsafe { plugin_gui_mutation(plugin, "destroy") }) else {
             return;
         };
-        gui.destroy();
+        gui.main_thread().destroy();
+        gui.clear_lifecycle_thread();
     });
 }
 
@@ -118,7 +119,7 @@ unsafe extern "C" fn gui_set_scale(plugin: *const clap_plugin, scale: f64) -> bo
         let Some(gui) = (unsafe { plugin_gui_mutation(plugin, "set_scale") }) else {
             return false;
         };
-        match gui.set_scale(scale) {
+        match gui.main_thread().set_scale(scale) {
             Ok(()) => true,
             Err(error) => {
                 log::warn!("gui.set_scale: plugin set_scale failed: {error}");
@@ -145,7 +146,7 @@ unsafe extern "C" fn gui_get_size(
         let Some(gui) = (unsafe { plugin_gui_query(plugin) }) else {
             return false;
         };
-        let size = match gui.get_size() {
+        let size = match gui.query().get_size() {
             Ok(size) => size,
             Err(error) => {
                 log::warn!("gui.get_size: plugin get_size failed: {error}");
@@ -165,7 +166,7 @@ unsafe extern "C" fn gui_can_resize(plugin: *const clap_plugin) -> bool {
         let Some(gui) = (unsafe { plugin_gui_query(plugin) }) else {
             return false;
         };
-        gui.can_resize()
+        gui.query().can_resize()
     })
 }
 
@@ -181,7 +182,7 @@ unsafe extern "C" fn gui_get_resize_hints(
         let Some(gui) = (unsafe { plugin_gui_query(plugin) }) else {
             return false;
         };
-        let Some(resize_hints) = gui.resize_hints() else {
+        let Some(resize_hints) = gui.query().resize_hints() else {
             log::debug!("gui.get_resize_hints: plugin has no resize hints");
             return false;
         };
@@ -219,7 +220,7 @@ unsafe extern "C" fn gui_adjust_size(
                 height: *height,
             }
         };
-        let adjusted = match gui.adjust_size(requested) {
+        let adjusted = match gui.query().adjust_size(requested) {
             Ok(adjusted) => adjusted,
             Err(error) => {
                 log::warn!("gui.adjust_size: plugin adjust_size failed: {error}");
@@ -239,7 +240,7 @@ unsafe extern "C" fn gui_set_size(plugin: *const clap_plugin, width: u32, height
         let Some(gui) = (unsafe { plugin_gui_mutation(plugin, "set_size") }) else {
             return false;
         };
-        match gui.set_size(GuiSize { width, height }) {
+        match gui.main_thread().set_size(GuiSize { width, height }) {
             Ok(()) => true,
             Err(error) => {
                 log::warn!("gui.set_size: plugin set_size failed: {error}");
@@ -265,7 +266,7 @@ unsafe extern "C" fn gui_set_parent(
             log::warn!("gui.set_parent: unsupported or invalid window API");
             return false;
         };
-        match gui.set_parent(parent) {
+        match gui.main_thread().set_parent(parent) {
             Ok(()) => true,
             Err(error) => {
                 log::warn!("gui.set_parent: plugin set_parent failed: {error}");
@@ -298,7 +299,7 @@ unsafe extern "C" fn gui_show(plugin: *const clap_plugin) -> bool {
         let Some(gui) = (unsafe { plugin_gui_mutation(plugin, "show") }) else {
             return false;
         };
-        match gui.show() {
+        match gui.main_thread().show() {
             Ok(()) => true,
             Err(error) => {
                 log::warn!("gui.show: plugin show failed: {error}");
@@ -313,7 +314,7 @@ unsafe extern "C" fn gui_hide(plugin: *const clap_plugin) -> bool {
         let Some(gui) = (unsafe { plugin_gui_mutation(plugin, "hide") }) else {
             return false;
         };
-        match gui.hide() {
+        match gui.main_thread().hide() {
             Ok(()) => true,
             Err(error) => {
                 log::warn!("gui.hide: plugin hide failed: {error}");
@@ -336,6 +337,7 @@ unsafe fn plugin_gui_query(plugin: *const clap_plugin) -> Option<Arc<dyn PluginG
 }
 
 struct GuiMutationAccess {
+    instance: &'static PluginInstanceState,
     gui: Arc<dyn PluginGuiExtension>,
     _guard: MutexGuard<'static, ()>,
 }
@@ -345,6 +347,12 @@ impl Deref for GuiMutationAccess {
 
     fn deref(&self) -> &Self::Target {
         self.gui.as_ref()
+    }
+}
+
+impl GuiMutationAccess {
+    fn clear_lifecycle_thread(&self) {
+        self.instance.clear_gui_lifecycle_thread();
     }
 }
 
@@ -362,10 +370,18 @@ unsafe fn plugin_gui_mutation(
     };
     // Extract only the capability handle to avoid coupling GUI callbacks to the
     // `PluginInstance` lifecycle/state lock (the GUI runtime has its own thread rules).
-    instance
-        .gui
-        .clone()
-        .map(|gui| GuiMutationAccess { gui, _guard: guard })
+    let Some(gui) = instance.gui.clone() else {
+        log::debug!("gui.{callback_name}: plugin has no GUI");
+        return None;
+    };
+    if !instance.enter_gui_lifecycle_thread(callback_name) {
+        return None;
+    }
+    Some(GuiMutationAccess {
+        instance,
+        gui,
+        _guard: guard,
+    })
 }
 
 unsafe fn clap_window_to_rust(window: &clap_window) -> Option<HostWindow> {

--- a/crates/wrac_clap_adapter/src/api.rs
+++ b/crates/wrac_clap_adapter/src/api.rs
@@ -42,8 +42,8 @@ pub use core::{ActivateContext, PluginInstance, PluginInstanceContext};
 pub use error::{PluginError, PluginResult};
 pub use extensions::{
     PluginAudioPortsExtension, PluginConfigurableAudioPortsExtension, PluginGuiExtension,
-    PluginLatencyExtension, PluginNotePortsExtension, PluginRenderExtension, PluginStateExtension,
-    PluginTailExtension,
+    PluginGuiMainThreadExtension, PluginGuiQueryExtension, PluginLatencyExtension,
+    PluginNotePortsExtension, PluginRenderExtension, PluginStateExtension, PluginTailExtension,
 };
 pub use host::{HostGui, HostParams, HostState};
 pub use params::PluginParamsQuery;

--- a/crates/wrac_clap_adapter/src/api/extensions.rs
+++ b/crates/wrac_clap_adapter/src/api/extensions.rs
@@ -9,7 +9,7 @@ mod tail;
 
 pub use audio_ports::PluginAudioPortsExtension;
 pub use configurable_audio_ports::PluginConfigurableAudioPortsExtension;
-pub use gui::PluginGuiExtension;
+pub use gui::{PluginGuiExtension, PluginGuiMainThreadExtension, PluginGuiQueryExtension};
 pub use latency::PluginLatencyExtension;
 pub use note_ports::PluginNotePortsExtension;
 pub use render::PluginRenderExtension;

--- a/crates/wrac_clap_adapter/src/api/extensions/gui.rs
+++ b/crates/wrac_clap_adapter/src/api/extensions/gui.rs
@@ -1,43 +1,89 @@
 use crate::{GuiApi, GuiConfig, GuiResizeHints, GuiSize, HostWindow, PluginResult};
 
-/// CLAP gui extension for embedded host-owned editor windows.
-pub trait PluginGuiExtension: Send + Sync + 'static {
-    /// Called from CLAP `gui.is_api_supported`. `[main-thread]`
+/// CLAP GUI query surface.
+///
+/// These methods must be safe to call from non-audio control threads. They must
+/// not touch thread-affine native UI objects directly.
+pub trait PluginGuiQueryExtension: Send + Sync + 'static {
+    /// Called from CLAP `gui.is_api_supported`.
+    ///
+    /// `[thread-safe & control-thread]`
     fn is_api_supported(&self, api: GuiApi, is_floating: bool) -> bool;
 
-    /// Called from CLAP `gui.get_preferred_api`. `[main-thread]`
+    /// Called from CLAP `gui.get_preferred_api`.
+    ///
+    /// `[thread-safe & control-thread]`
     fn preferred_api(&self) -> Option<GuiConfig>;
 
-    /// Called from CLAP `gui.create`. `[main-thread]`
-    fn create(&self, configuration: GuiConfig) -> PluginResult<()>;
-
-    /// Called from CLAP `gui.destroy` or plugin destruction. `[main-thread]`
-    fn destroy(&self);
-
-    /// Called from CLAP `gui.set_scale`. `[main-thread]`
-    fn set_scale(&self, scale: f64) -> PluginResult<()>;
-
-    /// Called from CLAP `gui.get_size`. `[main-thread]`
+    /// Called from CLAP `gui.get_size`.
+    ///
+    /// `[thread-safe & control-thread]`
     fn get_size(&self) -> PluginResult<GuiSize>;
 
-    /// Called from CLAP `gui.can_resize`. `[main-thread]`
+    /// Called from CLAP `gui.can_resize`.
+    ///
+    /// `[thread-safe & control-thread]`
     fn can_resize(&self) -> bool;
 
-    /// Called from CLAP `gui.get_resize_hints`. `[main-thread]`
+    /// Called from CLAP `gui.get_resize_hints`.
+    ///
+    /// `[thread-safe & control-thread]`
     fn resize_hints(&self) -> Option<GuiResizeHints>;
 
-    /// Called from CLAP `gui.adjust_size`. `[main-thread]`
+    /// Called from CLAP `gui.adjust_size`.
+    ///
+    /// `[thread-safe & control-thread]`
     fn adjust_size(&self, size: GuiSize) -> PluginResult<GuiSize>;
+}
 
-    /// Called from CLAP `gui.set_size`. `[main-thread]`
+/// CLAP GUI lifecycle / native UI surface.
+///
+/// Host/wrapper code is responsible for calling these methods from the main thread.
+/// Product code may assume the main-thread contract and may touch thread-affine UI
+/// objects here.
+pub trait PluginGuiMainThreadExtension: 'static {
+    /// Called from CLAP `gui.create`.
+    ///
+    /// `[main-thread]`
+    fn create(&self, configuration: GuiConfig) -> PluginResult<()>;
+
+    /// Called from CLAP `gui.destroy` or plugin destruction.
+    ///
+    /// `[main-thread]`
+    fn destroy(&self);
+
+    /// Called from CLAP `gui.set_scale`.
+    ///
+    /// `[main-thread]`
+    fn set_scale(&self, scale: f64) -> PluginResult<()>;
+
+    /// Called from CLAP `gui.set_size`.
+    ///
+    /// `[main-thread]`
     fn set_size(&self, size: GuiSize) -> PluginResult<()>;
 
-    /// Called from CLAP `gui.set_parent`. `[main-thread]`
+    /// Called from CLAP `gui.set_parent`.
+    ///
+    /// `[main-thread]`
     fn set_parent(&self, window: HostWindow) -> PluginResult<()>;
 
-    /// Called from CLAP `gui.show`. `[main-thread]`
+    /// Called from CLAP `gui.show`.
+    ///
+    /// `[main-thread]`
     fn show(&self) -> PluginResult<()>;
 
-    /// Called from CLAP `gui.hide`. `[main-thread]`
+    /// Called from CLAP `gui.hide`.
+    ///
+    /// `[main-thread]`
     fn hide(&self) -> PluginResult<()>;
+}
+
+/// CLAP GUI extension exposed to the adapter.
+///
+/// Query methods and main-thread lifecycle methods are split so product code can
+/// implement thread-safe host queries separately from native UI operations.
+pub trait PluginGuiExtension: Send + Sync + 'static {
+    fn query(&self) -> &(dyn PluginGuiQueryExtension + Send + Sync);
+
+    fn main_thread(&self) -> &dyn PluginGuiMainThreadExtension;
 }

--- a/crates/wrac_clap_adapter/src/lib.rs
+++ b/crates/wrac_clap_adapter/src/lib.rs
@@ -22,10 +22,10 @@ pub use api::{
     HostFamily, HostGui, HostParams, HostState, HostVersion, HostWindow, InactiveProcessor,
     NoteDialects, NotePortInfo, ParamFlags, ParamFlushContext, ParamInfo, ParamValueEvent,
     PluginAudioPortsExtension, PluginConfigurableAudioPortsExtension, PluginError, PluginFormat,
-    PluginGuiExtension, PluginInstance, PluginInstanceContext, PluginLatencyExtension,
-    PluginNotePortsExtension, PluginParamsQuery, PluginRenderExtension, PluginRenderMode,
-    PluginResult, PluginStateExtension, PluginTailExtension, ProcessContext, ProcessStatus, State,
-    SystemContext,
+    PluginGuiExtension, PluginGuiMainThreadExtension, PluginGuiQueryExtension, PluginInstance,
+    PluginInstanceContext, PluginLatencyExtension, PluginNotePortsExtension, PluginParamsQuery,
+    PluginRenderExtension, PluginRenderMode, PluginResult, PluginStateExtension,
+    PluginTailExtension, ProcessContext, ProcessStatus, State, SystemContext,
 };
 pub use descriptor::{
     AaxDescriptor, AaxStemConfig, Auv2Descriptor, PluginDescriptor, PluginFeature, Vst3Descriptor,

--- a/crates/wrac_wxp_gui/src/controller.rs
+++ b/crates/wrac_wxp_gui/src/controller.rs
@@ -6,7 +6,7 @@ use novonotes_run_loop::{RunLoop, RunLoopLocal};
 use parking_lot::Mutex;
 use wrac_clap_adapter::{
     GuiApi, GuiConfig, GuiResizeHints, GuiSize, HostGui, HostWindow, PluginError,
-    PluginGuiExtension, PluginResult,
+    PluginGuiExtension, PluginGuiMainThreadExtension, PluginGuiQueryExtension, PluginResult,
 };
 use wrac_host_context::{HostContext, HostFamily, PluginFormat};
 use wxp::{WebViewDispatch, dpi::LogicalSize};
@@ -851,7 +851,7 @@ fn corrected_scale_for_parent(_parent: Option<StoredParentWindow>) -> Option<f64
     None
 }
 
-impl PluginGuiExtension for WxpGuiController {
+impl PluginGuiQueryExtension for WxpGuiController {
     fn is_api_supported(&self, api: GuiApi, is_floating: bool) -> bool {
         !is_floating && api == default_gui_api()
     }
@@ -860,9 +860,37 @@ impl PluginGuiExtension for WxpGuiController {
         Some(default_gui_configuration())
     }
 
+    fn get_size(&self) -> PluginResult<GuiSize> {
+        let size = self.layout.accepted_size();
+        log::debug!(
+            "wxp controller: get_size called: width={}, height={}",
+            size.width,
+            size.height
+        );
+        Ok(size)
+    }
+
+    fn can_resize(&self) -> bool {
+        self.layout.can_resize()
+    }
+
+    fn resize_hints(&self) -> Option<GuiResizeHints> {
+        Some(self.layout.resize_hints())
+    }
+
+    fn adjust_size(&self, size: GuiSize) -> PluginResult<GuiSize> {
+        Ok(self.layout.clamp_size(size))
+    }
+}
+
+impl PluginGuiMainThreadExtension for WxpGuiController {
     fn create(&self, configuration: GuiConfig) -> PluginResult<()> {
         log::debug!("wxp controller: create called: configuration={configuration:?}");
-        if !self.is_api_supported(configuration.api, configuration.is_floating) {
+        if !PluginGuiQueryExtension::is_api_supported(
+            self,
+            configuration.api,
+            configuration.is_floating,
+        ) {
             log::debug!("wxp controller: create rejected unsupported configuration");
             return Err(PluginError::Message("unsupported GUI configuration"));
         }
@@ -914,28 +942,6 @@ impl PluginGuiExtension for WxpGuiController {
         *self.scale.lock() = scale;
         log::debug!("wxp controller: set_scale completed");
         Ok(())
-    }
-
-    fn get_size(&self) -> PluginResult<GuiSize> {
-        let size = self.layout.accepted_size();
-        log::debug!(
-            "wxp controller: get_size called: width={}, height={}",
-            size.width,
-            size.height
-        );
-        Ok(size)
-    }
-
-    fn can_resize(&self) -> bool {
-        self.layout.can_resize()
-    }
-
-    fn resize_hints(&self) -> Option<GuiResizeHints> {
-        Some(self.layout.resize_hints())
-    }
-
-    fn adjust_size(&self, size: GuiSize) -> PluginResult<GuiSize> {
-        Ok(self.layout.clamp_size(size))
     }
 
     fn set_size(&self, requested_size: GuiSize) -> PluginResult<()> {
@@ -1114,6 +1120,16 @@ impl PluginGuiExtension for WxpGuiController {
         }
         log::debug!("wxp controller: hide completed");
         Ok(())
+    }
+}
+
+impl PluginGuiExtension for WxpGuiController {
+    fn query(&self) -> &(dyn PluginGuiQueryExtension + Send + Sync) {
+        self
+    }
+
+    fn main_thread(&self) -> &dyn PluginGuiMainThreadExtension {
+        self
     }
 }
 


### PR DESCRIPTION
## Summary

- Split the WRAC GUI extension into thread-safe query callbacks and main-thread lifecycle callbacks.
- Route CLAP GUI query callbacks through the query surface and native GUI lifecycle callbacks through the main-thread surface.
- Add a defensive adapter check that rejects lifecycle callbacks that move between host threads within one GUI session.
- Update the wxp GUI controller implementation to match the split contract.

## Why

Some wrappers may issue CLAP GUI query callbacks from non-audio control threads. Those queries should be implementable without touching thread-affine native UI state, while lifecycle callbacks such as create, set_parent, show, hide, and destroy still require the CLAP main-thread contract.

## Validation

- cargo check --workspace --all-targets
