### PR TITLE
Serialize AUv2 CLAP process and flush

### DIFF
--- a/clap_wrapper_builder/clap-wrapper/src/detail/auv2/auv2_base_classes.h
+++ b/clap_wrapper_builder/clap-wrapper/src/detail/auv2/auv2_base_classes.h
@@ -20,10 +20,12 @@
 #include <iostream>
 #include <memory>
 #include <map>
+#include <atomic>
 
 #include "process.h"
 #include "parameter.h"
 #include "detail/shared/fixedqueue.h"
+#include "detail/shared/spinlock.h"
 #include "detail/os/osutil.h"
 #include "detail/clap/automation.h"
 
@@ -566,6 +568,11 @@ class WrapAsAUV2 : public ausdk::AUBase,
 
   std::atomic_bool _requestUICallback = false;
   std::atomic_bool _flushRequested = false;
+  std::atomic_bool _processEverCalled = false;
+  // CLAP requires params.flush() and process() to be mutually exclusive. AUv2
+  // can run idle callbacks while GarageBand is rendering, so use the same
+  // process/flush exclusion model as the VST3 wrapper.
+  ClapWrapper::detail::shared::SpinLock _processOrFlushLock;
 
   // the queue from audiothread to UI thread
   ClapWrapper::detail::shared::fixedqueue<queueEvent, 8192> _queueToUI;

--- a/clap_wrapper_builder/clap-wrapper/src/wrapasauv2.cpp
+++ b/clap_wrapper_builder/clap-wrapper/src/wrapasauv2.cpp
@@ -1046,6 +1046,7 @@ void WrapAsAUV2::activateCLAP()
   if (_plugin)
   {
     assert(!_initialized);
+    _processEverCalled = false;
     if (!_processAdapter) _processAdapter = std::make_unique<Clap::AUv2::ProcessAdapter>();
     auto maxSampleFrames = Base::GetMaxFramesPerSlice();
     auto minSampleFrames = (maxSampleFrames >= 16) ? 16 : 1;
@@ -1066,6 +1067,7 @@ void WrapAsAUV2::deactivateCLAP()
   if (_plugin)
   {
     _initialized = false;
+    _processEverCalled = false;
     _processAdapter.reset();
     _plugin->stop_processing();
     _plugin->deactivate();
@@ -1112,8 +1114,10 @@ OSStatus WrapAsAUV2::Render(AudioUnitRenderActionFlags &inFlags, const AudioTime
     // with an arbitrary number of output channels is mapped onto a
     // continuous array of float buffers for the VST process function
 
+    ClapWrapper::detail::shared::SpinLockGuard processOrFlushLock(_processOrFlushLock);
     auto it_is = _plugin->AlwaysAudioThread();
 
+    _processEverCalled = true;
     _processAdapter->process(data);
 
     {
@@ -1203,8 +1207,9 @@ void WrapAsAUV2::onIdle()
   if (!_plugin) return;
   if (_flushRequested.exchange(false))
   {
+    ClapWrapper::detail::shared::SpinLockGuard processOrFlushLock(_processOrFlushLock);
     auto guarantee_mainthread = _plugin->AlwaysMainThread();
-    if (_processAdapter)
+    if (_processAdapter && (!_initialized || !_processEverCalled))
     {
       _processAdapter->flush();
     }


### PR DESCRIPTION
## Summary
- Serialize AUv2 `process()` and `params.flush()` calls with the same spin-lock model used by the VST3 wrapper.
- Avoid calling `params.flush()` after AUv2 processing has started, letting the next `process()` satisfy CLAP parameter flush requests instead.

## Why
CLAP hosts must not call `params.flush()` concurrently with `process()`. GarageBand can run AUv2 idle callbacks while render is active, which allowed `request_flush()` handling to overlap with audio processing.

## Validation
- `git diff --check origin/novonotes-internal..HEAD`
- `cargo xtask build --target=au`
- Manual GarageBand HR CLAP smoke test in the downstream product: no `params.flush active busy` warnings after installing the fixed AU wrapper.
