### PR TITLE
Route state restore through lifecycle lane

### DIFF
--- a/crates/wrac_clap_adapter/src/abi.rs
+++ b/crates/wrac_clap_adapter/src/abi.rs
@@ -147,6 +147,7 @@ pub(crate) struct PluginInstanceState {
     processor_busy: AtomicBool,
     processor_active: AtomicBool,
     lifecycle_busy: AtomicBool,
+    lifecycle_thread: Mutex<Option<ThreadId>>,
     rt_process_depth: AtomicU32,
     rt_flush_depth: AtomicU32,
     rt_processor_contention: AtomicBool,
@@ -296,6 +297,7 @@ impl PluginInstanceState {
             processor_busy: AtomicBool::new(false),
             processor_active: AtomicBool::new(false),
             lifecycle_busy: AtomicBool::new(false),
+            lifecycle_thread: Mutex::new(None),
             rt_process_depth: AtomicU32::new(0),
             rt_flush_depth: AtomicU32::new(0),
             rt_processor_contention: AtomicBool::new(false),
@@ -468,6 +470,11 @@ impl PluginInstanceState {
         self.processor_active.load(Ordering::Acquire)
     }
 
+    pub(crate) fn is_in_realtime_callback(&self) -> bool {
+        self.rt_process_depth.load(Ordering::Acquire) > 0
+            || self.rt_flush_depth.load(Ordering::Acquire) > 0
+    }
+
     fn take_processor_blocking(&self) -> Option<Box<dyn ActiveProcessor>> {
         loop {
             if let Some(processor) = self.try_take_processor() {
@@ -498,7 +505,13 @@ impl PluginInstanceState {
         self.lifecycle_busy
             .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
             .ok()
-            .map(|_| LifecycleGuard(&self.lifecycle_busy))
+            .map(|_| {
+                *self.lifecycle_thread.lock() = Some(std::thread::current().id());
+                LifecycleGuard {
+                    busy: &self.lifecycle_busy,
+                    thread: &self.lifecycle_thread,
+                }
+            })
     }
 
     fn enter_lifecycle_blocking(&self) -> LifecycleGuard<'_> {
@@ -509,6 +522,19 @@ impl PluginInstanceState {
             // `destroy()` is a callback that can afford to wait. Releasing without
             // waiting would leave out-of-order wrapper lifecycle callbacks holding
             // stale adapter state.
+            std::thread::yield_now();
+        }
+    }
+
+    pub(crate) fn enter_lifecycle_blocking_or_reject_reentry(&self) -> Option<LifecycleGuard<'_>> {
+        let current = std::thread::current().id();
+        loop {
+            if let Some(guard) = self.try_enter_lifecycle() {
+                return Some(guard);
+            }
+            if matches!(*self.lifecycle_thread.lock(), Some(owner) if owner == current) {
+                return None;
+            }
             std::thread::yield_now();
         }
     }
@@ -551,11 +577,15 @@ unsafe fn clap_host_name(host: *const clap_host) -> Option<String> {
     )
 }
 
-struct LifecycleGuard<'a>(&'a AtomicBool);
+pub(crate) struct LifecycleGuard<'a> {
+    busy: &'a AtomicBool,
+    thread: &'a Mutex<Option<ThreadId>>,
+}
 
 impl Drop for LifecycleGuard<'_> {
     fn drop(&mut self) {
-        self.0.store(false, Ordering::Release);
+        *self.thread.lock() = None;
+        self.busy.store(false, Ordering::Release);
     }
 }
 

--- a/crates/wrac_clap_adapter/src/abi/state_extension.rs
+++ b/crates/wrac_clap_adapter/src/abi/state_extension.rs
@@ -60,17 +60,25 @@ unsafe extern "C" fn state_load(plugin: *const clap_plugin, stream: *const clap_
             log::warn!("state.load: missing plugin instance");
             return false;
         };
+        if instance.is_in_realtime_callback() {
+            wrac_log::rtwarn!("state.load: rejected from realtime callback");
+            return false;
+        }
         let Some(bytes) = (unsafe { read_stream_to_end(stream, MAX_STATE_BYTES) }) else {
             log::warn!("state.load: failed to read state stream");
             return false;
         };
 
