### PR TITLE
Refine host latency and notification APIs

### DIFF
--- a/crates/wrac_clap_adapter/src/abi.rs
+++ b/crates/wrac_clap_adapter/src/abi.rs
@@ -59,7 +59,10 @@ use crate::factory::{
     main_thread_hook_state, vst3_factory_ptr, vst3_factory_state,
 };
 use crate::host_gui::HostGuiProxy;
+use crate::host_latency::HostLatencyProxy;
+use crate::host_lifecycle::HostLifecycleProxy;
 use crate::host_state::HostStateProxy;
+use crate::host_tail::HostTailFactory;
 use crate::params::HostParamsProxy;
 use crate::{
     ActivateContext, ActiveProcessor, InactiveProcessor, PluginAudioPortsExtension,
@@ -122,6 +125,8 @@ pub(crate) struct PluginInstanceState {
     render: Option<Arc<dyn PluginRenderExtension>>,
     tail: Option<Arc<dyn PluginTailExtension>>,
     latency: Option<Arc<dyn PluginLatencyExtension>>,
+    host_latency: HostLatencyProxy,
+    host_tail: HostTailFactory,
     host_context: HostContext,
     // Re-entry guard for GUI mutation callbacks. Fails immediately on re-entry to avoid
     // deadlock (GUI query callbacks do not go through this guard).
@@ -153,6 +158,7 @@ pub(crate) struct PluginCapabilities {
     gui: bool,
     render: bool,
     tail: bool,
+    latency: bool,
 }
 
 // Safety: CLAP shares the same opaque plugin pointer across callbacks. Adapter state is
@@ -176,6 +182,7 @@ impl PluginInstanceState {
         let context = PluginInstanceContext {
             host_params: host_params.clone(),
             host_state: Arc::new(HostStateProxy::new(host)),
+            host_lifecycle: Arc::new(HostLifecycleProxy::new(host)),
             host_gui: Arc::new(HostGuiProxy::new(host)),
             host_context: host_context.clone(),
         };
@@ -211,6 +218,15 @@ impl PluginInstanceState {
         let render = core.render();
         let tail = core.tail();
         let latency = core.latency();
+        debug_assert!(
+            latency.is_some(),
+            "plugins should provide a latency extension because wrapper builds, especially AAX, expect it during activation; return zero latency when no delay is required"
+        );
+        if cfg!(not(debug_assertions)) && latency.is_none() {
+            log::warn!(
+                "factory.create_plugin: plugin has no latency extension; exposing zero-latency wrapper fallback"
+            );
+        }
         let capabilities = PluginCapabilities {
             audio_ports: audio_ports.is_some(),
             configurable_audio_ports: configurable_audio_ports.is_some(),
@@ -219,6 +235,7 @@ impl PluginInstanceState {
             gui: gui.is_some(),
             render: render.is_some(),
             tail: tail.is_some(),
+            latency: latency.is_some(),
         };
         let storage = registration.storage();
 
@@ -249,6 +266,8 @@ impl PluginInstanceState {
             render,
             tail,
             latency,
+            host_latency: HostLatencyProxy::new(host),
+            host_tail: HostTailFactory::new(host),
             host_context,
             gui_callback_busy: Mutex::new(()),
             gui_lifecycle_thread: Mutex::new(None),
@@ -888,10 +907,26 @@ unsafe extern "C" fn plugin_activate(
                 sample_rate,
                 min_frames_count,
                 max_frames_count,
+                host_tail: instance
+                    .capabilities
+                    .tail
+                    .then(|| instance.host_tail.create_handle())
+                    .flatten(),
             },
             inactive_processor,
         ) {
-            Ok(processor) => processor,
+            Ok(result) => {
+                if result.notifications.latency_changed {
+                    if instance.capabilities.latency {
+                        instance.host_latency.changed();
+                    } else {
+                        log::warn!(
+                            "plugin.activate: latency_changed requested without latency extension"
+                        );
+                    }
+                }
+                result.processor
+            }
             Err(error) => {
                 log::warn!("plugin.activate: plugin activate failed: {error}");
                 match core.initialize_processor() {
@@ -1067,9 +1102,13 @@ unsafe extern "C" fn plugin_get_extension(
         } else if id == CLAP_EXT_TAIL && instance.capabilities.tail {
             &tail_extension::TAIL as *const _ as *const c_void
         } else if id == CLAP_EXT_LATENCY {
-            // Some wrappers query latency unconditionally during activation. Exposing a
-            // zero-latency fallback keeps optional product support from becoming a null
-            // extension pointer at the wrapper boundary.
+            // Keep this pointer non-null even when `PluginInstance::latency()` returned
+            // `None`. clap-wrapper's AAX backend calls `_ext._latency->get(...)`
+            // unconditionally during activation, so exposing capability absence as a
+            // null CLAP extension pointer can crash before WRAC code gets a chance to
+            // diagnose the product bug. The product-facing contract is still enforced
+            // at instance creation by the debug assertion above; this fallback exists
+            // only to keep release wrapper builds from failing at the ABI boundary.
             &latency_extension::LATENCY as *const _ as *const c_void
         } else if id == CLAP_PLUGIN_AS_VST3 {
             &vst3_extension::VST3 as *const _ as *const c_void
@@ -1083,4 +1122,290 @@ unsafe extern "C" fn plugin_on_main_thread(_plugin: *const clap_plugin) {
     // WRAC intentionally does not route product work through CLAP's main-thread callback.
     // GUI and main-thread tasks should use novonotes_run_loop/wxp instead, which keeps
     // behavior consistent across native CLAP and wrapper-backed VST3/AU hosts.
+}
+
+#[cfg(test)]
+mod tests {
+    use std::any::Any;
+    use std::ptr;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    use clap_sys::ext::latency::{CLAP_EXT_LATENCY, clap_host_latency, clap_plugin_latency};
+    use clap_sys::host::clap_host;
+    use clap_sys::plugin::clap_plugin;
+    use clap_sys::version::CLAP_VERSION;
+
+    use super::{PluginInstanceState, plugin_activate, plugin_get_extension, plugin_init};
+    use crate::entry::EntryRegistration;
+    use crate::{
+        ActivateContext, ActivateNotifications, ActivateResult, ActiveProcessor, EntryContext,
+        InactiveProcessor, ParamFlushContext, PluginDescriptor, PluginEntry, PluginFactory,
+        PluginInstance, PluginInstanceContext, PluginLatencyExtension, PluginParamsQuery,
+        PluginResult, ProcessContext, ProcessStatus,
+    };
+    use wrac_host_context::HostContext;
+
+    static ZERO_LATENCY_ENTRY: TestEntry = TestEntry {
+        factory: TestFactory {
+            activate_latency_changed: false,
+        },
+    };
+    static ZERO_LATENCY_REGISTRATION: EntryRegistration =
+        EntryRegistration::new(&ZERO_LATENCY_ENTRY);
+
+    static ACTIVATE_LATENCY_CHANGED_ENTRY: TestEntry = TestEntry {
+        factory: TestFactory {
+            activate_latency_changed: true,
+        },
+    };
+    static ACTIVATE_LATENCY_CHANGED_REGISTRATION: EntryRegistration =
+        EntryRegistration::new(&ACTIVATE_LATENCY_CHANGED_ENTRY);
+
+    static LATENCY_CHANGED_COUNT: AtomicU32 = AtomicU32::new(0);
+
+    #[test]
+    fn zero_latency_exposes_latency_extension() {
+        let instance = test_instance(&ZERO_LATENCY_REGISTRATION, ptr::null());
+        let extension = unsafe {
+            plugin_get_extension(
+                &instance.plugin as *const clap_plugin,
+                CLAP_EXT_LATENCY.as_ptr(),
+            )
+        };
+        assert!(!extension.is_null());
+
+        let latency = unsafe { &*(extension as *const clap_plugin_latency) };
+        let get = latency.get.expect("latency.get callback");
+        let frames = unsafe { get(&instance.plugin as *const clap_plugin) };
+        assert_eq!(frames, 0);
+    }
+
+    #[test]
+    fn activate_notification_calls_host_latency_changed_during_activate() {
+        LATENCY_CHANGED_COUNT.store(0, Ordering::Relaxed);
+        let host = test_host();
+        let instance = test_instance(&ACTIVATE_LATENCY_CHANGED_REGISTRATION, &host);
+
+        assert!(unsafe { plugin_init(&instance.plugin as *const clap_plugin) });
+        let activated =
+            unsafe { plugin_activate(&instance.plugin as *const clap_plugin, 48_000.0, 1, 512) };
+
+        assert!(activated);
+        assert_eq!(LATENCY_CHANGED_COUNT.load(Ordering::Relaxed), 1);
+    }
+
+    fn test_instance(
+        registration: &'static EntryRegistration,
+        host: *const clap_host,
+    ) -> Box<PluginInstanceState> {
+        let mut instance = PluginInstanceState::new(
+            registration,
+            0,
+            TEST_DESCRIPTOR.id,
+            host,
+            None,
+            HostContext::detect_current(None),
+        )
+        .expect("test plugin instance");
+        let instance_ptr = (&mut *instance) as *mut PluginInstanceState;
+        instance.plugin.plugin_data = instance_ptr.cast();
+        instance
+    }
+
+    fn test_host() -> clap_host {
+        clap_host {
+            clap_version: CLAP_VERSION,
+            host_data: ptr::null_mut(),
+            name: c"Test Host".as_ptr(),
+            vendor: c"Test Vendor".as_ptr(),
+            url: c"https://example.invalid".as_ptr(),
+            version: c"0.0.0".as_ptr(),
+            get_extension: Some(test_host_get_extension),
+            request_restart: Some(test_host_request_restart),
+            request_process: Some(test_host_request_process),
+            request_callback: Some(test_host_request_callback),
+        }
+    }
+
+    unsafe extern "C" fn test_host_get_extension(
+        _host: *const clap_host,
+        extension_id: *const std::ffi::c_char,
+    ) -> *const std::ffi::c_void {
+        if extension_id.is_null() {
+            return ptr::null();
+        }
+        let id = unsafe { std::ffi::CStr::from_ptr(extension_id) };
+        if id == CLAP_EXT_LATENCY {
+            (&TEST_HOST_LATENCY as *const clap_host_latency).cast()
+        } else {
+            ptr::null()
+        }
+    }
+
+    unsafe extern "C" fn test_host_latency_changed(_host: *const clap_host) {
+        LATENCY_CHANGED_COUNT.fetch_add(1, Ordering::Relaxed);
+    }
+
+    unsafe extern "C" fn test_host_request_restart(_host: *const clap_host) {}
+    unsafe extern "C" fn test_host_request_process(_host: *const clap_host) {}
+    unsafe extern "C" fn test_host_request_callback(_host: *const clap_host) {}
+
+    static TEST_HOST_LATENCY: clap_host_latency = clap_host_latency {
+        changed: Some(test_host_latency_changed),
+    };
+
+    static TEST_DESCRIPTOR: PluginDescriptor = PluginDescriptor {
+        id: "dev.wrac.test",
+        name: "WRAC Test",
+        vendor: "WRAC",
+        url: "https://example.invalid",
+        manual_url: "",
+        support_url: "",
+        version: "0.0.0",
+        description: "",
+        features: &[],
+        auv2: None,
+        vst3: None,
+        aax: None,
+    };
+
+    struct TestEntry {
+        factory: TestFactory,
+    }
+
+    impl PluginEntry for TestEntry {
+        fn init(&self, _context: EntryContext<'_>) -> PluginResult<()> {
+            Ok(())
+        }
+
+        fn plugin_factory(&self) -> Option<&dyn PluginFactory> {
+            Some(&self.factory)
+        }
+    }
+
+    #[derive(Clone, Copy)]
+    struct TestFactory {
+        activate_latency_changed: bool,
+    }
+
+    impl PluginFactory for TestFactory {
+        fn plugin_count(&self) -> u32 {
+            1
+        }
+
+        fn plugin_descriptor(&self, index: u32) -> Option<PluginDescriptor> {
+            (index == 0).then_some(TEST_DESCRIPTOR)
+        }
+
+        fn create_plugin(
+            &self,
+            plugin_id: &str,
+            _context: PluginInstanceContext,
+        ) -> Option<Box<dyn PluginInstance>> {
+            (plugin_id == TEST_DESCRIPTOR.id).then(|| {
+                Box::new(TestPlugin {
+                    activate_latency_changed: self.activate_latency_changed,
+                }) as Box<dyn PluginInstance>
+            })
+        }
+    }
+
+    struct TestPlugin {
+        activate_latency_changed: bool,
+    }
+
+    impl PluginInstance for TestPlugin {
+        fn initialize_processor(&mut self) -> PluginResult<Box<dyn InactiveProcessor>> {
+            Ok(Box::new(TestInactiveProcessor))
+        }
+
+        fn activate(
+            &mut self,
+            _context: ActivateContext,
+            _processor: Box<dyn InactiveProcessor>,
+        ) -> PluginResult<ActivateResult> {
+            Ok(ActivateResult {
+                processor: Box::new(TestActiveProcessor),
+                notifications: ActivateNotifications {
+                    latency_changed: self.activate_latency_changed,
+                },
+            })
+        }
+
+        fn deactivate(
+            &mut self,
+            _processor: Box<dyn ActiveProcessor>,
+        ) -> PluginResult<Box<dyn InactiveProcessor>> {
+            Ok(Box::new(TestInactiveProcessor))
+        }
+
+        fn params(&self) -> Arc<dyn PluginParamsQuery> {
+            Arc::new(TestParams)
+        }
+
+        fn latency(&self) -> Option<Arc<dyn PluginLatencyExtension>> {
+            Some(Arc::new(TestLatency))
+        }
+    }
+
+    struct TestLatency;
+
+    impl PluginLatencyExtension for TestLatency {
+        fn latency_frames(&self) -> u32 {
+            0
+        }
+    }
+
+    struct TestParams;
+
+    impl PluginParamsQuery for TestParams {
+        fn count(&self) -> u32 {
+            0
+        }
+
+        fn get_info(&self, _index: u32) -> Option<crate::ParamInfo> {
+            None
+        }
+
+        fn get_value(&self, _param_id: u32) -> PluginResult<f64> {
+            Err(crate::PluginError::InvalidParameter)
+        }
+
+        fn value_to_text(&self, _param_id: u32, _value: f64) -> PluginResult<String> {
+            Err(crate::PluginError::InvalidParameter)
+        }
+
+        fn text_to_value(&self, _param_id: u32, _text: &str) -> PluginResult<f64> {
+            Err(crate::PluginError::InvalidParameter)
+        }
+    }
+
+    struct TestInactiveProcessor;
+
+    impl InactiveProcessor for TestInactiveProcessor {
+        fn into_any(self: Box<Self>) -> Box<dyn Any + Send> {
+            self
+        }
+
+        fn flush_params(&mut self, _context: ParamFlushContext<'_>) -> PluginResult<()> {
+            Ok(())
+        }
+    }
+
+    struct TestActiveProcessor;
+
+    impl ActiveProcessor for TestActiveProcessor {
+        fn into_any(self: Box<Self>) -> Box<dyn Any + Send> {
+            self
+        }
+
+        fn process(&mut self, _context: ProcessContext<'_>) -> PluginResult<ProcessStatus> {
+            Ok(ProcessStatus::Continue)
+        }
+
+        fn flush_params(&mut self, _context: ParamFlushContext<'_>) -> PluginResult<()> {
+            Ok(())
+        }
+    }
 }

--- a/crates/wrac_clap_adapter/src/api.rs
+++ b/crates/wrac_clap_adapter/src/api.rs
@@ -38,14 +38,16 @@ mod params;
 mod process;
 mod types;
 
-pub use core::{ActivateContext, PluginInstance, PluginInstanceContext};
+pub use core::{
+    ActivateContext, ActivateNotifications, ActivateResult, PluginInstance, PluginInstanceContext,
+};
 pub use error::{PluginError, PluginResult};
 pub use extensions::{
     PluginAudioPortsExtension, PluginConfigurableAudioPortsExtension, PluginGuiExtension,
     PluginGuiMainThreadExtension, PluginGuiQueryExtension, PluginLatencyExtension,
     PluginNotePortsExtension, PluginRenderExtension, PluginStateExtension, PluginTailExtension,
 };
-pub use host::{HostGui, HostParams, HostState};
+pub use host::{HostGui, HostLifecycle, HostParams, HostState, HostTail};
 pub use params::PluginParamsQuery;
 pub use process::{
     ActiveProcessor, InactiveProcessor, ParamFlushContext, ProcessContext, ProcessStatus,

--- a/crates/wrac_clap_adapter/src/api/core.rs
+++ b/crates/wrac_clap_adapter/src/api/core.rs
@@ -1,18 +1,41 @@
 use std::sync::Arc;
 
 use crate::{
-    ActiveProcessor, HostGui, HostParams, HostState, InactiveProcessor, PluginAudioPortsExtension,
-    PluginConfigurableAudioPortsExtension, PluginGuiExtension, PluginLatencyExtension,
-    PluginNotePortsExtension, PluginParamsQuery, PluginRenderExtension, PluginResult,
-    PluginStateExtension, PluginTailExtension,
+    ActiveProcessor, HostGui, HostLifecycle, HostParams, HostState, HostTail, InactiveProcessor,
+    PluginAudioPortsExtension, PluginConfigurableAudioPortsExtension, PluginGuiExtension,
+    PluginLatencyExtension, PluginNotePortsExtension, PluginParamsQuery, PluginRenderExtension,
+    PluginResult, PluginStateExtension, PluginTailExtension,
 };
 use wrac_host_context::HostContext;
 
-#[derive(Debug, Clone, Copy)]
 pub struct ActivateContext {
     pub sample_rate: f64,
     pub min_frames_count: u32,
     pub max_frames_count: u32,
+    pub host_tail: Option<Box<dyn HostTail>>,
+}
+
+pub struct ActivateResult {
+    pub processor: Box<dyn ActiveProcessor>,
+    pub notifications: ActivateNotifications,
+}
+
+impl ActivateResult {
+    pub fn new(processor: Box<dyn ActiveProcessor>) -> Self {
+        Self {
+            processor,
+            notifications: ActivateNotifications::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ActivateNotifications {
+    /// Requests `clap_host_latency.changed` during the current CLAP activate call.
+    ///
+    /// The adapter converts this flag to the host callback only while CLAP marks the
+    /// plugin as `[being-activated]`.
+    pub latency_changed: bool,
 }
 
 /// Per-instance environment passed from the adapter to the product instance.
@@ -22,6 +45,7 @@ pub struct ActivateContext {
 pub struct PluginInstanceContext {
     pub host_params: Arc<dyn HostParams>,
     pub host_state: Arc<dyn HostState>,
+    pub host_lifecycle: Arc<dyn HostLifecycle>,
     pub host_gui: Arc<dyn HostGui>,
     pub host_context: HostContext,
 }
@@ -50,7 +74,7 @@ pub trait PluginInstance: Send + 'static {
         &mut self,
         context: ActivateContext,
         processor: Box<dyn InactiveProcessor>,
-    ) -> PluginResult<Box<dyn ActiveProcessor>>;
+    ) -> PluginResult<ActivateResult>;
 
     /// Called from the plugin deactivation or destruction callback. `[control-thread]`
     fn deactivate(

--- a/crates/wrac_clap_adapter/src/api/extensions/latency.rs
+++ b/crates/wrac_clap_adapter/src/api/extensions/latency.rs
@@ -1,5 +1,5 @@
 /// CLAP latency extension.
 pub trait PluginLatencyExtension: Send + Sync + 'static {
-    /// Called from CLAP `latency.get`. `[thread-safe]`
+    /// Called from CLAP `latency.get`. `[thread-safe & control-thread]`
     fn latency_frames(&self) -> u32;
 }

--- a/crates/wrac_clap_adapter/src/api/extensions/tail.rs
+++ b/crates/wrac_clap_adapter/src/api/extensions/tail.rs
@@ -1,5 +1,7 @@
 /// CLAP tail extension.
 pub trait PluginTailExtension: Send + Sync + 'static {
     /// Called from CLAP `tail.get`. `[thread-safe]`
+    ///
+    /// CLAP may call this from the audio thread, so implementations must be realtime-safe.
     fn tail_frames(&self) -> u32;
 }

--- a/crates/wrac_clap_adapter/src/api/host.rs
+++ b/crates/wrac_clap_adapter/src/api/host.rs
@@ -1,34 +1,57 @@
 use crate::{GuiSize, PluginResult};
 
-/// Requests the host to schedule CLAP params synchronization.
+/// Requests host-side parameter synchronization and invalidation.
 ///
-/// This maps directly to `clap_host_params.request_flush`. It does not carry
-/// parameter values; plugins emit those as output events from `process` or
+/// `request_flush` maps directly to `clap_host_params.request_flush` and does not
+/// carry parameter values; plugins emit those as output events from `process` or
 /// `flush_params`.
+///
+/// `rescan` and `clear` currently call CLAP `[main-thread]` host callbacks directly.
+/// The adapter does not marshal them yet, so call those methods only from a context
+/// that is already on the host main thread. The product-facing API intentionally avoids
+/// `MainThread` naming because the long-term contract is for the adapter to turn these
+/// into queued/coalesced host requests.
 pub trait HostParams: Send + Sync {
+    /// Calls CLAP `host_params.request_flush`. `[thread-safe & control-thread]`
+    ///
+    /// CLAP marks this callback `!audio-thread`; do not call it from realtime code.
+    fn request_flush(&self);
+
     /// Calls CLAP `host_params.rescan`. `[main-thread]`
     fn rescan(&self, _flags: u32) {}
 
     /// Calls CLAP `host_params.clear`. `[main-thread]`
     fn clear(&self, _param_id: u32, _flags: u32) {}
-
-    /// Calls CLAP `host_params.request_flush`. `[thread-safe & control-thread]`
-    ///
-    /// CLAP marks this callback `!audio-thread`; do not call it from realtime code.
-    fn request_flush(&self);
 }
 
-/// Notifies the host that non-parameter project state changed and should be saved.
+/// Requests host-side project state notifications.
 ///
-/// This maps to CLAP `clap_host_state.mark_dirty()`. Use it for plugin-owned document
-/// state, not for parameter automation gestures.
+/// `mark_dirty` maps to CLAP `clap_host_state.mark_dirty()`. Use it for plugin-owned
+/// document state, not for parameter automation gestures.
 ///
-/// CLAP requires this notification to be sent from the main thread. The adapter
-/// does not marshal calls, so call this from the product's GUI/control path, not
-/// directly from `ActiveProcessor::process()` or a background worker.
+/// This currently calls a CLAP `[main-thread]` host callback directly. The adapter does
+/// not marshal it yet, so call it only from a context that is already on the host main
+/// thread. The product-facing API intentionally avoids `MainThread` naming because the
+/// long-term contract is for the adapter to turn this into a queued/coalesced host
+/// request.
 pub trait HostState: Send + Sync {
     /// Calls CLAP `host_state.mark_dirty`. `[main-thread]`
     fn mark_dirty(&self);
+}
+
+/// Requests host lifecycle changes.
+pub trait HostLifecycle: Send + Sync {
+    /// Calls CLAP `host.request_restart`. `[thread-safe & control-thread]`
+    fn request_restart(&self);
+}
+
+/// Host tail notification handle owned by an active processor.
+///
+/// CLAP marks `host_tail.changed` as `[audio-thread]`. This handle is moved into
+/// the active processor at activation time and intentionally does not require `Sync`.
+pub trait HostTail: Send + 'static {
+    /// Calls CLAP `host_tail.changed`. `[audio-thread]`
+    fn changed(&mut self);
 }
 
 /// Requests the host to resize the GUI client area on behalf of the product.
@@ -36,6 +59,10 @@ pub trait HostState: Send + Sync {
 /// This trait is `Send + Sync` because it is stored inside the shared plugin context,
 /// not because every method is meaningful from every thread. Call `request_resize` only
 /// from the product's GUI event path.
+///
+/// `resize_hints_changed` and `closed` currently call CLAP `[main-thread]` host
+/// callbacks directly. The adapter does not marshal them yet, so call those methods
+/// only from a context that is already on the host main thread.
 pub trait HostGui: Send + Sync {
     /// Calls CLAP `host_gui.resize_hints_changed`. `[main-thread]`
     fn resize_hints_changed(&self) {}

--- a/crates/wrac_clap_adapter/src/host_latency.rs
+++ b/crates/wrac_clap_adapter/src/host_latency.rs
@@ -1,0 +1,52 @@
+use clap_sys::ext::latency::{CLAP_EXT_LATENCY, clap_host_latency};
+use clap_sys::host::clap_host;
+
+pub(crate) struct HostLatencyProxy {
+    changed: Option<HostLatencyChanged>,
+}
+
+impl HostLatencyProxy {
+    pub(crate) fn new(host: *const clap_host) -> Self {
+        Self {
+            changed: host_latency_changed(host),
+        }
+    }
+
+    pub(crate) fn changed(&self) {
+        let Some(changed) = self.changed else {
+            log::debug!("host_latency.changed: host latency extension unavailable");
+            return;
+        };
+
+        unsafe {
+            (changed.changed)(changed.host);
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct HostLatencyChanged {
+    host: *const clap_host,
+    changed: unsafe extern "C" fn(host: *const clap_host),
+}
+
+// `changed` is called only by the adapter during CLAP activate, where CLAP marks
+// the plugin as `[being-activated]`.
+unsafe impl Send for HostLatencyChanged {}
+unsafe impl Sync for HostLatencyChanged {}
+
+fn host_latency_changed(host: *const clap_host) -> Option<HostLatencyChanged> {
+    if host.is_null() {
+        return None;
+    }
+
+    unsafe {
+        let get_extension = (*host).get_extension?;
+        let latency = get_extension(host, CLAP_EXT_LATENCY.as_ptr()) as *const clap_host_latency;
+        if latency.is_null() {
+            return None;
+        }
+        let changed = (*latency).changed?;
+        Some(HostLatencyChanged { host, changed })
+    }
+}

--- a/crates/wrac_clap_adapter/src/host_lifecycle.rs
+++ b/crates/wrac_clap_adapter/src/host_lifecycle.rs
@@ -1,0 +1,53 @@
+use clap_sys::host::clap_host;
+
+use crate::HostLifecycle;
+
+pub(crate) struct HostLifecycleProxy {
+    restart: Option<HostRequestRestart>,
+}
+
+impl HostLifecycleProxy {
+    pub(crate) fn new(host: *const clap_host) -> Self {
+        Self {
+            restart: host_request_restart(host),
+        }
+    }
+}
+
+impl HostLifecycle for HostLifecycleProxy {
+    fn request_restart(&self) {
+        let Some(restart) = self.restart else {
+            log::debug!("host.request_restart: callback unavailable");
+            return;
+        };
+
+        unsafe {
+            (restart.request_restart)(restart.host);
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct HostRequestRestart {
+    host: *const clap_host,
+    request_restart: unsafe extern "C" fn(host: *const clap_host),
+}
+
+// The CLAP host pointer is owned by the host for the plugin instance lifetime. The
+// public trait restricts product-facing use to control-thread contexts.
+unsafe impl Send for HostRequestRestart {}
+unsafe impl Sync for HostRequestRestart {}
+
+fn host_request_restart(host: *const clap_host) -> Option<HostRequestRestart> {
+    if host.is_null() {
+        return None;
+    }
+
+    unsafe {
+        let request_restart = (*host).request_restart?;
+        Some(HostRequestRestart {
+            host,
+            request_restart,
+        })
+    }
+}

--- a/crates/wrac_clap_adapter/src/host_tail.rs
+++ b/crates/wrac_clap_adapter/src/host_tail.rs
@@ -1,0 +1,60 @@
+use clap_sys::ext::tail::{CLAP_EXT_TAIL, clap_host_tail};
+use clap_sys::host::clap_host;
+
+use crate::HostTail;
+
+#[derive(Clone, Copy)]
+pub(crate) struct HostTailFactory {
+    changed: Option<HostTailChanged>,
+}
+
+impl HostTailFactory {
+    pub(crate) fn new(host: *const clap_host) -> Self {
+        Self {
+            changed: host_tail_changed(host),
+        }
+    }
+
+    pub(crate) fn create_handle(&self) -> Option<Box<dyn HostTail>> {
+        self.changed
+            .map(|changed| Box::new(HostTailProxy { changed }) as Box<dyn HostTail>)
+    }
+}
+
+struct HostTailProxy {
+    changed: HostTailChanged,
+}
+
+impl HostTail for HostTailProxy {
+    fn changed(&mut self) {
+        unsafe {
+            (self.changed.changed)(self.changed.host);
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct HostTailChanged {
+    host: *const clap_host,
+    changed: unsafe extern "C" fn(host: *const clap_host),
+}
+
+// The handle is moved into the ActiveProcessor and used only from serialized
+// audio-thread callbacks. It is Send so the processor can move between host threads.
+unsafe impl Send for HostTailChanged {}
+
+fn host_tail_changed(host: *const clap_host) -> Option<HostTailChanged> {
+    if host.is_null() {
+        return None;
+    }
+
+    unsafe {
+        let get_extension = (*host).get_extension?;
+        let tail = get_extension(host, CLAP_EXT_TAIL.as_ptr()) as *const clap_host_tail;
+        if tail.is_null() {
+            return None;
+        }
+        let changed = (*tail).changed?;
+        Some(HostTailChanged { host, changed })
+    }
+}

--- a/crates/wrac_clap_adapter/src/lib.rs
+++ b/crates/wrac_clap_adapter/src/lib.rs
@@ -12,15 +12,19 @@ mod entry;
 mod events;
 mod factory;
 mod host_gui;
+mod host_latency;
+mod host_lifecycle;
 mod host_state;
+mod host_tail;
 mod params;
 mod process_buffer;
 
 pub use api::{
-    ActivateContext, ActiveProcessor, AudioPortConfigRequest, AudioPortFlags, AudioPortInfo,
-    AudioPortType, DetectedHost, GuiApi, GuiConfig, GuiResizeHints, GuiSize, HostContext,
-    HostFamily, HostGui, HostParams, HostState, HostVersion, HostWindow, InactiveProcessor,
-    NoteDialects, NotePortInfo, ParamFlags, ParamFlushContext, ParamInfo, ParamValueEvent,
+    ActivateContext, ActivateNotifications, ActivateResult, ActiveProcessor,
+    AudioPortConfigRequest, AudioPortFlags, AudioPortInfo, AudioPortType, DetectedHost, GuiApi,
+    GuiConfig, GuiResizeHints, GuiSize, HostContext, HostFamily, HostGui, HostLifecycle,
+    HostParams, HostState, HostTail, HostVersion, HostWindow, InactiveProcessor, NoteDialects,
+    NotePortInfo, ParamFlags, ParamFlushContext, ParamInfo, ParamValueEvent,
     PluginAudioPortsExtension, PluginConfigurableAudioPortsExtension, PluginError, PluginFormat,
     PluginGuiExtension, PluginGuiMainThreadExtension, PluginGuiQueryExtension, PluginInstance,
     PluginInstanceContext, PluginLatencyExtension, PluginNotePortsExtension, PluginParamsQuery,

--- a/crates/wrac_clap_adapter/src/params.rs
+++ b/crates/wrac_clap_adapter/src/params.rs
@@ -35,6 +35,20 @@ impl HostParamsProxy {
 }
 
 impl HostParams for HostParamsProxy {
+    fn request_flush(&self) {
+        let Some(params) = self.host_params else {
+            log::debug!("host_params.request_flush: host params extension unavailable");
+            return;
+        };
+
+        if let Some(request_flush) = params.request_flush {
+            unsafe {
+                request_flush(params.host);
+            }
+        } else {
+            log::debug!("host_params.request_flush: host request_flush callback unavailable");
+        }
+    }
     fn rescan(&self, flags: u32) {
         let Some(params) = self.host_params else {
             log::debug!("host_params.rescan: host params extension unavailable");
@@ -62,21 +76,6 @@ impl HostParams for HostParamsProxy {
             }
         } else {
             log::debug!("host_params.clear: host clear callback unavailable");
-        }
-    }
-
-    fn request_flush(&self) {
-        let Some(params) = self.host_params else {
-            log::debug!("host_params.request_flush: host params extension unavailable");
-            return;
-        };
-
-        if let Some(request_flush) = params.request_flush {
-            unsafe {
-                request_flush(params.host);
-            }
-        } else {
-            log::debug!("host_params.request_flush: host request_flush callback unavailable");
         }
     }
 }

--- a/plugins/wrac-gain/src-plugin/src/plugin.rs
+++ b/plugins/wrac-gain/src-plugin/src/plugin.rs
@@ -27,7 +27,7 @@ use audio_ports::{AudioLayoutStore, WracGainAudioPorts, WracGainConfigurableAudi
 use params::WracGainParamsExtension;
 use state::WracGainStateExtension;
 use wrac_clap_adapter::{
-    AaxDescriptor, AaxStemConfig, ActivateContext, ActiveProcessor, Auv2Descriptor,
+    AaxDescriptor, AaxStemConfig, ActivateContext, ActivateResult, ActiveProcessor, Auv2Descriptor,
     InactiveProcessor, PluginAudioPortsExtension, PluginConfigurableAudioPortsExtension,
     PluginDescriptor, PluginEntry, PluginFactory, PluginFeature, PluginGuiExtension,
     PluginInstance, PluginInstanceContext, PluginParamsQuery, PluginResult, PluginStateExtension,
@@ -196,7 +196,7 @@ impl PluginInstance for WracGainPlugin {
         &mut self,
         context: ActivateContext,
         _processor: Box<dyn InactiveProcessor>,
-    ) -> PluginResult<Box<dyn ActiveProcessor>> {
+    ) -> PluginResult<ActivateResult> {
         // Boundary between the non-RT layout store and the RT processor.
         //
         // The adapter rejects layout changes while active, so the channel count
@@ -213,11 +213,11 @@ impl PluginInstance for WracGainPlugin {
             context.max_frames_count,
             audio_channel_count
         );
-        Ok(Box::new(WracGainAudioProcessor::new(
+        Ok(ActivateResult::new(Box::new(WracGainAudioProcessor::new(
             self.shared.clone(),
             self.param_output_queue.clone(),
             audio_channel_count,
-        )))
+        ))))
     }
 
     /// Called when the host stops audio processing.


### PR DESCRIPTION
## Summary

- Keep the CLAP latency extension available for wrapper compatibility while detecting missing product latency support in debug builds.
- Add activate-time host latency notifications and active-processor host tail notification handles.
- Rename product-facing host state/params APIs away from MainThread naming while documenting the current direct main-thread callback limitation.

## Verification

- cargo test -p wrac_clap_adapter --lib
- cargo check --workspace --all-targets