### PR TITLE
Expose raw CLAP forwarding hooks

### DIFF
--- a/crates/wrac_clap_adapter/Cargo.toml
+++ b/crates/wrac_clap_adapter/Cargo.toml
@@ -15,5 +15,9 @@ parking_lot = "0.12"
 wrac_host_context = { workspace = true }
 wrac_log = { workspace = true }
 
+[features]
+default = []
+raw-clap-forwarding = []
+
 [lints.rust]
 unreachable_pub = "deny"

--- a/crates/wrac_clap_adapter/src/abi.rs
+++ b/crates/wrac_clap_adapter/src/abi.rs
@@ -7,7 +7,7 @@ use std::cell::UnsafeCell;
 use std::ffi::{CStr, c_char, c_void};
 use std::ptr;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::thread::ThreadId;
 
 use clap_sys::ext::audio_ports::CLAP_EXT_AUDIO_PORTS;
@@ -82,6 +82,21 @@ const CLAP_PLUGIN_AS_VST3: &CStr = c"clap.plugin-info-as-vst3/0";
 const CLAP_PLUGIN_FACTORY_INFO_AAX: &CStr = c"clap.plugin-factory-info-as-aax/1";
 const WRAC_PLUGIN_MAIN_THREAD_HOOK: &CStr = c"com.novonotes.wrac.plugin-main-thread-hook/0";
 
+pub(crate) struct RtDepthGuard<'a>(&'a AtomicU32);
+
+impl<'a> RtDepthGuard<'a> {
+    pub(crate) fn enter(depth: &'a AtomicU32) -> Self {
+        depth.fetch_add(1, Ordering::Relaxed);
+        Self(depth)
+    }
+}
+
+impl Drop for RtDepthGuard<'_> {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
 /// Synchronization boundary between a CLAP instance and the Rust core.
 ///
 /// Key design: separate the "lifecycle lock" from "capabilities read directly by
@@ -124,6 +139,9 @@ pub(crate) struct PluginInstanceState {
     processor_busy: AtomicBool,
     processor_active: AtomicBool,
     lifecycle_busy: AtomicBool,
+    rt_process_depth: AtomicU32,
+    rt_flush_depth: AtomicU32,
+    rt_processor_contention: AtomicBool,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -240,6 +258,9 @@ impl PluginInstanceState {
             processor_busy: AtomicBool::new(false),
             processor_active: AtomicBool::new(false),
             lifecycle_busy: AtomicBool::new(false),
+            rt_process_depth: AtomicU32::new(0),
+            rt_flush_depth: AtomicU32::new(0),
+            rt_processor_contention: AtomicBool::new(false),
         }))
     }
 
@@ -263,17 +284,37 @@ impl PluginInstanceState {
             .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
             .is_err()
         {
+            self.rt_processor_contention.store(true, Ordering::Release);
             return None;
         }
 
-        struct ProcessorBusyGuard<'a>(&'a AtomicBool);
+        struct ProcessorBusyGuard<'a> {
+            busy: &'a AtomicBool,
+            contention: &'a AtomicBool,
+            process_depth: &'a AtomicU32,
+            flush_depth: &'a AtomicU32,
+        }
         impl Drop for ProcessorBusyGuard<'_> {
             fn drop(&mut self) {
-                self.0.store(false, Ordering::Release);
+                self.busy.store(false, Ordering::Release);
+                if self.contention.swap(false, Ordering::AcqRel) {
+                    let process_depth = self.process_depth.load(Ordering::Relaxed);
+                    let flush_depth = self.flush_depth.load(Ordering::Relaxed);
+                    wrac_log::rtdebug!(
+                        "processor.busy clear pd={} fd={}",
+                        process_depth,
+                        flush_depth
+                    );
+                }
             }
         }
 
-        let _guard = ProcessorBusyGuard(&self.processor_busy);
+        let _guard = ProcessorBusyGuard {
+            busy: &self.processor_busy,
+            contention: &self.rt_processor_contention,
+            process_depth: &self.rt_process_depth,
+            flush_depth: &self.rt_flush_depth,
+        };
         Some(f(unsafe { &mut *self.processor.get() }.as_mut()))
     }
 
