### PR TITLE
Expose CLAP host callback forwarding proxies

### DIFF
--- a/crates/wrac_clap_adapter/README.md
+++ b/crates/wrac_clap_adapter/README.md
@@ -37,6 +37,8 @@ This crate, on the other hand, also targets VST3/AU/AAX hosts via `clap-wrapper`
 - `PluginRenderExtension`: CLAP `render`
 - `PluginTailExtension`: CLAP `tail`
 - `PluginLatencyExtension`: CLAP `latency`
+- `HostParams`, `HostState`, `HostAudioPorts`, `HostNotePorts`, `HostLifecycle`,
+  `HostGui`, `HostTail`: thin proxies for plugin-to-host CLAP callbacks
 - `export_clap_entry!`: exports the CLAP entry point
 
 Each trait is a thin Rust representation of the corresponding CLAP C ABI. This crate is not designed as a general plugin framework.
@@ -47,9 +49,8 @@ This crate is provided as part of an implementation example, not as a general-pu
 
 Additionally, full CLAP ABI coverage is not yet complete. Known limitations:
 
-- `audio-ports`: exposes current port metadata only; dynamic port rescan notifications are not supported
 - `configurable-audio-ports`: only layout negotiation while inactive is supported
-- `params`: value rescan after state restore is supported, but a dynamic rescan API for the parameter schema itself is not provided
+- Host callback proxies are thin wrappers and do not marshal calls to a different thread
 - Output event batching helpers are minimal (sample-accurate event ordering is the product's responsibility)
 - The `audio-ports-activation` extension is not implemented
 - Typed factories other than plugin factory and AUv2 wrapper info are not implemented yet

--- a/crates/wrac_clap_adapter/src/abi.rs
+++ b/crates/wrac_clap_adapter/src/abi.rs
@@ -129,6 +129,7 @@ pub(crate) struct PluginInstanceState {
     latency: Option<Arc<dyn PluginLatencyExtension>>,
     host_latency: HostLatencyProxy,
     host_tail: HostTailFactory,
+    host_extensions_initialized: Arc<AtomicBool>,
     host_context: HostContext,
     // Re-entry guard for GUI mutation callbacks. Fails immediately on re-entry to avoid
     // deadlock (GUI query callbacks do not go through this guard).
@@ -178,16 +179,29 @@ impl PluginInstanceState {
         clap_host_name: Option<String>,
         host_context: HostContext,
     ) -> Option<Box<Self>> {
-        let host_params = Arc::new(HostParamsProxy::new(host));
+        let host_extensions_initialized = Arc::new(AtomicBool::new(false));
+        let host_params = Arc::new(HostParamsProxy::new(
+            host,
+            host_extensions_initialized.clone(),
+        ));
         // Pass as a safe proxy so product GUI code can hold it without knowing about
         // host pointers or CLAP event lifetimes.
         let context = PluginInstanceContext {
             host_params: host_params.clone(),
-            host_state: Arc::new(HostStateProxy::new(host)),
-            host_audio_ports: Arc::new(HostAudioPortsProxy::new(host)),
-            host_note_ports: Arc::new(HostNotePortsProxy::new(host)),
+            host_state: Arc::new(HostStateProxy::new(
+                host,
+                host_extensions_initialized.clone(),
+            )),
+            host_audio_ports: Arc::new(HostAudioPortsProxy::new(
+                host,
+                host_extensions_initialized.clone(),
+            )),
+            host_note_ports: Arc::new(HostNotePortsProxy::new(
+                host,
+                host_extensions_initialized.clone(),
+            )),
             host_lifecycle: Arc::new(HostLifecycleProxy::new(host)),
-            host_gui: Arc::new(HostGuiProxy::new(host)),
+            host_gui: Arc::new(HostGuiProxy::new(host, host_extensions_initialized.clone())),
             host_context: host_context.clone(),
         };
         let mut core = registration
@@ -270,8 +284,9 @@ impl PluginInstanceState {
             render,
             tail,
             latency,
-            host_latency: HostLatencyProxy::new(host),
-            host_tail: HostTailFactory::new(host),
+            host_latency: HostLatencyProxy::new(host, host_extensions_initialized.clone()),
+            host_tail: HostTailFactory::new(host, host_extensions_initialized.clone()),
+            host_extensions_initialized,
             host_context,
             gui_callback_busy: Mutex::new(()),
             gui_lifecycle_thread: Mutex::new(None),
@@ -829,11 +844,14 @@ pub(crate) unsafe extern "C" fn factory_create_plugin(
 
 unsafe extern "C" fn plugin_init(plugin: *const clap_plugin) -> bool {
     ffi_bool(|| {
-        let initialized = unsafe { PluginInstanceState::from_plugin(plugin).is_some() };
-        if !initialized {
+        let Some(instance) = (unsafe { PluginInstanceState::from_plugin(plugin) }) else {
             log::warn!("plugin.init: missing plugin instance");
-        }
-        initialized
+            return false;
+        };
+        instance
+            .host_extensions_initialized
+            .store(true, Ordering::Release);
+        true
     })
 }
 
@@ -846,6 +864,9 @@ unsafe extern "C" fn plugin_destroy(plugin: *const clap_plugin) {
         let detach_in_adapter = instance.host_context.plugin_format == PluginFormat::Unknown;
         let registration = instance.registration;
         let guard = instance.enter_lifecycle_blocking();
+        instance
+            .host_extensions_initialized
+            .store(false, Ordering::Release);
 
         if let Some(gui) = &instance.gui {
             if let Some(_gui_callback) = instance.gui_callback_busy.try_lock() {
@@ -1234,14 +1255,18 @@ mod tests {
     #[test]
     fn activate_notification_calls_host_latency_changed_during_activate() {
         LATENCY_CHANGED_COUNT.store(0, Ordering::Relaxed);
-        let host = test_host();
+        let host_get_extension_count = AtomicU32::new(0);
+        let host = test_host_with_get_extension_count(&host_get_extension_count);
         let instance = test_instance(&ACTIVATE_LATENCY_CHANGED_REGISTRATION, &host);
+        assert_eq!(host_get_extension_count.load(Ordering::Relaxed), 0);
 
         assert!(unsafe { plugin_init(&instance.plugin as *const clap_plugin) });
+        assert_eq!(host_get_extension_count.load(Ordering::Relaxed), 0);
         let activated =
             unsafe { plugin_activate(&instance.plugin as *const clap_plugin, 48_000.0, 1, 512) };
 
         assert!(activated);
+        assert_eq!(host_get_extension_count.load(Ordering::Relaxed), 1);
         assert_eq!(LATENCY_CHANGED_COUNT.load(Ordering::Relaxed), 1);
     }
 
@@ -1281,14 +1306,18 @@ mod tests {
         AUDIO_PORTS_RESCAN_COUNT.store(0, Ordering::Relaxed);
         NOTE_PORTS_SUPPORTED_DIALECTS_COUNT.store(0, Ordering::Relaxed);
         NOTE_PORTS_RESCAN_COUNT.store(0, Ordering::Relaxed);
-        let host = test_host();
+        let host_get_extension_count = AtomicU32::new(0);
+        let host = test_host_with_get_extension_count(&host_get_extension_count);
         let instance = test_instance(&REQUEST_HOST_PORTS_REGISTRATION, &host);
+        assert_eq!(host_get_extension_count.load(Ordering::Relaxed), 0);
 
         assert!(unsafe { plugin_init(&instance.plugin as *const clap_plugin) });
+        assert_eq!(host_get_extension_count.load(Ordering::Relaxed), 0);
         let activated =
             unsafe { plugin_activate(&instance.plugin as *const clap_plugin, 48_000.0, 1, 512) };
 
         assert!(activated);
+        assert_eq!(host_get_extension_count.load(Ordering::Relaxed), 2);
         assert_eq!(
             AUDIO_PORTS_IS_RESCAN_FLAG_SUPPORTED_COUNT.load(Ordering::Relaxed),
             1
@@ -1320,9 +1349,17 @@ mod tests {
     }
 
     fn test_host() -> clap_host {
+        test_host_with_data(ptr::null_mut())
+    }
+
+    fn test_host_with_get_extension_count(count: &AtomicU32) -> clap_host {
+        test_host_with_data((count as *const AtomicU32).cast_mut().cast())
+    }
+
+    fn test_host_with_data(host_data: *mut std::ffi::c_void) -> clap_host {
         clap_host {
             clap_version: CLAP_VERSION,
-            host_data: ptr::null_mut(),
+            host_data,
             name: c"Test Host".as_ptr(),
             vendor: c"Test Vendor".as_ptr(),
             url: c"https://example.invalid".as_ptr(),
@@ -1335,11 +1372,17 @@ mod tests {
     }
 
     unsafe extern "C" fn test_host_get_extension(
-        _host: *const clap_host,
+        host: *const clap_host,
         extension_id: *const std::ffi::c_char,
     ) -> *const std::ffi::c_void {
         if extension_id.is_null() {
             return ptr::null();
+        }
+        if let Some(count) = unsafe {
+            host.as_ref()
+                .and_then(|host| host.host_data.cast::<AtomicU32>().as_ref())
+        } {
+            count.fetch_add(1, Ordering::Relaxed);
         }
         let id = unsafe { std::ffi::CStr::from_ptr(extension_id) };
         if id == CLAP_EXT_LATENCY {

--- a/crates/wrac_clap_adapter/src/abi.rs
+++ b/crates/wrac_clap_adapter/src/abi.rs
@@ -58,9 +58,11 @@ use crate::factory::{
     auv2_factory_ptr, auv2_factory_state, clap_factory_state, factory_ptr, main_thread_hook_ptr,
     main_thread_hook_state, vst3_factory_ptr, vst3_factory_state,
 };
+use crate::host_audio_ports::HostAudioPortsProxy;
 use crate::host_gui::HostGuiProxy;
 use crate::host_latency::HostLatencyProxy;
 use crate::host_lifecycle::HostLifecycleProxy;
+use crate::host_note_ports::HostNotePortsProxy;
 use crate::host_state::HostStateProxy;
 use crate::host_tail::HostTailFactory;
 use crate::params::HostParamsProxy;
@@ -182,6 +184,8 @@ impl PluginInstanceState {
         let context = PluginInstanceContext {
             host_params: host_params.clone(),
             host_state: Arc::new(HostStateProxy::new(host)),
+            host_audio_ports: Arc::new(HostAudioPortsProxy::new(host)),
+            host_note_ports: Arc::new(HostNotePortsProxy::new(host)),
             host_lifecycle: Arc::new(HostLifecycleProxy::new(host)),
             host_gui: Arc::new(HostGuiProxy::new(host)),
             host_context: host_context.clone(),
@@ -1118,10 +1122,14 @@ unsafe extern "C" fn plugin_get_extension(
     })
 }
 
-unsafe extern "C" fn plugin_on_main_thread(_plugin: *const clap_plugin) {
-    // WRAC intentionally does not route product work through CLAP's main-thread callback.
-    // GUI and main-thread tasks should use novonotes_run_loop/wxp instead, which keeps
-    // behavior consistent across native CLAP and wrapper-backed VST3/AU hosts.
+unsafe extern "C" fn plugin_on_main_thread(plugin: *const clap_plugin) {
+    ffi_unit(|| {
+        let Some(instance) = (unsafe { PluginInstanceState::from_plugin(plugin) }) else {
+            log::warn!("plugin.on_main_thread: missing plugin instance");
+            return;
+        };
+        instance.core.lock().on_main_thread();
+    });
 }
 
 #[cfg(test)]
@@ -1131,24 +1139,37 @@ mod tests {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicU32, Ordering};
 
+    use clap_sys::ext::audio_ports::{
+        CLAP_AUDIO_PORTS_RESCAN_NAMES, CLAP_EXT_AUDIO_PORTS, clap_host_audio_ports,
+    };
     use clap_sys::ext::latency::{CLAP_EXT_LATENCY, clap_host_latency, clap_plugin_latency};
+    use clap_sys::ext::note_ports::{
+        CLAP_EXT_NOTE_PORTS, CLAP_NOTE_DIALECT_CLAP, CLAP_NOTE_PORTS_RESCAN_NAMES,
+        clap_host_note_ports,
+    };
     use clap_sys::host::clap_host;
     use clap_sys::plugin::clap_plugin;
     use clap_sys::version::CLAP_VERSION;
 
-    use super::{PluginInstanceState, plugin_activate, plugin_get_extension, plugin_init};
+    use super::{
+        PluginInstanceState, plugin_activate, plugin_get_extension, plugin_init,
+        plugin_on_main_thread,
+    };
     use crate::entry::EntryRegistration;
     use crate::{
         ActivateContext, ActivateNotifications, ActivateResult, ActiveProcessor, EntryContext,
-        InactiveProcessor, ParamFlushContext, PluginDescriptor, PluginEntry, PluginFactory,
-        PluginInstance, PluginInstanceContext, PluginLatencyExtension, PluginParamsQuery,
-        PluginResult, ProcessContext, ProcessStatus,
+        HostAudioPorts, HostLifecycle, HostNotePorts, InactiveProcessor, NoteDialects,
+        ParamFlushContext, PluginDescriptor, PluginEntry, PluginFactory, PluginInstance,
+        PluginInstanceContext, PluginLatencyExtension, PluginParamsQuery, PluginResult,
+        ProcessContext, ProcessStatus,
     };
     use wrac_host_context::HostContext;
 
     static ZERO_LATENCY_ENTRY: TestEntry = TestEntry {
         factory: TestFactory {
             activate_latency_changed: false,
+            request_host_lifecycle: false,
+            request_host_ports: false,
         },
     };
     static ZERO_LATENCY_REGISTRATION: EntryRegistration =
@@ -1157,12 +1178,41 @@ mod tests {
     static ACTIVATE_LATENCY_CHANGED_ENTRY: TestEntry = TestEntry {
         factory: TestFactory {
             activate_latency_changed: true,
+            request_host_lifecycle: false,
+            request_host_ports: false,
         },
     };
     static ACTIVATE_LATENCY_CHANGED_REGISTRATION: EntryRegistration =
         EntryRegistration::new(&ACTIVATE_LATENCY_CHANGED_ENTRY);
 
+    static REQUEST_HOST_LIFECYCLE_ENTRY: TestEntry = TestEntry {
+        factory: TestFactory {
+            activate_latency_changed: false,
+            request_host_lifecycle: true,
+            request_host_ports: false,
+        },
+    };
+    static REQUEST_HOST_PORTS_ENTRY: TestEntry = TestEntry {
+        factory: TestFactory {
+            activate_latency_changed: false,
+            request_host_lifecycle: false,
+            request_host_ports: true,
+        },
+    };
+    static REQUEST_HOST_LIFECYCLE_REGISTRATION: EntryRegistration =
+        EntryRegistration::new(&REQUEST_HOST_LIFECYCLE_ENTRY);
+    static REQUEST_HOST_PORTS_REGISTRATION: EntryRegistration =
+        EntryRegistration::new(&REQUEST_HOST_PORTS_ENTRY);
+
     static LATENCY_CHANGED_COUNT: AtomicU32 = AtomicU32::new(0);
+    static REQUEST_RESTART_COUNT: AtomicU32 = AtomicU32::new(0);
+    static REQUEST_PROCESS_COUNT: AtomicU32 = AtomicU32::new(0);
+    static REQUEST_CALLBACK_COUNT: AtomicU32 = AtomicU32::new(0);
+    static AUDIO_PORTS_IS_RESCAN_FLAG_SUPPORTED_COUNT: AtomicU32 = AtomicU32::new(0);
+    static AUDIO_PORTS_RESCAN_COUNT: AtomicU32 = AtomicU32::new(0);
+    static NOTE_PORTS_SUPPORTED_DIALECTS_COUNT: AtomicU32 = AtomicU32::new(0);
+    static NOTE_PORTS_RESCAN_COUNT: AtomicU32 = AtomicU32::new(0);
+    static ON_MAIN_THREAD_COUNT: AtomicU32 = AtomicU32::new(0);
 
     #[test]
     fn zero_latency_exposes_latency_extension() {
@@ -1193,6 +1243,62 @@ mod tests {
 
         assert!(activated);
         assert_eq!(LATENCY_CHANGED_COUNT.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn activate_forwards_host_lifecycle_requests() {
+        REQUEST_RESTART_COUNT.store(0, Ordering::Relaxed);
+        REQUEST_PROCESS_COUNT.store(0, Ordering::Relaxed);
+        REQUEST_CALLBACK_COUNT.store(0, Ordering::Relaxed);
+        let host = test_host();
+        let instance = test_instance(&REQUEST_HOST_LIFECYCLE_REGISTRATION, &host);
+
+        assert!(unsafe { plugin_init(&instance.plugin as *const clap_plugin) });
+        let activated =
+            unsafe { plugin_activate(&instance.plugin as *const clap_plugin, 48_000.0, 1, 512) };
+
+        assert!(activated);
+        assert_eq!(REQUEST_RESTART_COUNT.load(Ordering::Relaxed), 1);
+        assert_eq!(REQUEST_PROCESS_COUNT.load(Ordering::Relaxed), 1);
+        assert_eq!(REQUEST_CALLBACK_COUNT.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn plugin_on_main_thread_calls_instance_hook() {
+        ON_MAIN_THREAD_COUNT.store(0, Ordering::Relaxed);
+        let instance = test_instance(&ZERO_LATENCY_REGISTRATION, ptr::null());
+
+        unsafe {
+            plugin_on_main_thread(&instance.plugin as *const clap_plugin);
+        }
+
+        assert_eq!(ON_MAIN_THREAD_COUNT.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn activate_forwards_host_port_requests() {
+        AUDIO_PORTS_IS_RESCAN_FLAG_SUPPORTED_COUNT.store(0, Ordering::Relaxed);
+        AUDIO_PORTS_RESCAN_COUNT.store(0, Ordering::Relaxed);
+        NOTE_PORTS_SUPPORTED_DIALECTS_COUNT.store(0, Ordering::Relaxed);
+        NOTE_PORTS_RESCAN_COUNT.store(0, Ordering::Relaxed);
+        let host = test_host();
+        let instance = test_instance(&REQUEST_HOST_PORTS_REGISTRATION, &host);
+
+        assert!(unsafe { plugin_init(&instance.plugin as *const clap_plugin) });
+        let activated =
+            unsafe { plugin_activate(&instance.plugin as *const clap_plugin, 48_000.0, 1, 512) };
+
+        assert!(activated);
+        assert_eq!(
+            AUDIO_PORTS_IS_RESCAN_FLAG_SUPPORTED_COUNT.load(Ordering::Relaxed),
+            1
+        );
+        assert_eq!(AUDIO_PORTS_RESCAN_COUNT.load(Ordering::Relaxed), 1);
+        assert_eq!(
+            NOTE_PORTS_SUPPORTED_DIALECTS_COUNT.load(Ordering::Relaxed),
+            1
+        );
+        assert_eq!(NOTE_PORTS_RESCAN_COUNT.load(Ordering::Relaxed), 1);
     }
 
     fn test_instance(
@@ -1238,6 +1344,10 @@ mod tests {
         let id = unsafe { std::ffi::CStr::from_ptr(extension_id) };
         if id == CLAP_EXT_LATENCY {
             (&TEST_HOST_LATENCY as *const clap_host_latency).cast()
+        } else if id == CLAP_EXT_AUDIO_PORTS {
+            (&TEST_HOST_AUDIO_PORTS as *const clap_host_audio_ports).cast()
+        } else if id == CLAP_EXT_NOTE_PORTS {
+            (&TEST_HOST_NOTE_PORTS as *const clap_host_note_ports).cast()
         } else {
             ptr::null()
         }
@@ -1247,12 +1357,51 @@ mod tests {
         LATENCY_CHANGED_COUNT.fetch_add(1, Ordering::Relaxed);
     }
 
-    unsafe extern "C" fn test_host_request_restart(_host: *const clap_host) {}
-    unsafe extern "C" fn test_host_request_process(_host: *const clap_host) {}
-    unsafe extern "C" fn test_host_request_callback(_host: *const clap_host) {}
+    unsafe extern "C" fn test_host_request_restart(_host: *const clap_host) {
+        REQUEST_RESTART_COUNT.fetch_add(1, Ordering::Relaxed);
+    }
+
+    unsafe extern "C" fn test_host_request_process(_host: *const clap_host) {
+        REQUEST_PROCESS_COUNT.fetch_add(1, Ordering::Relaxed);
+    }
+
+    unsafe extern "C" fn test_host_request_callback(_host: *const clap_host) {
+        REQUEST_CALLBACK_COUNT.fetch_add(1, Ordering::Relaxed);
+    }
 
     static TEST_HOST_LATENCY: clap_host_latency = clap_host_latency {
         changed: Some(test_host_latency_changed),
+    };
+
+    unsafe extern "C" fn test_host_audio_ports_is_rescan_flag_supported(
+        _host: *const clap_host,
+        flag: u32,
+    ) -> bool {
+        AUDIO_PORTS_IS_RESCAN_FLAG_SUPPORTED_COUNT.fetch_add(1, Ordering::Relaxed);
+        flag == CLAP_AUDIO_PORTS_RESCAN_NAMES
+    }
+
+    unsafe extern "C" fn test_host_audio_ports_rescan(_host: *const clap_host, _flags: u32) {
+        AUDIO_PORTS_RESCAN_COUNT.fetch_add(1, Ordering::Relaxed);
+    }
+
+    static TEST_HOST_AUDIO_PORTS: clap_host_audio_ports = clap_host_audio_ports {
+        is_rescan_flag_supported: Some(test_host_audio_ports_is_rescan_flag_supported),
+        rescan: Some(test_host_audio_ports_rescan),
+    };
+
+    unsafe extern "C" fn test_host_note_ports_supported_dialects(_host: *const clap_host) -> u32 {
+        NOTE_PORTS_SUPPORTED_DIALECTS_COUNT.fetch_add(1, Ordering::Relaxed);
+        CLAP_NOTE_DIALECT_CLAP
+    }
+
+    unsafe extern "C" fn test_host_note_ports_rescan(_host: *const clap_host, _flags: u32) {
+        NOTE_PORTS_RESCAN_COUNT.fetch_add(1, Ordering::Relaxed);
+    }
+
+    static TEST_HOST_NOTE_PORTS: clap_host_note_ports = clap_host_note_ports {
+        supported_dialects: Some(test_host_note_ports_supported_dialects),
+        rescan: Some(test_host_note_ports_rescan),
     };
 
     static TEST_DESCRIPTOR: PluginDescriptor = PluginDescriptor {
@@ -1287,6 +1436,8 @@ mod tests {
     #[derive(Clone, Copy)]
     struct TestFactory {
         activate_latency_changed: bool,
+        request_host_lifecycle: bool,
+        request_host_ports: bool,
     }
 
     impl PluginFactory for TestFactory {
@@ -1301,11 +1452,16 @@ mod tests {
         fn create_plugin(
             &self,
             plugin_id: &str,
-            _context: PluginInstanceContext,
+            context: PluginInstanceContext,
         ) -> Option<Box<dyn PluginInstance>> {
             (plugin_id == TEST_DESCRIPTOR.id).then(|| {
                 Box::new(TestPlugin {
                     activate_latency_changed: self.activate_latency_changed,
+                    request_host_lifecycle: self.request_host_lifecycle,
+                    request_host_ports: self.request_host_ports,
+                    host_lifecycle: context.host_lifecycle,
+                    host_audio_ports: context.host_audio_ports,
+                    host_note_ports: context.host_note_ports,
                 }) as Box<dyn PluginInstance>
             })
         }
@@ -1313,6 +1469,11 @@ mod tests {
 
     struct TestPlugin {
         activate_latency_changed: bool,
+        request_host_lifecycle: bool,
+        request_host_ports: bool,
+        host_lifecycle: Arc<dyn HostLifecycle>,
+        host_audio_ports: Arc<dyn HostAudioPorts>,
+        host_note_ports: Arc<dyn HostNotePorts>,
     }
 
     impl PluginInstance for TestPlugin {
@@ -1325,6 +1486,23 @@ mod tests {
             _context: ActivateContext,
             _processor: Box<dyn InactiveProcessor>,
         ) -> PluginResult<ActivateResult> {
+            if self.request_host_lifecycle {
+                self.host_lifecycle.request_restart();
+                self.host_lifecycle.request_process();
+                self.host_lifecycle.request_callback();
+            }
+            if self.request_host_ports {
+                assert!(
+                    self.host_audio_ports
+                        .is_rescan_flag_supported(CLAP_AUDIO_PORTS_RESCAN_NAMES)
+                );
+                self.host_audio_ports.rescan(CLAP_AUDIO_PORTS_RESCAN_NAMES);
+                assert_eq!(
+                    self.host_note_ports.supported_dialects(),
+                    NoteDialects::CLAP
+                );
+                self.host_note_ports.rescan(CLAP_NOTE_PORTS_RESCAN_NAMES);
+            }
             Ok(ActivateResult {
                 processor: Box::new(TestActiveProcessor),
                 notifications: ActivateNotifications {
@@ -1338,6 +1516,10 @@ mod tests {
             _processor: Box<dyn ActiveProcessor>,
         ) -> PluginResult<Box<dyn InactiveProcessor>> {
             Ok(Box::new(TestInactiveProcessor))
+        }
+
+        fn on_main_thread(&mut self) {
+            ON_MAIN_THREAD_COUNT.fetch_add(1, Ordering::Relaxed);
         }
 
         fn params(&self) -> Arc<dyn PluginParamsQuery> {

--- a/crates/wrac_clap_adapter/src/api.rs
+++ b/crates/wrac_clap_adapter/src/api.rs
@@ -47,7 +47,9 @@ pub use extensions::{
     PluginGuiMainThreadExtension, PluginGuiQueryExtension, PluginLatencyExtension,
     PluginNotePortsExtension, PluginRenderExtension, PluginStateExtension, PluginTailExtension,
 };
-pub use host::{HostGui, HostLifecycle, HostParams, HostState, HostTail};
+pub use host::{
+    HostAudioPorts, HostGui, HostLifecycle, HostNotePorts, HostParams, HostState, HostTail,
+};
 pub use params::PluginParamsQuery;
 pub use process::{
     ActiveProcessor, InactiveProcessor, ParamFlushContext, ProcessContext, ProcessStatus,

--- a/crates/wrac_clap_adapter/src/api/core.rs
+++ b/crates/wrac_clap_adapter/src/api/core.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
 use crate::{
-    ActiveProcessor, HostGui, HostLifecycle, HostParams, HostState, HostTail, InactiveProcessor,
-    PluginAudioPortsExtension, PluginConfigurableAudioPortsExtension, PluginGuiExtension,
-    PluginLatencyExtension, PluginNotePortsExtension, PluginParamsQuery, PluginRenderExtension,
-    PluginResult, PluginStateExtension, PluginTailExtension,
+    ActiveProcessor, HostAudioPorts, HostGui, HostLifecycle, HostNotePorts, HostParams, HostState,
+    HostTail, InactiveProcessor, PluginAudioPortsExtension, PluginConfigurableAudioPortsExtension,
+    PluginGuiExtension, PluginLatencyExtension, PluginNotePortsExtension, PluginParamsQuery,
+    PluginRenderExtension, PluginResult, PluginStateExtension, PluginTailExtension,
 };
 use wrac_host_context::HostContext;
 
@@ -45,6 +45,8 @@ pub struct ActivateNotifications {
 pub struct PluginInstanceContext {
     pub host_params: Arc<dyn HostParams>,
     pub host_state: Arc<dyn HostState>,
+    pub host_audio_ports: Arc<dyn HostAudioPorts>,
+    pub host_note_ports: Arc<dyn HostNotePorts>,
     pub host_lifecycle: Arc<dyn HostLifecycle>,
     pub host_gui: Arc<dyn HostGui>,
     pub host_context: HostContext,
@@ -81,6 +83,10 @@ pub trait PluginInstance: Send + 'static {
         &mut self,
         processor: Box<dyn ActiveProcessor>,
     ) -> PluginResult<Box<dyn InactiveProcessor>>;
+
+    /// Called from CLAP `plugin.on_main_thread`, usually after `HostLifecycle::request_callback`.
+    /// `[main-thread]`
+    fn on_main_thread(&mut self) {}
 
     /// Returns the CLAP audio-ports extension during plugin instance creation.
     ///

--- a/crates/wrac_clap_adapter/src/api/host.rs
+++ b/crates/wrac_clap_adapter/src/api/host.rs
@@ -12,7 +12,7 @@ use crate::{GuiSize, NoteDialects, PluginResult};
 /// `MainThread` naming because the long-term contract is for the adapter to turn these
 /// into queued/coalesced host requests.
 pub trait HostParams: Send + Sync {
-    /// Calls CLAP `host_params.request_flush`. `[non-audio control path]`
+    /// Calls CLAP `host_params.request_flush`. `[thread-safe & control-thread]`
     ///
     /// CLAP allows this from any non-audio thread. WRAC keeps the product-facing
     /// contract narrower because wrapper hosts may not implement the native CLAP
@@ -69,13 +69,13 @@ pub trait HostNotePorts: Send + Sync {
 /// thread-safe, but product code should prefer non-realtime control paths unless it
 /// is transparently forwarding an inner plugin request.
 pub trait HostLifecycle: Send + Sync {
-    /// Calls CLAP `host.request_restart`. `[non-audio control path]`
+    /// Calls CLAP `host.request_restart`. `[thread-safe & control-thread]`
     fn request_restart(&self);
 
-    /// Calls CLAP `host.request_process`. `[thread-safe forwarding path]`
+    /// Calls CLAP `host.request_process`. `[thread-safe]`
     fn request_process(&self);
 
-    /// Calls CLAP `host.request_callback`. `[thread-safe forwarding path]`
+    /// Calls CLAP `host.request_callback`. `[thread-safe]`
     ///
     /// The host is expected to schedule a later `PluginInstance::on_main_thread` call.
     fn request_callback(&self);
@@ -94,29 +94,29 @@ pub trait HostTail: Send + 'static {
 ///
 /// This trait is `Send + Sync` because it is stored inside the shared plugin context,
 /// not because every method is meaningful from every thread. Call GUI host callbacks
-/// only from the product's GUI event or GUI lifecycle path; several wrapper hosts are
-/// less permissive than native CLAP here.
+/// only from the product's GUI/main-thread path; several wrapper hosts are less
+/// permissive than native CLAP here.
 ///
 pub trait HostGui: Send + Sync {
-    /// Calls CLAP `host_gui.resize_hints_changed`. `[GUI lifecycle path]`
+    /// Calls CLAP `host_gui.resize_hints_changed`. `[main-thread]`
     fn resize_hints_changed(&self) {}
 
-    /// Calls CLAP `host_gui.request_resize`. `[GUI event path]`
+    /// Calls CLAP `host_gui.request_resize`. `[main-thread]`
     ///
     /// Product code should call this from its GUI event path even though native
     /// CLAP permits broader use.
     fn request_resize(&self, size: GuiSize) -> PluginResult<()>;
 
-    /// Calls CLAP `host_gui.request_show`. `[GUI event path]`
+    /// Calls CLAP `host_gui.request_show`. `[main-thread]`
     fn request_show(&self) -> bool {
         false
     }
 
-    /// Calls CLAP `host_gui.request_hide`. `[GUI event path]`
+    /// Calls CLAP `host_gui.request_hide`. `[main-thread]`
     fn request_hide(&self) -> bool {
         false
     }
 
-    /// Calls CLAP `host_gui.closed`. `[GUI lifecycle path]`
+    /// Calls CLAP `host_gui.closed`. `[main-thread]`
     fn closed(&self, _was_destroyed: bool) {}
 }

--- a/crates/wrac_clap_adapter/src/api/host.rs
+++ b/crates/wrac_clap_adapter/src/api/host.rs
@@ -1,4 +1,4 @@
-use crate::{GuiSize, PluginResult};
+use crate::{GuiSize, NoteDialects, PluginResult};
 
 /// Requests host-side parameter synchronization and invalidation.
 ///
@@ -39,10 +39,40 @@ pub trait HostState: Send + Sync {
     fn mark_dirty(&self);
 }
 
-/// Requests host lifecycle changes.
+/// Requests host-side audio port metadata invalidation.
+pub trait HostAudioPorts: Send + Sync {
+    /// Calls CLAP `host_audio_ports.is_rescan_flag_supported`. `[main-thread]`
+    fn is_rescan_flag_supported(&self, _flag: u32) -> bool {
+        false
+    }
+
+    /// Calls CLAP `host_audio_ports.rescan`. `[main-thread]`
+    fn rescan(&self, _flags: u32) {}
+}
+
+/// Requests host-side note port metadata invalidation.
+pub trait HostNotePorts: Send + Sync {
+    /// Calls CLAP `host_note_ports.supported_dialects`. `[main-thread]`
+    fn supported_dialects(&self) -> NoteDialects {
+        NoteDialects::default()
+    }
+
+    /// Calls CLAP `host_note_ports.rescan`. `[main-thread]`
+    fn rescan(&self, _flags: u32) {}
+}
+
+/// Requests CLAP core host actions.
 pub trait HostLifecycle: Send + Sync {
     /// Calls CLAP `host.request_restart`. `[thread-safe & control-thread]`
     fn request_restart(&self);
+
+    /// Calls CLAP `host.request_process`. `[thread-safe]`
+    fn request_process(&self);
+
+    /// Calls CLAP `host.request_callback`. `[thread-safe]`
+    ///
+    /// The host is expected to schedule a later `PluginInstance::on_main_thread` call.
+    fn request_callback(&self);
 }
 
 /// Host tail notification handle owned by an active processor.

--- a/crates/wrac_clap_adapter/src/api/host.rs
+++ b/crates/wrac_clap_adapter/src/api/host.rs
@@ -12,7 +12,7 @@ use crate::{GuiSize, NoteDialects, PluginResult};
 /// `MainThread` naming because the long-term contract is for the adapter to turn these
 /// into queued/coalesced host requests.
 pub trait HostParams: Send + Sync {
-    /// Calls CLAP `host_params.request_flush`. `[thread-safe,!audio-thread]`
+    /// Calls CLAP `host_params.request_flush`. `[thread-safe & control-thread]`
     ///
     /// CLAP marks this callback `!audio-thread`; do not call it from realtime code.
     fn request_flush(&self);
@@ -63,7 +63,7 @@ pub trait HostNotePorts: Send + Sync {
 
 /// Requests CLAP core host actions.
 pub trait HostLifecycle: Send + Sync {
-    /// Calls CLAP `host.request_restart`. `[thread-safe]`
+    /// Calls CLAP `host.request_restart`. `[thread-safe & control-thread]`
     fn request_restart(&self);
 
     /// Calls CLAP `host.request_process`. `[thread-safe]`
@@ -90,11 +90,14 @@ pub trait HostTail: Send + 'static {
 /// not because every method is meaningful from every thread. Call `request_resize` only
 /// from the product's GUI event path.
 ///
+/// `resize_hints_changed` and `closed` currently call CLAP `[main-thread]` host
+/// callbacks directly. The adapter does not marshal them yet, so call those methods
+/// only from a context that is already on the host main thread.
 pub trait HostGui: Send + Sync {
-    /// Calls CLAP `host_gui.resize_hints_changed`. `[thread-safe & !floating]`
+    /// Calls CLAP `host_gui.resize_hints_changed`. `[main-thread]`
     fn resize_hints_changed(&self) {}
 
-    /// Calls CLAP `host_gui.request_resize`. `[thread-safe & !floating]`
+    /// Calls CLAP `host_gui.request_resize`. `[thread-safe & control-thread]`
     ///
     /// Product code should normally call this from its GUI event path.
     fn request_resize(&self, size: GuiSize) -> PluginResult<()>;
@@ -109,6 +112,6 @@ pub trait HostGui: Send + Sync {
         false
     }
 
-    /// Calls CLAP `host_gui.closed`. `[thread-safe]`
+    /// Calls CLAP `host_gui.closed`. `[main-thread]`
     fn closed(&self, _was_destroyed: bool) {}
 }

--- a/crates/wrac_clap_adapter/src/api/host.rs
+++ b/crates/wrac_clap_adapter/src/api/host.rs
@@ -12,9 +12,11 @@ use crate::{GuiSize, NoteDialects, PluginResult};
 /// `MainThread` naming because the long-term contract is for the adapter to turn these
 /// into queued/coalesced host requests.
 pub trait HostParams: Send + Sync {
-    /// Calls CLAP `host_params.request_flush`. `[thread-safe & control-thread]`
+    /// Calls CLAP `host_params.request_flush`. `[non-audio control path]`
     ///
-    /// CLAP marks this callback `!audio-thread`; do not call it from realtime code.
+    /// CLAP allows this from any non-audio thread. WRAC keeps the product-facing
+    /// contract narrower because wrapper hosts may not implement the native CLAP
+    /// threading contract exactly.
     fn request_flush(&self);
 
     /// Calls CLAP `host_params.rescan`. `[main-thread]`
@@ -62,14 +64,18 @@ pub trait HostNotePorts: Send + Sync {
 }
 
 /// Requests CLAP core host actions.
+///
+/// These calls are forwarded directly to the host. Native CLAP marks them as
+/// thread-safe, but product code should prefer non-realtime control paths unless it
+/// is transparently forwarding an inner plugin request.
 pub trait HostLifecycle: Send + Sync {
-    /// Calls CLAP `host.request_restart`. `[thread-safe & control-thread]`
+    /// Calls CLAP `host.request_restart`. `[non-audio control path]`
     fn request_restart(&self);
 
-    /// Calls CLAP `host.request_process`. `[thread-safe]`
+    /// Calls CLAP `host.request_process`. `[thread-safe forwarding path]`
     fn request_process(&self);
 
-    /// Calls CLAP `host.request_callback`. `[thread-safe]`
+    /// Calls CLAP `host.request_callback`. `[thread-safe forwarding path]`
     ///
     /// The host is expected to schedule a later `PluginInstance::on_main_thread` call.
     fn request_callback(&self);
@@ -87,31 +93,30 @@ pub trait HostTail: Send + 'static {
 /// Requests the host to resize the GUI client area on behalf of the product.
 ///
 /// This trait is `Send + Sync` because it is stored inside the shared plugin context,
-/// not because every method is meaningful from every thread. Call `request_resize` only
-/// from the product's GUI event path.
+/// not because every method is meaningful from every thread. Call GUI host callbacks
+/// only from the product's GUI event or GUI lifecycle path; several wrapper hosts are
+/// less permissive than native CLAP here.
 ///
-/// `resize_hints_changed` and `closed` currently call CLAP `[main-thread]` host
-/// callbacks directly. The adapter does not marshal them yet, so call those methods
-/// only from a context that is already on the host main thread.
 pub trait HostGui: Send + Sync {
-    /// Calls CLAP `host_gui.resize_hints_changed`. `[main-thread]`
+    /// Calls CLAP `host_gui.resize_hints_changed`. `[GUI lifecycle path]`
     fn resize_hints_changed(&self) {}
 
-    /// Calls CLAP `host_gui.request_resize`. `[thread-safe & control-thread]`
+    /// Calls CLAP `host_gui.request_resize`. `[GUI event path]`
     ///
-    /// Product code should normally call this from its GUI event path.
+    /// Product code should call this from its GUI event path even though native
+    /// CLAP permits broader use.
     fn request_resize(&self, size: GuiSize) -> PluginResult<()>;
 
-    /// Calls CLAP `host_gui.request_show`. `[thread-safe]`
+    /// Calls CLAP `host_gui.request_show`. `[GUI event path]`
     fn request_show(&self) -> bool {
         false
     }
 
-    /// Calls CLAP `host_gui.request_hide`. `[thread-safe]`
+    /// Calls CLAP `host_gui.request_hide`. `[GUI event path]`
     fn request_hide(&self) -> bool {
         false
     }
 
-    /// Calls CLAP `host_gui.closed`. `[main-thread]`
+    /// Calls CLAP `host_gui.closed`. `[GUI lifecycle path]`
     fn closed(&self, _was_destroyed: bool) {}
 }

--- a/crates/wrac_clap_adapter/src/api/host.rs
+++ b/crates/wrac_clap_adapter/src/api/host.rs
@@ -12,7 +12,7 @@ use crate::{GuiSize, NoteDialects, PluginResult};
 /// `MainThread` naming because the long-term contract is for the adapter to turn these
 /// into queued/coalesced host requests.
 pub trait HostParams: Send + Sync {
-    /// Calls CLAP `host_params.request_flush`. `[thread-safe & control-thread]`
+    /// Calls CLAP `host_params.request_flush`. `[thread-safe,!audio-thread]`
     ///
     /// CLAP marks this callback `!audio-thread`; do not call it from realtime code.
     fn request_flush(&self);
@@ -63,7 +63,7 @@ pub trait HostNotePorts: Send + Sync {
 
 /// Requests CLAP core host actions.
 pub trait HostLifecycle: Send + Sync {
-    /// Calls CLAP `host.request_restart`. `[thread-safe & control-thread]`
+    /// Calls CLAP `host.request_restart`. `[thread-safe]`
     fn request_restart(&self);
 
     /// Calls CLAP `host.request_process`. `[thread-safe]`
@@ -90,14 +90,11 @@ pub trait HostTail: Send + 'static {
 /// not because every method is meaningful from every thread. Call `request_resize` only
 /// from the product's GUI event path.
 ///
-/// `resize_hints_changed` and `closed` currently call CLAP `[main-thread]` host
-/// callbacks directly. The adapter does not marshal them yet, so call those methods
-/// only from a context that is already on the host main thread.
 pub trait HostGui: Send + Sync {
-    /// Calls CLAP `host_gui.resize_hints_changed`. `[main-thread]`
+    /// Calls CLAP `host_gui.resize_hints_changed`. `[thread-safe & !floating]`
     fn resize_hints_changed(&self) {}
 
-    /// Calls CLAP `host_gui.request_resize`. `[thread-safe & control-thread]`
+    /// Calls CLAP `host_gui.request_resize`. `[thread-safe & !floating]`
     ///
     /// Product code should normally call this from its GUI event path.
     fn request_resize(&self, size: GuiSize) -> PluginResult<()>;
@@ -112,6 +109,6 @@ pub trait HostGui: Send + Sync {
         false
     }
 
-    /// Calls CLAP `host_gui.closed`. `[main-thread]`
+    /// Calls CLAP `host_gui.closed`. `[thread-safe]`
     fn closed(&self, _was_destroyed: bool) {}
 }

--- a/crates/wrac_clap_adapter/src/host_audio_ports.rs
+++ b/crates/wrac_clap_adapter/src/host_audio_ports.rs
@@ -1,0 +1,78 @@
+use clap_sys::ext::audio_ports::{CLAP_EXT_AUDIO_PORTS, clap_host_audio_ports};
+use clap_sys::host::clap_host;
+
+use crate::HostAudioPorts;
+
+pub(crate) struct HostAudioPortsProxy {
+    host_audio_ports: Option<HostAudioPortsCallbacks>,
+}
+
+impl HostAudioPortsProxy {
+    pub(crate) fn new(host: *const clap_host) -> Self {
+        Self {
+            host_audio_ports: host_audio_ports(host),
+        }
+    }
+}
+
+impl HostAudioPorts for HostAudioPortsProxy {
+    fn is_rescan_flag_supported(&self, flag: u32) -> bool {
+        let Some(audio_ports) = self.host_audio_ports else {
+            log::debug!("host_audio_ports.is_rescan_flag_supported: host extension unavailable");
+            return false;
+        };
+
+        let Some(is_rescan_flag_supported) = audio_ports.is_rescan_flag_supported else {
+            log::debug!("host_audio_ports.is_rescan_flag_supported: host callback unavailable");
+            return false;
+        };
+
+        unsafe { is_rescan_flag_supported(audio_ports.host, flag) }
+    }
+
+    fn rescan(&self, flags: u32) {
+        let Some(audio_ports) = self.host_audio_ports else {
+            log::debug!("host_audio_ports.rescan: host extension unavailable");
+            return;
+        };
+
+        let Some(rescan) = audio_ports.rescan else {
+            log::debug!("host_audio_ports.rescan: host callback unavailable");
+            return;
+        };
+
+        unsafe {
+            rescan(audio_ports.host, flags);
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct HostAudioPortsCallbacks {
+    host: *const clap_host,
+    is_rescan_flag_supported:
+        Option<unsafe extern "C" fn(host: *const clap_host, flag: u32) -> bool>,
+    rescan: Option<unsafe extern "C" fn(host: *const clap_host, flags: u32)>,
+}
+
+// The CLAP host pointer is owned by the host for the plugin instance lifetime.
+unsafe impl Send for HostAudioPortsCallbacks {}
+unsafe impl Sync for HostAudioPortsCallbacks {}
+
+fn host_audio_ports(host: *const clap_host) -> Option<HostAudioPortsCallbacks> {
+    if host.is_null() {
+        return None;
+    }
+
+    unsafe {
+        let get_extension = (*host).get_extension?;
+        let audio_ports =
+            get_extension(host, CLAP_EXT_AUDIO_PORTS.as_ptr()) as *const clap_host_audio_ports;
+        let audio_ports = audio_ports.as_ref()?;
+        Some(HostAudioPortsCallbacks {
+            host,
+            is_rescan_flag_supported: audio_ports.is_rescan_flag_supported,
+            rescan: audio_ports.rescan,
+        })
+    }
+}

--- a/crates/wrac_clap_adapter/src/host_audio_ports.rs
+++ b/crates/wrac_clap_adapter/src/host_audio_ports.rs
@@ -1,23 +1,42 @@
 use clap_sys::ext::audio_ports::{CLAP_EXT_AUDIO_PORTS, clap_host_audio_ports};
 use clap_sys::host::clap_host;
+use std::sync::{
+    Arc, OnceLock,
+    atomic::{AtomicBool, Ordering},
+};
 
 use crate::HostAudioPorts;
 
 pub(crate) struct HostAudioPortsProxy {
-    host_audio_ports: Option<HostAudioPortsCallbacks>,
+    host: *const clap_host,
+    initialized: Arc<AtomicBool>,
+    host_audio_ports: OnceLock<Option<HostAudioPortsCallbacks>>,
 }
 
 impl HostAudioPortsProxy {
-    pub(crate) fn new(host: *const clap_host) -> Self {
+    pub(crate) fn new(host: *const clap_host, initialized: Arc<AtomicBool>) -> Self {
         Self {
-            host_audio_ports: host_audio_ports(host),
+            host,
+            initialized,
+            host_audio_ports: OnceLock::new(),
         }
+    }
+
+    fn callbacks(&self) -> Option<HostAudioPortsCallbacks> {
+        if !self.initialized.load(Ordering::Acquire) {
+            log::debug!("host_audio_ports: host extension unavailable before plugin.init");
+            return None;
+        }
+
+        *self
+            .host_audio_ports
+            .get_or_init(|| host_audio_ports(self.host))
     }
 }
 
 impl HostAudioPorts for HostAudioPortsProxy {
     fn is_rescan_flag_supported(&self, flag: u32) -> bool {
-        let Some(audio_ports) = self.host_audio_ports else {
+        let Some(audio_ports) = self.callbacks() else {
             log::debug!("host_audio_ports.is_rescan_flag_supported: host extension unavailable");
             return false;
         };
@@ -31,7 +50,7 @@ impl HostAudioPorts for HostAudioPortsProxy {
     }
 
     fn rescan(&self, flags: u32) {
-        let Some(audio_ports) = self.host_audio_ports else {
+        let Some(audio_ports) = self.callbacks() else {
             log::debug!("host_audio_ports.rescan: host extension unavailable");
             return;
         };
@@ -58,6 +77,11 @@ struct HostAudioPortsCallbacks {
 // The CLAP host pointer is owned by the host for the plugin instance lifetime.
 unsafe impl Send for HostAudioPortsCallbacks {}
 unsafe impl Sync for HostAudioPortsCallbacks {}
+
+// Extension lookup is delayed until after `plugin.init`; callers only hold the safe
+// trait object exposed by the adapter context.
+unsafe impl Send for HostAudioPortsProxy {}
+unsafe impl Sync for HostAudioPortsProxy {}
 
 fn host_audio_ports(host: *const clap_host) -> Option<HostAudioPortsCallbacks> {
     if host.is_null() {

--- a/crates/wrac_clap_adapter/src/host_gui.rs
+++ b/crates/wrac_clap_adapter/src/host_gui.rs
@@ -1,23 +1,42 @@
 use clap_sys::ext::gui::{CLAP_EXT_GUI, clap_host_gui};
 use clap_sys::host::clap_host;
+use std::sync::{
+    Arc, OnceLock,
+    atomic::{AtomicBool, Ordering},
+};
 
 use crate::{GuiSize, HostGui, PluginError, PluginResult};
 
 pub(crate) struct HostGuiProxy {
-    host_gui: Option<HostGuiCallbacks>,
+    host: *const clap_host,
+    initialized: Arc<AtomicBool>,
+    host_gui: OnceLock<Option<HostGuiCallbacks>>,
 }
 
 impl HostGuiProxy {
-    pub(crate) fn new(host: *const clap_host) -> Self {
+    pub(crate) fn new(host: *const clap_host, initialized: Arc<AtomicBool>) -> Self {
         Self {
-            host_gui: host_gui_request_resize(host),
+            host,
+            initialized,
+            host_gui: OnceLock::new(),
         }
+    }
+
+    fn callbacks(&self) -> Option<HostGuiCallbacks> {
+        if !self.initialized.load(Ordering::Acquire) {
+            log::debug!("host_gui: host extension unavailable before plugin.init");
+            return None;
+        }
+
+        *self
+            .host_gui
+            .get_or_init(|| host_gui_request_resize(self.host))
     }
 }
 
 impl HostGui for HostGuiProxy {
     fn resize_hints_changed(&self) {
-        let Some(host_gui) = self.host_gui else {
+        let Some(host_gui) = self.callbacks() else {
             log::debug!("host_gui.resize_hints_changed: host GUI extension unavailable");
             return;
         };
@@ -34,7 +53,7 @@ impl HostGui for HostGuiProxy {
     }
 
     fn request_resize(&self, size: GuiSize) -> PluginResult<()> {
-        let Some(host_gui) = self.host_gui else {
+        let Some(host_gui) = self.callbacks() else {
             return Err(PluginError::Message(
                 "host does not expose CLAP GUI extension",
             ));
@@ -49,7 +68,7 @@ impl HostGui for HostGuiProxy {
     }
 
     fn request_show(&self) -> bool {
-        let Some(host_gui) = self.host_gui else {
+        let Some(host_gui) = self.callbacks() else {
             log::debug!("host_gui.request_show: host GUI extension unavailable");
             return false;
         };
@@ -63,7 +82,7 @@ impl HostGui for HostGuiProxy {
     }
 
     fn request_hide(&self) -> bool {
-        let Some(host_gui) = self.host_gui else {
+        let Some(host_gui) = self.callbacks() else {
             log::debug!("host_gui.request_hide: host GUI extension unavailable");
             return false;
         };
@@ -77,7 +96,7 @@ impl HostGui for HostGuiProxy {
     }
 
     fn closed(&self, was_destroyed: bool) {
-        let Some(host_gui) = self.host_gui else {
+        let Some(host_gui) = self.callbacks() else {
             log::debug!("host_gui.closed: host GUI extension unavailable");
             return;
         };
@@ -107,6 +126,11 @@ struct HostGuiCallbacks {
 // must still use request_resize from the GUI event path, not from audio/background work.
 unsafe impl Send for HostGuiCallbacks {}
 unsafe impl Sync for HostGuiCallbacks {}
+
+// Extension lookup is delayed until after `plugin.init`; callers only hold the safe
+// trait object exposed by the adapter context.
+unsafe impl Send for HostGuiProxy {}
+unsafe impl Sync for HostGuiProxy {}
 
 fn host_gui_request_resize(host: *const clap_host) -> Option<HostGuiCallbacks> {
     if host.is_null() {

--- a/crates/wrac_clap_adapter/src/host_latency.rs
+++ b/crates/wrac_clap_adapter/src/host_latency.rs
@@ -1,19 +1,27 @@
 use clap_sys::ext::latency::{CLAP_EXT_LATENCY, clap_host_latency};
 use clap_sys::host::clap_host;
+use std::sync::{
+    Arc, OnceLock,
+    atomic::{AtomicBool, Ordering},
+};
 
 pub(crate) struct HostLatencyProxy {
-    changed: Option<HostLatencyChanged>,
+    host: *const clap_host,
+    initialized: Arc<AtomicBool>,
+    changed: OnceLock<Option<HostLatencyChanged>>,
 }
 
 impl HostLatencyProxy {
-    pub(crate) fn new(host: *const clap_host) -> Self {
+    pub(crate) fn new(host: *const clap_host, initialized: Arc<AtomicBool>) -> Self {
         Self {
-            changed: host_latency_changed(host),
+            host,
+            initialized,
+            changed: OnceLock::new(),
         }
     }
 
     pub(crate) fn changed(&self) {
-        let Some(changed) = self.changed else {
+        let Some(changed) = self.callbacks() else {
             log::debug!("host_latency.changed: host latency extension unavailable");
             return;
         };
@@ -21,6 +29,15 @@ impl HostLatencyProxy {
         unsafe {
             (changed.changed)(changed.host);
         }
+    }
+
+    fn callbacks(&self) -> Option<HostLatencyChanged> {
+        if !self.initialized.load(Ordering::Acquire) {
+            log::debug!("host_latency: host extension unavailable before plugin.init");
+            return None;
+        }
+
+        *self.changed.get_or_init(|| host_latency_changed(self.host))
     }
 }
 
@@ -34,6 +51,11 @@ struct HostLatencyChanged {
 // the plugin as `[being-activated]`.
 unsafe impl Send for HostLatencyChanged {}
 unsafe impl Sync for HostLatencyChanged {}
+
+// Extension lookup is delayed until after `plugin.init`; this proxy is used by the
+// adapter after initialization during activation.
+unsafe impl Send for HostLatencyProxy {}
+unsafe impl Sync for HostLatencyProxy {}
 
 fn host_latency_changed(host: *const clap_host) -> Option<HostLatencyChanged> {
     if host.is_null() {

--- a/crates/wrac_clap_adapter/src/host_lifecycle.rs
+++ b/crates/wrac_clap_adapter/src/host_lifecycle.rs
@@ -3,51 +3,81 @@ use clap_sys::host::clap_host;
 use crate::HostLifecycle;
 
 pub(crate) struct HostLifecycleProxy {
-    restart: Option<HostRequestRestart>,
+    callbacks: HostLifecycleCallbacks,
 }
 
 impl HostLifecycleProxy {
     pub(crate) fn new(host: *const clap_host) -> Self {
         Self {
-            restart: host_request_restart(host),
+            callbacks: HostLifecycleCallbacks::new(host),
         }
     }
 }
 
 impl HostLifecycle for HostLifecycleProxy {
     fn request_restart(&self) {
-        let Some(restart) = self.restart else {
+        let Some(request_restart) = self.callbacks.request_restart else {
             log::debug!("host.request_restart: callback unavailable");
             return;
         };
 
         unsafe {
-            (restart.request_restart)(restart.host);
+            request_restart(self.callbacks.host);
+        }
+    }
+
+    fn request_process(&self) {
+        let Some(request_process) = self.callbacks.request_process else {
+            log::debug!("host.request_process: callback unavailable");
+            return;
+        };
+
+        unsafe {
+            request_process(self.callbacks.host);
+        }
+    }
+
+    fn request_callback(&self) {
+        let Some(request_callback) = self.callbacks.request_callback else {
+            log::debug!("host.request_callback: callback unavailable");
+            return;
+        };
+
+        unsafe {
+            request_callback(self.callbacks.host);
         }
     }
 }
 
 #[derive(Clone, Copy)]
-struct HostRequestRestart {
+struct HostLifecycleCallbacks {
     host: *const clap_host,
-    request_restart: unsafe extern "C" fn(host: *const clap_host),
+    request_restart: Option<unsafe extern "C" fn(host: *const clap_host)>,
+    request_process: Option<unsafe extern "C" fn(host: *const clap_host)>,
+    request_callback: Option<unsafe extern "C" fn(host: *const clap_host)>,
 }
 
-// The CLAP host pointer is owned by the host for the plugin instance lifetime. The
-// public trait restricts product-facing use to control-thread contexts.
-unsafe impl Send for HostRequestRestart {}
-unsafe impl Sync for HostRequestRestart {}
+// The CLAP host pointer is owned by the host for the plugin instance lifetime. The public trait
+// mirrors CLAP's host lifecycle callbacks and does not add scheduling or thread correction.
+unsafe impl Send for HostLifecycleCallbacks {}
+unsafe impl Sync for HostLifecycleCallbacks {}
 
-fn host_request_restart(host: *const clap_host) -> Option<HostRequestRestart> {
-    if host.is_null() {
-        return None;
-    }
+impl HostLifecycleCallbacks {
+    fn new(host: *const clap_host) -> Self {
+        let Some(host_ref) = (unsafe { host.as_ref() }) else {
+            return Self {
+                host,
+                request_restart: None,
+                request_process: None,
+                request_callback: None,
+            };
+        };
 
-    unsafe {
-        let request_restart = (*host).request_restart?;
-        Some(HostRequestRestart {
+        Self {
             host,
-            request_restart,
-        })
+            request_restart: host_ref.request_restart,
+            request_process: host_ref.request_process,
+            request_callback: host_ref.request_callback,
+        }
     }
 }

--- a/crates/wrac_clap_adapter/src/host_note_ports.rs
+++ b/crates/wrac_clap_adapter/src/host_note_ports.rs
@@ -1,0 +1,77 @@
+use clap_sys::ext::note_ports::{CLAP_EXT_NOTE_PORTS, clap_host_note_ports};
+use clap_sys::host::clap_host;
+
+use crate::{HostNotePorts, NoteDialects};
+
+pub(crate) struct HostNotePortsProxy {
+    host_note_ports: Option<HostNotePortsCallbacks>,
+}
+
+impl HostNotePortsProxy {
+    pub(crate) fn new(host: *const clap_host) -> Self {
+        Self {
+            host_note_ports: host_note_ports(host),
+        }
+    }
+}
+
+impl HostNotePorts for HostNotePortsProxy {
+    fn supported_dialects(&self) -> NoteDialects {
+        let Some(note_ports) = self.host_note_ports else {
+            log::debug!("host_note_ports.supported_dialects: host extension unavailable");
+            return NoteDialects::default();
+        };
+
+        let Some(supported_dialects) = note_ports.supported_dialects else {
+            log::debug!("host_note_ports.supported_dialects: host callback unavailable");
+            return NoteDialects::default();
+        };
+
+        NoteDialects::from_bits(unsafe { supported_dialects(note_ports.host) })
+    }
+
+    fn rescan(&self, flags: u32) {
+        let Some(note_ports) = self.host_note_ports else {
+            log::debug!("host_note_ports.rescan: host extension unavailable");
+            return;
+        };
+
+        let Some(rescan) = note_ports.rescan else {
+            log::debug!("host_note_ports.rescan: host callback unavailable");
+            return;
+        };
+
+        unsafe {
+            rescan(note_ports.host, flags);
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct HostNotePortsCallbacks {
+    host: *const clap_host,
+    supported_dialects: Option<unsafe extern "C" fn(host: *const clap_host) -> u32>,
+    rescan: Option<unsafe extern "C" fn(host: *const clap_host, flags: u32)>,
+}
+
+// The CLAP host pointer is owned by the host for the plugin instance lifetime.
+unsafe impl Send for HostNotePortsCallbacks {}
+unsafe impl Sync for HostNotePortsCallbacks {}
+
+fn host_note_ports(host: *const clap_host) -> Option<HostNotePortsCallbacks> {
+    if host.is_null() {
+        return None;
+    }
+
+    unsafe {
+        let get_extension = (*host).get_extension?;
+        let note_ports =
+            get_extension(host, CLAP_EXT_NOTE_PORTS.as_ptr()) as *const clap_host_note_ports;
+        let note_ports = note_ports.as_ref()?;
+        Some(HostNotePortsCallbacks {
+            host,
+            supported_dialects: note_ports.supported_dialects,
+            rescan: note_ports.rescan,
+        })
+    }
+}

--- a/crates/wrac_clap_adapter/src/host_note_ports.rs
+++ b/crates/wrac_clap_adapter/src/host_note_ports.rs
@@ -1,23 +1,42 @@
 use clap_sys::ext::note_ports::{CLAP_EXT_NOTE_PORTS, clap_host_note_ports};
 use clap_sys::host::clap_host;
+use std::sync::{
+    Arc, OnceLock,
+    atomic::{AtomicBool, Ordering},
+};
 
 use crate::{HostNotePorts, NoteDialects};
 
 pub(crate) struct HostNotePortsProxy {
-    host_note_ports: Option<HostNotePortsCallbacks>,
+    host: *const clap_host,
+    initialized: Arc<AtomicBool>,
+    host_note_ports: OnceLock<Option<HostNotePortsCallbacks>>,
 }
 
 impl HostNotePortsProxy {
-    pub(crate) fn new(host: *const clap_host) -> Self {
+    pub(crate) fn new(host: *const clap_host, initialized: Arc<AtomicBool>) -> Self {
         Self {
-            host_note_ports: host_note_ports(host),
+            host,
+            initialized,
+            host_note_ports: OnceLock::new(),
         }
+    }
+
+    fn callbacks(&self) -> Option<HostNotePortsCallbacks> {
+        if !self.initialized.load(Ordering::Acquire) {
+            log::debug!("host_note_ports: host extension unavailable before plugin.init");
+            return None;
+        }
+
+        *self
+            .host_note_ports
+            .get_or_init(|| host_note_ports(self.host))
     }
 }
 
 impl HostNotePorts for HostNotePortsProxy {
     fn supported_dialects(&self) -> NoteDialects {
-        let Some(note_ports) = self.host_note_ports else {
+        let Some(note_ports) = self.callbacks() else {
             log::debug!("host_note_ports.supported_dialects: host extension unavailable");
             return NoteDialects::default();
         };
@@ -31,7 +50,7 @@ impl HostNotePorts for HostNotePortsProxy {
     }
 
     fn rescan(&self, flags: u32) {
-        let Some(note_ports) = self.host_note_ports else {
+        let Some(note_ports) = self.callbacks() else {
             log::debug!("host_note_ports.rescan: host extension unavailable");
             return;
         };
@@ -57,6 +76,11 @@ struct HostNotePortsCallbacks {
 // The CLAP host pointer is owned by the host for the plugin instance lifetime.
 unsafe impl Send for HostNotePortsCallbacks {}
 unsafe impl Sync for HostNotePortsCallbacks {}
+
+// Extension lookup is delayed until after `plugin.init`; callers only hold the safe
+// trait object exposed by the adapter context.
+unsafe impl Send for HostNotePortsProxy {}
+unsafe impl Sync for HostNotePortsProxy {}
 
 fn host_note_ports(host: *const clap_host) -> Option<HostNotePortsCallbacks> {
     if host.is_null() {

--- a/crates/wrac_clap_adapter/src/host_state.rs
+++ b/crates/wrac_clap_adapter/src/host_state.rs
@@ -1,23 +1,42 @@
 use clap_sys::ext::state::{CLAP_EXT_STATE, clap_host_state};
 use clap_sys::host::clap_host;
+use std::sync::{
+    Arc, OnceLock,
+    atomic::{AtomicBool, Ordering},
+};
 
 use crate::HostState;
 
 pub(crate) struct HostStateProxy {
-    host_state: Option<HostStateMarkDirty>,
+    host: *const clap_host,
+    initialized: Arc<AtomicBool>,
+    host_state: OnceLock<Option<HostStateMarkDirty>>,
 }
 
 impl HostStateProxy {
-    pub(crate) fn new(host: *const clap_host) -> Self {
+    pub(crate) fn new(host: *const clap_host, initialized: Arc<AtomicBool>) -> Self {
         Self {
-            host_state: host_state_mark_dirty(host),
+            host,
+            initialized,
+            host_state: OnceLock::new(),
         }
+    }
+
+    fn callbacks(&self) -> Option<HostStateMarkDirty> {
+        if !self.initialized.load(Ordering::Acquire) {
+            log::debug!("host_state: host extension unavailable before plugin.init");
+            return None;
+        }
+
+        *self
+            .host_state
+            .get_or_init(|| host_state_mark_dirty(self.host))
     }
 }
 
 impl HostState for HostStateProxy {
     fn mark_dirty(&self) {
-        let Some(host_state) = self.host_state else {
+        let Some(host_state) = self.callbacks() else {
             log::debug!("host_state.mark_dirty: host state extension unavailable");
             return;
         };
@@ -39,6 +58,11 @@ struct HostStateMarkDirty {
 // main-thread constraint, so products never receive the raw pointer.
 unsafe impl Send for HostStateMarkDirty {}
 unsafe impl Sync for HostStateMarkDirty {}
+
+// Extension lookup is delayed until after `plugin.init`; callers only hold the safe
+// trait object exposed by the adapter context.
+unsafe impl Send for HostStateProxy {}
+unsafe impl Sync for HostStateProxy {}
 
 fn host_state_mark_dirty(host: *const clap_host) -> Option<HostStateMarkDirty> {
     if host.is_null() {

--- a/crates/wrac_clap_adapter/src/host_tail.rs
+++ b/crates/wrac_clap_adapter/src/host_tail.rs
@@ -1,23 +1,39 @@
 use clap_sys::ext::tail::{CLAP_EXT_TAIL, clap_host_tail};
 use clap_sys::host::clap_host;
+use std::sync::{
+    Arc, OnceLock,
+    atomic::{AtomicBool, Ordering},
+};
 
 use crate::HostTail;
 
-#[derive(Clone, Copy)]
 pub(crate) struct HostTailFactory {
-    changed: Option<HostTailChanged>,
+    host: *const clap_host,
+    initialized: Arc<AtomicBool>,
+    changed: OnceLock<Option<HostTailChanged>>,
 }
 
 impl HostTailFactory {
-    pub(crate) fn new(host: *const clap_host) -> Self {
+    pub(crate) fn new(host: *const clap_host, initialized: Arc<AtomicBool>) -> Self {
         Self {
-            changed: host_tail_changed(host),
+            host,
+            initialized,
+            changed: OnceLock::new(),
         }
     }
 
     pub(crate) fn create_handle(&self) -> Option<Box<dyn HostTail>> {
-        self.changed
+        self.changed()
             .map(|changed| Box::new(HostTailProxy { changed }) as Box<dyn HostTail>)
+    }
+
+    fn changed(&self) -> Option<HostTailChanged> {
+        if !self.initialized.load(Ordering::Acquire) {
+            log::debug!("host_tail: host extension unavailable before plugin.init");
+            return None;
+        }
+
+        *self.changed.get_or_init(|| host_tail_changed(self.host))
     }
 }
 
@@ -42,6 +58,11 @@ struct HostTailChanged {
 // The handle is moved into the ActiveProcessor and used only from serialized
 // audio-thread callbacks. It is Send so the processor can move between host threads.
 unsafe impl Send for HostTailChanged {}
+
+// Extension lookup is delayed until after `plugin.init`; this factory is used by the
+// adapter during activation before the audio-thread handle is created.
+unsafe impl Send for HostTailFactory {}
+unsafe impl Sync for HostTailFactory {}
 
 fn host_tail_changed(host: *const clap_host) -> Option<HostTailChanged> {
     if host.is_null() {

--- a/crates/wrac_clap_adapter/src/lib.rs
+++ b/crates/wrac_clap_adapter/src/lib.rs
@@ -11,9 +11,11 @@ mod descriptor;
 mod entry;
 mod events;
 mod factory;
+mod host_audio_ports;
 mod host_gui;
 mod host_latency;
 mod host_lifecycle;
+mod host_note_ports;
 mod host_state;
 mod host_tail;
 mod params;
@@ -22,13 +24,13 @@ mod process_buffer;
 pub use api::{
     ActivateContext, ActivateNotifications, ActivateResult, ActiveProcessor,
     AudioPortConfigRequest, AudioPortFlags, AudioPortInfo, AudioPortType, DetectedHost, GuiApi,
-    GuiConfig, GuiResizeHints, GuiSize, HostContext, HostFamily, HostGui, HostLifecycle,
-    HostParams, HostState, HostTail, HostVersion, HostWindow, InactiveProcessor, NoteDialects,
-    NotePortInfo, ParamFlags, ParamFlushContext, ParamInfo, ParamValueEvent,
-    PluginAudioPortsExtension, PluginConfigurableAudioPortsExtension, PluginError, PluginFormat,
-    PluginGuiExtension, PluginGuiMainThreadExtension, PluginGuiQueryExtension, PluginInstance,
-    PluginInstanceContext, PluginLatencyExtension, PluginNotePortsExtension, PluginParamsQuery,
-    PluginRenderExtension, PluginRenderMode, PluginResult, PluginStateExtension,
+    GuiConfig, GuiResizeHints, GuiSize, HostAudioPorts, HostContext, HostFamily, HostGui,
+    HostLifecycle, HostNotePorts, HostParams, HostState, HostTail, HostVersion, HostWindow,
+    InactiveProcessor, NoteDialects, NotePortInfo, ParamFlags, ParamFlushContext, ParamInfo,
+    ParamValueEvent, PluginAudioPortsExtension, PluginConfigurableAudioPortsExtension, PluginError,
+    PluginFormat, PluginGuiExtension, PluginGuiMainThreadExtension, PluginGuiQueryExtension,
+    PluginInstance, PluginInstanceContext, PluginLatencyExtension, PluginNotePortsExtension,
+    PluginParamsQuery, PluginRenderExtension, PluginRenderMode, PluginResult, PluginStateExtension,
     PluginTailExtension, ProcessContext, ProcessStatus, State, SystemContext,
 };
 #[cfg(feature = "raw-clap-forwarding")]

--- a/crates/wrac_clap_adapter/src/params.rs
+++ b/crates/wrac_clap_adapter/src/params.rs
@@ -3,23 +3,31 @@ use clap_sys::ext::params::{
     clap_param_rescan_flags,
 };
 use clap_sys::host::clap_host;
+use std::sync::{
+    Arc, OnceLock,
+    atomic::{AtomicBool, Ordering},
+};
 
 use crate::HostParams;
 
 /// Thin proxy for the CLAP host params extension.
 pub(crate) struct HostParamsProxy {
-    host_params: Option<HostParamsCallbacks>,
+    host: *const clap_host,
+    initialized: Arc<AtomicBool>,
+    host_params: OnceLock<Option<HostParamsCallbacks>>,
 }
 
 impl HostParamsProxy {
-    pub(crate) fn new(host: *const clap_host) -> Self {
+    pub(crate) fn new(host: *const clap_host, initialized: Arc<AtomicBool>) -> Self {
         Self {
-            host_params: host_params(host),
+            host,
+            initialized,
+            host_params: OnceLock::new(),
         }
     }
 
     pub(crate) fn rescan_values(&self) {
-        let Some(params) = self.host_params else {
+        let Some(params) = self.callbacks() else {
             log::debug!("host_params.rescan_values: host params extension unavailable");
             return;
         };
@@ -32,11 +40,20 @@ impl HostParamsProxy {
             log::debug!("host_params.rescan_values: host rescan callback unavailable");
         }
     }
+
+    fn callbacks(&self) -> Option<HostParamsCallbacks> {
+        if !self.initialized.load(Ordering::Acquire) {
+            log::debug!("host_params: host extension unavailable before plugin.init");
+            return None;
+        }
+
+        *self.host_params.get_or_init(|| host_params(self.host))
+    }
 }
 
 impl HostParams for HostParamsProxy {
     fn request_flush(&self) {
-        let Some(params) = self.host_params else {
+        let Some(params) = self.callbacks() else {
             log::debug!("host_params.request_flush: host params extension unavailable");
             return;
         };
@@ -50,7 +67,7 @@ impl HostParams for HostParamsProxy {
         }
     }
     fn rescan(&self, flags: u32) {
-        let Some(params) = self.host_params else {
+        let Some(params) = self.callbacks() else {
             log::debug!("host_params.rescan: host params extension unavailable");
             return;
         };
@@ -65,7 +82,7 @@ impl HostParams for HostParamsProxy {
     }
 
     fn clear(&self, param_id: u32, flags: u32) {
-        let Some(params) = self.host_params else {
+        let Some(params) = self.callbacks() else {
             log::debug!("host_params.clear: host params extension unavailable");
             return;
         };
@@ -96,6 +113,12 @@ struct HostParamsCallbacks {
 // main-thread contract.
 unsafe impl Send for HostParamsCallbacks {}
 unsafe impl Sync for HostParamsCallbacks {}
+
+// The host pointer is owned by the host for the plugin instance lifetime. Extension
+// lookup is delayed until after `plugin.init`, and product code only receives the
+// trait object, never this raw pointer.
+unsafe impl Send for HostParamsProxy {}
+unsafe impl Sync for HostParamsProxy {}
 
 fn host_params(host: *const clap_host) -> Option<HostParamsCallbacks> {
     if host.is_null() {


### PR DESCRIPTION
## Summary
- Add host audio and note port forwarding proxies to `PluginInstanceContext`.
- Extend host lifecycle forwarding with `request_process` and `request_callback`.
- Route CLAP `plugin.on_main_thread` to a new `PluginInstance::on_main_thread` hook.
- Update README coverage and add adapter tests for the forwarded callbacks.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p wrac_clap_adapter`
- `cargo xtask quality`