-        let Some(state_support) = instance.state.as_ref() else {
+        if instance.state.is_none() {
             log::debug!("state.load: plugin has no state support");
             return false;
         };
         let byte_len = bytes.len();
-        if let Err(error) = state_support.restore_state(State { bytes }) {
+        let Some(_guard) = instance.enter_lifecycle_blocking_or_reject_reentry() else {
+            log::warn!("state.load: rejected lifecycle re-entry");
+            return false;
+        };
+        if let Err(error) = instance.core.lock().restore_state(State { bytes }) {
             log::warn!("state.load: plugin restore_state failed: {error}");
             return false;
         }

--- a/crates/wrac_clap_adapter/src/abi/state_extension.rs
+++ b/crates/wrac_clap_adapter/src/abi/state_extension.rs
@@ -4,7 +4,6 @@ use clap_sys::stream::{clap_istream, clap_ostream};
 
 use super::PluginInstanceState;
 use super::ffi::{ffi_bool, read_stream_to_end, write_stream};
-use crate::State;
 
 pub(super) static STATE: clap_plugin_state = clap_plugin_state {
     save: Some(state_save),
@@ -69,7 +68,7 @@ unsafe extern "C" fn state_load(plugin: *const clap_plugin, stream: *const clap_
             return false;
         };
 
-        if instance.state.is_none() {
+        let Some(state_support) = instance.state.as_ref() else {
             log::debug!("state.load: plugin has no state support");
             return false;
         };
@@ -78,7 +77,7 @@ unsafe extern "C" fn state_load(plugin: *const clap_plugin, stream: *const clap_
             log::warn!("state.load: rejected lifecycle re-entry");
             return false;
         };
-        if let Err(error) = instance.core.lock().restore_state(State { bytes }) {
+        if let Err(error) = state_support.restore_state(crate::State { bytes }) {
             log::warn!("state.load: plugin restore_state failed: {error}");
             return false;
         }

--- a/crates/wrac_clap_adapter/src/api/core.rs
+++ b/crates/wrac_clap_adapter/src/api/core.rs
@@ -4,7 +4,7 @@ use crate::{
     ActiveProcessor, HostAudioPorts, HostGui, HostLifecycle, HostNotePorts, HostParams, HostState,
     HostTail, InactiveProcessor, PluginAudioPortsExtension, PluginConfigurableAudioPortsExtension,
     PluginGuiExtension, PluginLatencyExtension, PluginNotePortsExtension, PluginParamsQuery,
-    PluginRenderExtension, PluginResult, PluginStateExtension, PluginTailExtension,
+    PluginRenderExtension, PluginResult, PluginStateExtension, PluginTailExtension, State,
 };
 use wrac_host_context::HostContext;
 
@@ -87,6 +87,14 @@ pub trait PluginInstance: Send + 'static {
     /// Called from CLAP `plugin.on_main_thread`, usually after `HostLifecycle::request_callback`.
     /// `[main-thread]`
     fn on_main_thread(&mut self) {}
+
+    /// Restores plugin state through the serialized lifecycle lane.
+    ///
+    /// Called from CLAP `state.load`. `[control-thread]`
+    fn restore_state(&mut self, state: State) -> PluginResult<()> {
+        let _ = state;
+        Ok(())
+    }
 
     /// Returns the CLAP audio-ports extension during plugin instance creation.
     ///

--- a/crates/wrac_clap_adapter/src/api/core.rs
+++ b/crates/wrac_clap_adapter/src/api/core.rs
@@ -4,7 +4,7 @@ use crate::{
     ActiveProcessor, HostAudioPorts, HostGui, HostLifecycle, HostNotePorts, HostParams, HostState,
     HostTail, InactiveProcessor, PluginAudioPortsExtension, PluginConfigurableAudioPortsExtension,
     PluginGuiExtension, PluginLatencyExtension, PluginNotePortsExtension, PluginParamsQuery,
-    PluginRenderExtension, PluginResult, PluginStateExtension, PluginTailExtension, State,
+    PluginRenderExtension, PluginResult, PluginStateExtension, PluginTailExtension,
 };
 use wrac_host_context::HostContext;
 
@@ -87,14 +87,6 @@ pub trait PluginInstance: Send + 'static {
     /// Called from CLAP `plugin.on_main_thread`, usually after `HostLifecycle::request_callback`.
     /// `[main-thread]`
     fn on_main_thread(&mut self) {}
-
-    /// Restores plugin state through the serialized lifecycle lane.
-    ///
-    /// Called from CLAP `state.load`. `[control-thread]`
-    fn restore_state(&mut self, state: State) -> PluginResult<()> {
-        let _ = state;
-        Ok(())
-    }
 
     /// Returns the CLAP audio-ports extension during plugin instance creation.
     ///

--- a/crates/wrac_clap_adapter/src/api/extensions/configurable_audio_ports.rs
+++ b/crates/wrac_clap_adapter/src/api/extensions/configurable_audio_ports.rs
@@ -9,7 +9,7 @@ pub trait PluginConfigurableAudioPortsExtension: Send + Sync + 'static {
     fn can_apply_audio_port_configuration(&self, requests: &[AudioPortConfigRequest]) -> bool;
 
     /// Called from CLAP `configurable_audio_ports.apply_configuration`.
-    /// `[thread-safe & control-thread]`
+    /// `[control-thread]`
     ///
     /// The adapter rejects this while a processor or lifecycle callback is active.
     fn apply_audio_port_configuration(

--- a/crates/wrac_clap_adapter/src/api/extensions/state.rs
+++ b/crates/wrac_clap_adapter/src/api/extensions/state.rs
@@ -4,4 +4,7 @@ use crate::{PluginResult, State};
 pub trait PluginStateExtension: Send + Sync + 'static {
     /// Called from CLAP `state.save`. `[thread-safe & control-thread]`
     fn save_state(&self) -> PluginResult<State>;
+
+    /// Called from CLAP `state.load`. `[control-thread]`
+    fn restore_state(&self, state: State) -> PluginResult<()>;
 }

--- a/crates/wrac_clap_adapter/src/api/extensions/state.rs
+++ b/crates/wrac_clap_adapter/src/api/extensions/state.rs
@@ -4,7 +4,4 @@ use crate::{PluginResult, State};
 pub trait PluginStateExtension: Send + Sync + 'static {
     /// Called from CLAP `state.save`. `[thread-safe & control-thread]`
     fn save_state(&self) -> PluginResult<State>;
-
-    /// Called from CLAP `state.load`. `[thread-safe & control-thread]`
-    fn restore_state(&self, state: State) -> PluginResult<()>;
 }


### PR DESCRIPTION
## Summary
- Move state restore from PluginStateExtension to PluginInstance::restore_state
- Serialize state.load through the lifecycle lane
- Reject realtime callback restore and same-thread lifecycle re-entry while allowing active-state loads to wait

## Verification
- cargo xtask quality