@@ -300,17 +341,37 @@ impl PluginInstanceState {
             .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
             .is_err()
         {
+            self.rt_processor_contention.store(true, Ordering::Release);
             return None;
         }
 
-        struct ProcessorBusyGuard<'a>(&'a AtomicBool);
+        struct ProcessorBusyGuard<'a> {
+            busy: &'a AtomicBool,
+            contention: &'a AtomicBool,
+            process_depth: &'a AtomicU32,
+            flush_depth: &'a AtomicU32,
+        }
         impl Drop for ProcessorBusyGuard<'_> {
             fn drop(&mut self) {
-                self.0.store(false, Ordering::Release);
+                self.busy.store(false, Ordering::Release);
+                if self.contention.swap(false, Ordering::AcqRel) {
+                    let process_depth = self.process_depth.load(Ordering::Relaxed);
+                    let flush_depth = self.flush_depth.load(Ordering::Relaxed);
+                    wrac_log::rtdebug!(
+                        "processor.busy clear pd={} fd={}",
+                        process_depth,
+                        flush_depth
+                    );
+                }
             }
         }
 
-        let _guard = ProcessorBusyGuard(&self.processor_busy);
+        let _guard = ProcessorBusyGuard {
+            busy: &self.processor_busy,
+            contention: &self.rt_processor_contention,
+            process_depth: &self.rt_process_depth,
+            flush_depth: &self.rt_flush_depth,
+        };
         Some(f(unsafe { &mut *self.inactive_processor.get() }.as_mut()))
     }
 
@@ -924,6 +985,7 @@ unsafe extern "C" fn plugin_process(
             wrac_log::rtwarn!("plugin.process: null process pointer");
             return CLAP_PROCESS_SLEEP;
         }
+        let _process_depth_guard = RtDepthGuard::enter(&instance.rt_process_depth);
         let process = unsafe { &*process };
         let events = unsafe { crate::EventLists::from_raw(process.in_events, process.out_events) };
         let audio = match unsafe { audio_buffers(process) } {
@@ -949,6 +1011,8 @@ unsafe extern "C" fn plugin_process(
                 audio,
                 events,
                 transport: unsafe { process.transport.as_ref() }.map(TransportEvent::from_raw),
+                #[cfg(feature = "raw-clap-forwarding")]
+                raw: unsafe { crate::RawProcessContext::from_raw(process) },
             }) {
                 Ok(ProcessStatus::Continue) => CLAP_PROCESS_CONTINUE,
                 Ok(ProcessStatus::ContinueIfNotQuiet) => CLAP_PROCESS_CONTINUE_IF_NOT_QUIET,
@@ -960,6 +1024,8 @@ unsafe extern "C" fn plugin_process(
                 }
             }
         }) else {
+            let flush_depth = instance.rt_flush_depth.load(Ordering::Relaxed);
+            wrac_log::rtdebug!("plugin.process busy fd={}", flush_depth);
             wrac_log::rtwarn!("plugin.process: processor is busy");
             return CLAP_PROCESS_SLEEP;
         };

--- a/crates/wrac_clap_adapter/src/abi/params_extension.rs
+++ b/crates/wrac_clap_adapter/src/abi/params_extension.rs
@@ -13,8 +13,8 @@ use clap_sys::ext::params::{
 };
 use clap_sys::plugin::clap_plugin;
 
-use super::PluginInstanceState;
 use super::ffi::{ffi_bool, ffi_u32, ffi_unit, fill_c_char_array, write_c_str_buffer};
+use super::{PluginInstanceState, RtDepthGuard};
 use crate::ParamFlags;
 use wrac_host_context::PluginFormat;
 
@@ -203,15 +203,29 @@ unsafe extern "C" fn params_flush(
         let Some(instance) = (unsafe { PluginInstanceState::from_plugin(plugin) }) else {
             return;
         };
-        let events = unsafe { crate::EventLists::from_raw(in_events, out_events) };
+        let _flush_depth_guard = RtDepthGuard::enter(&instance.rt_flush_depth);
+        let process_depth = instance
+            .rt_process_depth
+            .load(std::sync::atomic::Ordering::Relaxed);
+        if process_depth > 0 {
+            wrac_log::rtdebug!("params.flush enter pd={}", process_depth);
+        }
         let result = if instance.is_processor_active() {
             let Some(result) = instance.with_processor_mut(|active| {
                 let Some(active) = active else {
                     wrac_log::rtwarn!("params.flush: active processor state is inconsistent");
                     return Ok(());
                 };
-                active.flush_params(crate::ParamFlushContext { events })
+                active.flush_params(param_flush_context(in_events, out_events))
             }) else {
+                let flush_depth = instance
+                    .rt_flush_depth
+                    .load(std::sync::atomic::Ordering::Relaxed);
+                wrac_log::rtdebug!(
+                    "params.flush active busy pd={} fd={}",
+                    process_depth,
+                    flush_depth
+                );
                 wrac_log::rtwarn!("params.flush: active processor is busy");
                 return;
             };
@@ -228,8 +242,16 @@ unsafe extern "C" fn params_flush(
                         wrac_log::rtwarn!("params.flush: active processor state is inconsistent");
                         return Ok(());
                     };
-                    active.flush_params(crate::ParamFlushContext { events })
+                    active.flush_params(param_flush_context(in_events, out_events))
                 }) else {
+                    let flush_depth = instance
+                        .rt_flush_depth
+                        .load(std::sync::atomic::Ordering::Relaxed);
+                    wrac_log::rtdebug!(
+                        "params.flush active busy pd={} fd={}",
+                        process_depth,
+                        flush_depth
+                    );
                     wrac_log::rtwarn!("params.flush: active processor is busy");
                     return;
                 };
@@ -242,7 +264,7 @@ unsafe extern "C" fn params_flush(
                         );
                         return Ok(());
                     };
-                    inactive.flush_params(crate::ParamFlushContext { events })
+                    inactive.flush_params(param_flush_context(in_events, out_events))
                 }) else {
                     wrac_log::rtwarn!("params.flush: inactive processor is busy");
                     return;
@@ -254,6 +276,17 @@ unsafe extern "C" fn params_flush(
             wrac_log::rtwarn!("params.flush: processor failed: {error}");
         }
     });
+}
+
+fn param_flush_context<'a>(
+    in_events: *const clap_input_events,
+    out_events: *const clap_output_events,
+) -> crate::ParamFlushContext<'a> {
+    crate::ParamFlushContext {
+        events: unsafe { crate::EventLists::from_raw(in_events, out_events) },
+        #[cfg(feature = "raw-clap-forwarding")]
+        raw: unsafe { crate::RawParamFlushContext::from_raw(in_events, out_events) },
+    }
 }
 
 fn parameter_flags(flags: ParamFlags) -> u32 {

--- a/crates/wrac_clap_adapter/src/api.rs
+++ b/crates/wrac_clap_adapter/src/api.rs
@@ -50,6 +50,8 @@ pub use params::PluginParamsQuery;
 pub use process::{
     ActiveProcessor, InactiveProcessor, ParamFlushContext, ProcessContext, ProcessStatus,
 };
+#[cfg(feature = "raw-clap-forwarding")]
+pub use process::{RawParamFlushContext, RawProcessContext};
 pub use types::{
     AudioPortConfigRequest, AudioPortFlags, AudioPortInfo, AudioPortType, GuiApi, GuiConfig,
     GuiResizeHints, GuiSize, HostWindow, NoteDialects, NotePortInfo, ParamFlags, ParamInfo,

--- a/crates/wrac_clap_adapter/src/api/process.rs
+++ b/crates/wrac_clap_adapter/src/api/process.rs
@@ -1,8 +1,15 @@
 use std::any::Any;
+#[cfg(feature = "raw-clap-forwarding")]
+use std::{marker::PhantomData, rc::Rc};
 
 use crate::PluginResult;
 use crate::events::{EventLists, TransportEvent};
 use crate::process_buffer::AudioProcessBuffer;
+#[cfg(feature = "raw-clap-forwarding")]
+use clap_sys::{
+    events::{clap_input_events, clap_output_events},
+    process::clap_process,
+};
 
 /// Processing object used while the CLAP plugin is active.
 ///
@@ -38,10 +45,14 @@ pub struct ProcessContext<'a> {
     pub audio: AudioProcessBuffer<'a>,
     pub events: EventLists<'a>,
     pub transport: Option<TransportEvent>,
+    #[cfg(feature = "raw-clap-forwarding")]
+    pub(crate) raw: RawProcessContext<'a>,
 }
 
 pub struct ParamFlushContext<'a> {
     pub events: EventLists<'a>,
+    #[cfg(feature = "raw-clap-forwarding")]
+    pub(crate) raw: RawParamFlushContext<'a>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -50,4 +61,81 @@ pub enum ProcessStatus {
     ContinueIfNotQuiet,
     Tail,
     Sleep,
+}
+
+#[cfg(feature = "raw-clap-forwarding")]
+impl<'a> ProcessContext<'a> {
+    /// Returns the exact CLAP process pointer received by the WRAC adapter.
+    ///
+    /// This is intentionally available only behind `raw-clap-forwarding`. It exists for
+    /// CLAP-to-CLAP proxy products that must synchronously forward process data without
+    /// re-encoding events or buffers. Do not store the returned view beyond the callback.
+    pub fn raw_forwarding(&self) -> RawProcessContext<'a> {
+        self.raw
+    }
+}
+
+#[cfg(feature = "raw-clap-forwarding")]
+impl<'a> ParamFlushContext<'a> {
+    /// Returns the exact CLAP params.flush event lists received by the WRAC adapter.
+    ///
+    /// The view is callback-lifetime bound and must only be used for synchronous
+    /// forwarding into another CLAP plugin instance.
+    pub fn raw_forwarding(&self) -> RawParamFlushContext<'a> {
+        self.raw
+    }
+}
+
+#[cfg(feature = "raw-clap-forwarding")]
+#[derive(Clone, Copy)]
+pub struct RawProcessContext<'a> {
+    process: *const clap_process,
+    _marker: PhantomData<(&'a clap_process, Rc<()>)>,
+}
+
+#[cfg(feature = "raw-clap-forwarding")]
+impl<'a> RawProcessContext<'a> {
+    pub(crate) unsafe fn from_raw(process: *const clap_process) -> Self {
+        Self {
+            process,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Raw CLAP `clap_process` pointer valid only for the current process callback.
+    pub fn as_ptr(self) -> *const clap_process {
+        self.process
+    }
+}
+
+#[cfg(feature = "raw-clap-forwarding")]
+#[derive(Clone, Copy)]
+pub struct RawParamFlushContext<'a> {
+    input_events: *const clap_input_events,
+    output_events: *const clap_output_events,
+    _marker: PhantomData<(&'a clap_input_events, &'a mut clap_output_events, Rc<()>)>,
+}
+
+#[cfg(feature = "raw-clap-forwarding")]
+impl<'a> RawParamFlushContext<'a> {
+    pub(crate) unsafe fn from_raw(
+        input_events: *const clap_input_events,
+        output_events: *const clap_output_events,
+    ) -> Self {
+        Self {
+            input_events,
+            output_events,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Raw CLAP `clap_input_events` pointer valid only for the current flush callback.
+    pub fn input_events(self) -> *const clap_input_events {
+        self.input_events
+    }
+
+    /// Raw CLAP `clap_output_events` pointer valid only for the current flush callback.
+    pub fn output_events(self) -> *const clap_output_events {
+        self.output_events
+    }
 }

--- a/crates/wrac_clap_adapter/src/lib.rs
+++ b/crates/wrac_clap_adapter/src/lib.rs
@@ -27,6 +27,8 @@ pub use api::{
     PluginRenderExtension, PluginRenderMode, PluginResult, PluginStateExtension,
     PluginTailExtension, ProcessContext, ProcessStatus, State, SystemContext,
 };
+#[cfg(feature = "raw-clap-forwarding")]
+pub use api::{RawParamFlushContext, RawProcessContext};
 pub use descriptor::{
     AaxDescriptor, AaxStemConfig, Auv2Descriptor, PluginDescriptor, PluginFeature, Vst3Descriptor,
 };


### PR DESCRIPTION
## Summary
- Add feature-gated raw CLAP forwarding accessors to `wrac_clap_adapter`.
- Expose raw process and parameter flush event lists so proxy-style plugins can forward CLAP calls without translating through higher-level WRAC abstractions.

## Why
HR CLAP needs to proxy an inner CLAP plugin directly. Keeping this behind an explicit feature gate prevents normal product plugins from depending on the raw forwarding surface by accident.

## Validation
- `cargo check -p wrac_clap_adapter`
