### PR TITLE
Defer product construction to CLAP init

### DIFF
--- a/crates/wrac_clap_adapter/README.md
+++ b/crates/wrac_clap_adapter/README.md
@@ -43,6 +43,12 @@ This crate, on the other hand, also targets VST3/AU/AAX hosts via `clap-wrapper`
 
 Each trait is a thin Rust representation of the corresponding CLAP C ABI. This crate is not designed as a general plugin framework.
 
+## Instance lifecycle
+
+`clap.plugin-factory.create_plugin` creates only the CLAP ABI shell. Product instance construction is deferred until `plugin.init`, where CLAP and clap-wrapper make host extensions available. Capability objects such as ports, parameters, state, GUI, latency, and tail are frozen during `plugin.init` so later host callbacks can answer without taking the product lifecycle lock.
+
+Calls that arrive before initialization do not wait for initialization to complete. They fail fast, return `null`/`false`/`0`, or no-op depending on the CLAP callback shape. This keeps wrapper construction paths from deadlocking if a native VST3/AU/AAX host re-enters the wrapper while its native object is still being built. Teardown callbacks are the exception: `deactivate` and `destroy` wait for in-flight processing access to finish so the adapter can reclaim processors before the host releases the instance.
+
 ## Limitations
 
 This crate is provided as part of an implementation example, not as a general-purpose framework. Future changes will not provide API backwards compatibility or migration support.

--- a/crates/wrac_clap_adapter/README.md
+++ b/crates/wrac_clap_adapter/README.md
@@ -45,9 +45,9 @@ Each trait is a thin Rust representation of the corresponding CLAP C ABI. This c
 
 ## Instance lifecycle
 
-`clap.plugin-factory.create_plugin` creates only the CLAP ABI shell. Product instance construction is deferred until `plugin.init`, where CLAP and clap-wrapper make host extensions available. Capability objects such as ports, parameters, state, GUI, latency, and tail are frozen during `plugin.init` so later host callbacks can answer without taking the product lifecycle lock.
+`clap.plugin-factory.create_plugin` creates only the CLAP ABI shell. Product instance construction is deferred until `plugin.init`, where CLAP and clap-wrapper initialize the plugin-facing lifecycle. Capability objects such as ports, parameters, state, GUI, latency, and tail are frozen during `plugin.init` so later host callbacks can answer without taking the product lifecycle lock.
 
-Calls that arrive before initialization do not wait for initialization to complete. They fail fast, return `null`/`false`/`0`, or no-op depending on the CLAP callback shape. This keeps wrapper construction paths from deadlocking if a native VST3/AU/AAX host re-enters the wrapper while its native object is still being built. Teardown callbacks are the exception: `deactivate` and `destroy` wait for in-flight processing access to finish so the adapter can reclaim processors before the host releases the instance.
+Calls that arrive before capability freeze do not wait for initialization to complete. They fail fast, return `null`/`false`/`0`, or no-op depending on the CLAP callback shape. Product-held host extension proxies also remain inert until capability freeze is complete, preventing init-time host callbacks from observing half-initialized plugin capabilities. Teardown callbacks are the exception: `deactivate` and `destroy` wait for in-flight processing access to finish so the adapter can reclaim processors before the host releases the instance.
 
 ## Limitations
 

--- a/crates/wrac_clap_adapter/src/abi.rs
+++ b/crates/wrac_clap_adapter/src/abi.rs
@@ -219,7 +219,10 @@ impl PluginInstanceState {
             host,
             host_extensions_initialized.clone(),
         ));
-        let host_lifecycle = Arc::new(HostLifecycleProxy::new(host));
+        let host_lifecycle = Arc::new(HostLifecycleProxy::new(
+            host,
+            host_extensions_initialized.clone(),
+        ));
         let host_gui = Arc::new(HostGuiProxy::new(host, host_extensions_initialized.clone()));
         let storage = registration.storage();
 
@@ -1322,6 +1325,7 @@ mod tests {
         factory: TestFactory {
             activate_latency_changed: false,
             request_host_lifecycle: false,
+            request_host_lifecycle_during_create: false,
             request_host_ports: false,
             request_host_ports_during_create: false,
             count_create_plugin: false,
@@ -1334,6 +1338,7 @@ mod tests {
         factory: TestFactory {
             activate_latency_changed: true,
             request_host_lifecycle: false,
+            request_host_lifecycle_during_create: false,
             request_host_ports: false,
             request_host_ports_during_create: false,
             count_create_plugin: false,
@@ -1346,6 +1351,7 @@ mod tests {
         factory: TestFactory {
             activate_latency_changed: false,
             request_host_lifecycle: true,
+            request_host_lifecycle_during_create: false,
             request_host_ports: false,
             request_host_ports_during_create: false,
             count_create_plugin: false,
@@ -1355,6 +1361,7 @@ mod tests {
         factory: TestFactory {
             activate_latency_changed: false,
             request_host_lifecycle: false,
+            request_host_lifecycle_during_create: false,
             request_host_ports: true,
             request_host_ports_during_create: false,
             count_create_plugin: false,
@@ -1364,6 +1371,7 @@ mod tests {
         factory: TestFactory {
             activate_latency_changed: false,
             request_host_lifecycle: false,
+            request_host_lifecycle_during_create: true,
             request_host_ports: false,
             request_host_ports_during_create: true,
             count_create_plugin: false,
@@ -1373,6 +1381,7 @@ mod tests {
         factory: TestFactory {
             activate_latency_changed: false,
             request_host_lifecycle: false,
+            request_host_lifecycle_during_create: false,
             request_host_ports: false,
             request_host_ports_during_create: false,
             count_create_plugin: true,
@@ -1527,13 +1536,16 @@ mod tests {
         AUDIO_PORTS_RESCAN_COUNT.store(0, Ordering::Relaxed);
         NOTE_PORTS_SUPPORTED_DIALECTS_COUNT.store(0, Ordering::Relaxed);
         NOTE_PORTS_RESCAN_COUNT.store(0, Ordering::Relaxed);
-        let host_get_extension_count = AtomicU32::new(0);
-        let host = test_host_with_get_extension_count(&host_get_extension_count);
+        let host_counts = HostCallbackCounts::default();
+        let host = test_host_with_callback_counts(&host_counts);
         let instance = test_instance(&REQUEST_HOST_PORTS_DURING_CREATE_REGISTRATION, &host);
 
         assert!(unsafe { plugin_init(&instance.plugin as *const clap_plugin) });
 
-        assert_eq!(host_get_extension_count.load(Ordering::Relaxed), 0);
+        assert_eq!(host_counts.request_restart.load(Ordering::Relaxed), 0);
+        assert_eq!(host_counts.request_process.load(Ordering::Relaxed), 0);
+        assert_eq!(host_counts.request_callback.load(Ordering::Relaxed), 0);
+        assert_eq!(host_counts.get_extension.load(Ordering::Relaxed), 0);
         assert_eq!(
             AUDIO_PORTS_IS_RESCAN_FLAG_SUPPORTED_COUNT.load(Ordering::Relaxed),
             0
@@ -1570,6 +1582,29 @@ mod tests {
 
     fn test_host_with_get_extension_count(count: &AtomicU32) -> clap_host {
         test_host_with_data((count as *const AtomicU32).cast_mut().cast())
+    }
+
+    #[derive(Default)]
+    struct HostCallbackCounts {
+        get_extension: AtomicU32,
+        request_restart: AtomicU32,
+        request_process: AtomicU32,
+        request_callback: AtomicU32,
+    }
+
+    fn test_host_with_callback_counts(counts: &HostCallbackCounts) -> clap_host {
+        clap_host {
+            clap_version: CLAP_VERSION,
+            host_data: (counts as *const HostCallbackCounts).cast_mut().cast(),
+            name: c"Test Host".as_ptr(),
+            vendor: c"Test Vendor".as_ptr(),
+            url: c"https://example.invalid".as_ptr(),
+            version: c"0.0.0".as_ptr(),
+            get_extension: Some(test_host_get_extension_with_callback_counts),
+            request_restart: Some(test_host_request_restart_with_callback_counts),
+            request_process: Some(test_host_request_process_with_callback_counts),
+            request_callback: Some(test_host_request_callback_with_callback_counts),
+        }
     }
 
     fn test_host_with_data(host_data: *mut std::ffi::c_void) -> clap_host {
@@ -1612,6 +1647,19 @@ mod tests {
         }
     }
 
+    unsafe extern "C" fn test_host_get_extension_with_callback_counts(
+        host: *const clap_host,
+        extension_id: *const std::ffi::c_char,
+    ) -> *const std::ffi::c_void {
+        if let Some(counts) = unsafe {
+            host.as_ref()
+                .and_then(|host| host.host_data.cast::<HostCallbackCounts>().as_ref())
+        } {
+            counts.get_extension.fetch_add(1, Ordering::Relaxed);
+        }
+        unsafe { test_host_get_extension(ptr::null(), extension_id) }
+    }
+
     unsafe extern "C" fn test_host_latency_changed(_host: *const clap_host) {
         LATENCY_CHANGED_COUNT.fetch_add(1, Ordering::Relaxed);
     }
@@ -1626,6 +1674,33 @@ mod tests {
 
     unsafe extern "C" fn test_host_request_callback(_host: *const clap_host) {
         REQUEST_CALLBACK_COUNT.fetch_add(1, Ordering::Relaxed);
+    }
+
+    unsafe extern "C" fn test_host_request_restart_with_callback_counts(host: *const clap_host) {
+        if let Some(counts) = unsafe {
+            host.as_ref()
+                .and_then(|host| host.host_data.cast::<HostCallbackCounts>().as_ref())
+        } {
+            counts.request_restart.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    unsafe extern "C" fn test_host_request_process_with_callback_counts(host: *const clap_host) {
+        if let Some(counts) = unsafe {
+            host.as_ref()
+                .and_then(|host| host.host_data.cast::<HostCallbackCounts>().as_ref())
+        } {
+            counts.request_process.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    unsafe extern "C" fn test_host_request_callback_with_callback_counts(host: *const clap_host) {
+        if let Some(counts) = unsafe {
+            host.as_ref()
+                .and_then(|host| host.host_data.cast::<HostCallbackCounts>().as_ref())
+        } {
+            counts.request_callback.fetch_add(1, Ordering::Relaxed);
+        }
     }
 
     static TEST_HOST_LATENCY: clap_host_latency = clap_host_latency {
@@ -1696,6 +1771,7 @@ mod tests {
     struct TestFactory {
         activate_latency_changed: bool,
         request_host_lifecycle: bool,
+        request_host_lifecycle_during_create: bool,
         request_host_ports: bool,
         request_host_ports_during_create: bool,
         count_create_plugin: bool,
@@ -1717,6 +1793,11 @@ mod tests {
         ) -> Option<Box<dyn PluginInstance>> {
             if self.count_create_plugin {
                 CREATE_PLUGIN_COUNT.fetch_add(1, Ordering::Relaxed);
+            }
+            if self.request_host_lifecycle_during_create {
+                context.host_lifecycle.request_restart();
+                context.host_lifecycle.request_process();
+                context.host_lifecycle.request_callback();
             }
             if self.request_host_ports_during_create {
                 assert!(

--- a/crates/wrac_clap_adapter/src/abi.rs
+++ b/crates/wrac_clap_adapter/src/abi.rs
@@ -129,8 +129,10 @@ pub(crate) struct PluginInstanceState {
     host_latency: HostLatencyProxy,
     host_tail: HostTailFactory,
     // Host extension proxies are passed to product code before the product instance exists.
-    // Keep them inert until `plugin.init` starts, where CLAP and clap-wrapper both make host
-    // extensions available. Calls made earlier are rejected/no-op rather than waiting.
+    // Keep extension lookups inert until capability freeze completes. CLAP permits
+    // `get_extension` during `plugin.init`; allowing product constructors to trigger host
+    // extension callbacks earlier could make a re-entrant host cache half-initialized plugin
+    // capabilities.
     host_extensions_initialized: Arc<AtomicBool>,
     host_context: HostContext,
     // Re-entry guard for GUI mutation callbacks. Fails immediately on re-entry to avoid
@@ -847,15 +849,6 @@ unsafe extern "C" fn plugin_init(plugin: *const clap_plugin) -> bool {
             log::warn!("plugin.init: plugin instance is already initialized");
             return false;
         }
-        // Product construction happens inside `plugin.init` so constructors may receive
-        // host proxies only after clap-wrapper has entered the CLAP initialization phase.
-        // The proxies still avoid blocking: if a backend cannot serve an init-time host
-        // callback, the call resolves as unavailable instead of waiting for initialization
-        // to complete.
-        instance
-            .host_extensions_initialized
-            .store(true, Ordering::Release);
-
         let context = PluginInstanceContext {
             host_params: instance.host_params.clone(),
             host_state: instance.host_state.clone(),
@@ -872,9 +865,6 @@ unsafe extern "C" fn plugin_init(plugin: *const clap_plugin) -> bool {
             .and_then(|factory| factory.create_plugin(&instance.plugin_id, context))
         else {
             log::warn!("plugin.init: product factory returned no plugin core");
-            instance
-                .host_extensions_initialized
-                .store(false, Ordering::Release);
             return false;
         };
         // Product construction initializes logging. Emit immediately afterward so
@@ -897,9 +887,6 @@ unsafe extern "C" fn plugin_init(plugin: *const clap_plugin) -> bool {
             Ok(processor) => processor,
             Err(error) => {
                 log::warn!("plugin.init: inactive processor creation failed: {error}");
-                instance
-                    .host_extensions_initialized
-                    .store(false, Ordering::Release);
                 return false;
             }
         };
@@ -941,13 +928,16 @@ unsafe extern "C" fn plugin_init(plugin: *const clap_plugin) -> bool {
         };
         if instance.runtime.set(runtime).is_err() {
             log::warn!("plugin.init: runtime was already initialized");
-            instance
-                .host_extensions_initialized
-                .store(false, Ordering::Release);
             return false;
         }
         instance.put_inactive_processor_blocking(inactive_processor);
         *instance.core.lock() = Some(core);
+        // Product-held host extension proxies become live only after plugin capabilities are
+        // frozen. This keeps legal init-time `get_extension` re-entry from observing a
+        // partially initialized runtime.
+        instance
+            .host_extensions_initialized
+            .store(true, Ordering::Release);
         true
     })
 }
@@ -1333,6 +1323,7 @@ mod tests {
             activate_latency_changed: false,
             request_host_lifecycle: false,
             request_host_ports: false,
+            request_host_ports_during_create: false,
             count_create_plugin: false,
         },
     };
@@ -1344,6 +1335,7 @@ mod tests {
             activate_latency_changed: true,
             request_host_lifecycle: false,
             request_host_ports: false,
+            request_host_ports_during_create: false,
             count_create_plugin: false,
         },
     };
@@ -1355,6 +1347,7 @@ mod tests {
             activate_latency_changed: false,
             request_host_lifecycle: true,
             request_host_ports: false,
+            request_host_ports_during_create: false,
             count_create_plugin: false,
         },
     };
@@ -1363,6 +1356,16 @@ mod tests {
             activate_latency_changed: false,
             request_host_lifecycle: false,
             request_host_ports: true,
+            request_host_ports_during_create: false,
+            count_create_plugin: false,
+        },
+    };
+    static REQUEST_HOST_PORTS_DURING_CREATE_ENTRY: TestEntry = TestEntry {
+        factory: TestFactory {
+            activate_latency_changed: false,
+            request_host_lifecycle: false,
+            request_host_ports: false,
+            request_host_ports_during_create: true,
             count_create_plugin: false,
         },
     };
@@ -1371,6 +1374,7 @@ mod tests {
             activate_latency_changed: false,
             request_host_lifecycle: false,
             request_host_ports: false,
+            request_host_ports_during_create: false,
             count_create_plugin: true,
         },
     };
@@ -1378,6 +1382,8 @@ mod tests {
         EntryRegistration::new(&REQUEST_HOST_LIFECYCLE_ENTRY);
     static REQUEST_HOST_PORTS_REGISTRATION: EntryRegistration =
         EntryRegistration::new(&REQUEST_HOST_PORTS_ENTRY);
+    static REQUEST_HOST_PORTS_DURING_CREATE_REGISTRATION: EntryRegistration =
+        EntryRegistration::new(&REQUEST_HOST_PORTS_DURING_CREATE_ENTRY);
     static DEFER_CREATE_REGISTRATION: EntryRegistration =
         EntryRegistration::new(&DEFER_CREATE_ENTRY);
 
@@ -1513,6 +1519,31 @@ mod tests {
             1
         );
         assert_eq!(NOTE_PORTS_RESCAN_COUNT.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn product_construction_keeps_host_extension_proxies_inert() {
+        AUDIO_PORTS_IS_RESCAN_FLAG_SUPPORTED_COUNT.store(0, Ordering::Relaxed);
+        AUDIO_PORTS_RESCAN_COUNT.store(0, Ordering::Relaxed);
+        NOTE_PORTS_SUPPORTED_DIALECTS_COUNT.store(0, Ordering::Relaxed);
+        NOTE_PORTS_RESCAN_COUNT.store(0, Ordering::Relaxed);
+        let host_get_extension_count = AtomicU32::new(0);
+        let host = test_host_with_get_extension_count(&host_get_extension_count);
+        let instance = test_instance(&REQUEST_HOST_PORTS_DURING_CREATE_REGISTRATION, &host);
+
+        assert!(unsafe { plugin_init(&instance.plugin as *const clap_plugin) });
+
+        assert_eq!(host_get_extension_count.load(Ordering::Relaxed), 0);
+        assert_eq!(
+            AUDIO_PORTS_IS_RESCAN_FLAG_SUPPORTED_COUNT.load(Ordering::Relaxed),
+            0
+        );
+        assert_eq!(AUDIO_PORTS_RESCAN_COUNT.load(Ordering::Relaxed), 0);
+        assert_eq!(
+            NOTE_PORTS_SUPPORTED_DIALECTS_COUNT.load(Ordering::Relaxed),
+            0
+        );
+        assert_eq!(NOTE_PORTS_RESCAN_COUNT.load(Ordering::Relaxed), 0);
     }
 
     fn test_instance(
@@ -1666,6 +1697,7 @@ mod tests {
         activate_latency_changed: bool,
         request_host_lifecycle: bool,
         request_host_ports: bool,
+        request_host_ports_during_create: bool,
         count_create_plugin: bool,
     }
 
@@ -1685,6 +1717,21 @@ mod tests {
         ) -> Option<Box<dyn PluginInstance>> {
             if self.count_create_plugin {
                 CREATE_PLUGIN_COUNT.fetch_add(1, Ordering::Relaxed);
+            }
+            if self.request_host_ports_during_create {
+                assert!(
+                    !context
+                        .host_audio_ports
+                        .is_rescan_flag_supported(CLAP_AUDIO_PORTS_RESCAN_NAMES)
+                );
+                context
+                    .host_audio_ports
+                    .rescan(CLAP_AUDIO_PORTS_RESCAN_NAMES);
+                assert_eq!(
+                    context.host_note_ports.supported_dialects(),
+                    NoteDialects::default()
+                );
+                context.host_note_ports.rescan(CLAP_NOTE_PORTS_RESCAN_NAMES);
             }
             (plugin_id == TEST_DESCRIPTOR.id).then(|| {
                 Box::new(TestPlugin {

--- a/crates/wrac_clap_adapter/src/abi.rs
+++ b/crates/wrac_clap_adapter/src/abi.rs
@@ -6,8 +6,8 @@
 use std::cell::UnsafeCell;
 use std::ffi::{CStr, c_char, c_void};
 use std::ptr;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::{Arc, OnceLock};
 use std::thread::ThreadId;
 
 use clap_sys::ext::audio_ports::CLAP_EXT_AUDIO_PORTS;
@@ -107,28 +107,30 @@ impl Drop for RtDepthGuard<'_> {
 /// Key design: separate the "lifecycle lock" from "capabilities read directly by
 /// host-facing callbacks". The `core` lock is used only by `activate`/`deactivate`,
 /// which move processor ownership. Parameter/state/port queries read `Arc`s frozen at
-/// instance creation. Without this separation, a wrapper that re-enters a query during
+/// plugin initialization. Without this separation, a wrapper that re-enters a query during
 /// `activate()` would fail to acquire the core lock and return "no parameters" or "state
 /// save failed" to the host — no crash, but project data and routing can be corrupted.
+///
+/// Lifecycle callbacks that create runtime state fail fast on re-entry instead of waiting.
+/// Waiting from pre-init or init-time host callbacks can deadlock with wrapper formats whose
+/// native object is still being constructed. Teardown is the exception: `deactivate` and
+/// `destroy` wait so they can finish reclaiming processors before the host releases the object.
 pub(crate) struct PluginInstanceState {
     plugin: clap_plugin,
     registration: &'static EntryRegistration,
-    // Owner of the processor lifecycle; only activate/deactivate take this lock.
-    core: Mutex<Box<dyn PluginInstance>>,
-    // Capability presence is frozen at instance creation. Coupling it to runtime state
-    // would make extensions appear to disappear transiently during queries.
-    capabilities: PluginCapabilities,
-    audio_ports: Option<Arc<dyn PluginAudioPortsExtension>>,
-    configurable_audio_ports: Option<Arc<dyn PluginConfigurableAudioPortsExtension>>,
-    note_ports: Option<Arc<dyn PluginNotePortsExtension>>,
-    parameters: Arc<dyn PluginParamsQuery>,
-    state: Option<Arc<dyn PluginStateExtension>>,
-    gui: Option<Arc<dyn PluginGuiExtension>>,
-    render: Option<Arc<dyn PluginRenderExtension>>,
-    tail: Option<Arc<dyn PluginTailExtension>>,
-    latency: Option<Arc<dyn PluginLatencyExtension>>,
+    plugin_id: String,
+    clap_host_name: Option<String>,
+    // Owner of the product instance lifecycle. It is intentionally empty until
+    // `plugin.init`, because CLAP forbids host extension access before that callback.
+    core: Mutex<Option<Box<dyn PluginInstance>>>,
+    // Capability presence is frozen during `plugin.init`, before host callbacks may query
+    // extensions. Coupling it to later runtime state would make extensions appear transient.
+    runtime: OnceLock<PluginRuntime>,
     host_latency: HostLatencyProxy,
     host_tail: HostTailFactory,
+    // Host extension proxies are passed to product code before the product instance exists.
+    // Keep them inert until `plugin.init` starts, where CLAP and clap-wrapper both make host
+    // extensions available. Calls made earlier are rejected/no-op rather than waiting.
     host_extensions_initialized: Arc<AtomicBool>,
     host_context: HostContext,
     // Re-entry guard for GUI mutation callbacks. Fails immediately on re-entry to avoid
@@ -139,6 +141,11 @@ pub(crate) struct PluginInstanceState {
     // that move between host threads within one GUI session.
     gui_lifecycle_thread: Mutex<Option<ThreadId>>,
     host_params: Arc<HostParamsProxy>,
+    host_state: Arc<HostStateProxy>,
+    host_audio_ports: Arc<HostAudioPortsProxy>,
+    host_note_ports: Arc<HostNotePortsProxy>,
+    host_lifecycle: Arc<HostLifecycleProxy>,
+    host_gui: Arc<HostGuiProxy>,
     // To preserve soundness even when a wrapper violates thread/lifecycle annotations,
     // the RT path never takes a lock — only a callback that wins the atomic guard
     // constructs a `&mut` to the active or inactive processor.
@@ -165,6 +172,19 @@ pub(crate) struct PluginCapabilities {
     latency: bool,
 }
 
+struct PluginRuntime {
+    capabilities: PluginCapabilities,
+    audio_ports: Option<Arc<dyn PluginAudioPortsExtension>>,
+    configurable_audio_ports: Option<Arc<dyn PluginConfigurableAudioPortsExtension>>,
+    note_ports: Option<Arc<dyn PluginNotePortsExtension>>,
+    parameters: Arc<dyn PluginParamsQuery>,
+    state: Option<Arc<dyn PluginStateExtension>>,
+    gui: Option<Arc<dyn PluginGuiExtension>>,
+    render: Option<Arc<dyn PluginRenderExtension>>,
+    tail: Option<Arc<dyn PluginTailExtension>>,
+    latency: Option<Arc<dyn PluginLatencyExtension>>,
+}
+
 // Safety: CLAP shares the same opaque plugin pointer across callbacks. Adapter state is
 // shared via locks and atomics, so Rust aliasing rules are never violated even when the
 // host's thread annotations or callback ordering breaks down.
@@ -185,77 +205,20 @@ impl PluginInstanceState {
             host,
             host_extensions_initialized.clone(),
         ));
-        // Pass as a safe proxy so product GUI code can hold it without knowing about
-        // host pointers or CLAP event lifetimes.
-        let context = PluginInstanceContext {
-            host_params: host_params.clone(),
-            host_state: Arc::new(HostStateProxy::new(
-                host,
-                host_extensions_initialized.clone(),
-            )),
-            host_audio_ports: Arc::new(HostAudioPortsProxy::new(
-                host,
-                host_extensions_initialized.clone(),
-            )),
-            host_note_ports: Arc::new(HostNotePortsProxy::new(
-                host,
-                host_extensions_initialized.clone(),
-            )),
-            host_lifecycle: Arc::new(HostLifecycleProxy::new(host)),
-            host_gui: Arc::new(HostGuiProxy::new(host, host_extensions_initialized.clone())),
-            host_context: host_context.clone(),
-        };
-        let mut core = registration
-            .entry
-            .plugin_factory()?
-            .create_plugin(plugin_id, context)?;
-        // Product construction initializes logging. Emit immediately afterward so
-        // wrapper/host routing is visible before capability queries or GUI attachment.
-        log::info!(
-            "factory.create_plugin: host_context host=\"{}\" process=\"{}\" format={} clap_host_name=\"{}\"",
-            host_context.host.display_name,
-            host_context.host.process_name,
-            host_context.plugin_format.as_str(),
-            clap_host_name.as_deref().unwrap_or("")
-        );
-        // Freeze capabilities here, before callbacks begin. Waiting on the core lock
-        // inside get_extension would make us dependent on host re-entry order. The Arc
-        // is just an entry point; the source of truth remains in the plugin's store.
-        let audio_ports = core.audio_ports();
-        let configurable_audio_ports = core.configurable_audio_ports();
-        let note_ports = core.note_ports();
-        let parameters = core.params();
-        let inactive_processor = match core.initialize_processor() {
-            Ok(processor) => processor,
-            Err(error) => {
-                log::warn!("factory.create_plugin: inactive processor creation failed: {error}");
-                return None;
-            }
-        };
-        let state = core.state();
-        let gui = core.gui();
-        let render = core.render();
-        let tail = core.tail();
-        let latency = core.latency();
-        debug_assert!(
-            latency.is_some(),
-            "plugins should provide a latency extension because wrapper builds, especially AAX, expect it during activation; return zero latency when no delay is required"
-        );
-        if cfg!(not(debug_assertions)) && latency.is_none() {
-            log::warn!(
-                "factory.create_plugin: plugin has no latency extension; exposing zero-latency wrapper fallback"
-            );
-        }
-        let capabilities = PluginCapabilities {
-            audio_ports: audio_ports.is_some(),
-            configurable_audio_ports: configurable_audio_ports.is_some(),
-            note_ports: note_ports.is_some(),
-            state: state.is_some(),
-            gui: gui.is_some(),
-            render: render.is_some(),
-            tail: tail.is_some(),
-            latency: latency.is_some(),
-        };
+        let host_state = Arc::new(HostStateProxy::new(
+            host,
+            host_extensions_initialized.clone(),
+        ));
+        let host_audio_ports = Arc::new(HostAudioPortsProxy::new(
+            host,
+            host_extensions_initialized.clone(),
+        ));
+        let host_note_ports = Arc::new(HostNotePortsProxy::new(
+            host,
+            host_extensions_initialized.clone(),
+        ));
+        let host_lifecycle = Arc::new(HostLifecycleProxy::new(host));
+        let host_gui = Arc::new(HostGuiProxy::new(host, host_extensions_initialized.clone()));
         let storage = registration.storage();
 
         Some(Box::new(Self {
@@ -274,17 +237,10 @@ impl PluginInstanceState {
                 on_main_thread: Some(plugin_on_main_thread),
             },
             registration,
-            core: Mutex::new(core),
-            capabilities,
-            audio_ports,
-            configurable_audio_ports,
-            note_ports,
-            parameters,
-            state,
-            gui,
-            render,
-            tail,
-            latency,
+            plugin_id: plugin_id.to_string(),
+            clap_host_name,
+            core: Mutex::new(None),
+            runtime: OnceLock::new(),
             host_latency: HostLatencyProxy::new(host, host_extensions_initialized.clone()),
             host_tail: HostTailFactory::new(host, host_extensions_initialized.clone()),
             host_extensions_initialized,
@@ -292,7 +248,12 @@ impl PluginInstanceState {
             gui_callback_busy: Mutex::new(()),
             gui_lifecycle_thread: Mutex::new(None),
             host_params,
-            inactive_processor: UnsafeCell::new(Some(inactive_processor)),
+            host_state,
+            host_audio_ports,
+            host_note_ports,
+            host_lifecycle,
+            host_gui,
+            inactive_processor: UnsafeCell::new(None),
             processor: UnsafeCell::new(None),
             processor_busy: AtomicBool::new(false),
             processor_active: AtomicBool::new(false),
@@ -861,7 +822,7 @@ pub(crate) unsafe extern "C" fn factory_create_plugin(
             if attach_in_adapter {
                 registration.entry.detach_main_thread();
             }
-            log::warn!("factory.create_plugin: product factory returned no plugin core");
+            log::warn!("factory.create_plugin: failed to allocate plugin instance state");
             return ptr::null();
         };
         let instance_ptr = (&mut *instance) as *mut PluginInstanceState;
@@ -878,9 +839,115 @@ unsafe extern "C" fn plugin_init(plugin: *const clap_plugin) -> bool {
             log::warn!("plugin.init: missing plugin instance");
             return false;
         };
+        let Some(_guard) = instance.try_enter_lifecycle() else {
+            log::warn!("plugin.init: lifecycle is busy");
+            return false;
+        };
+        if instance.runtime.get().is_some() || instance.core.lock().is_some() {
+            log::warn!("plugin.init: plugin instance is already initialized");
+            return false;
+        }
+        // Product construction happens inside `plugin.init` so constructors may receive
+        // host proxies only after clap-wrapper has entered the CLAP initialization phase.
+        // The proxies still avoid blocking: if a backend cannot serve an init-time host
+        // callback, the call resolves as unavailable instead of waiting for initialization
+        // to complete.
         instance
             .host_extensions_initialized
             .store(true, Ordering::Release);
+
+        let context = PluginInstanceContext {
+            host_params: instance.host_params.clone(),
+            host_state: instance.host_state.clone(),
+            host_audio_ports: instance.host_audio_ports.clone(),
+            host_note_ports: instance.host_note_ports.clone(),
+            host_lifecycle: instance.host_lifecycle.clone(),
+            host_gui: instance.host_gui.clone(),
+            host_context: instance.host_context.clone(),
+        };
+        let Some(mut core) = instance
+            .registration
+            .entry
+            .plugin_factory()
+            .and_then(|factory| factory.create_plugin(&instance.plugin_id, context))
+        else {
+            log::warn!("plugin.init: product factory returned no plugin core");
+            instance
+                .host_extensions_initialized
+                .store(false, Ordering::Release);
+            return false;
+        };
+        // Product construction initializes logging. Emit immediately afterward so
+        // wrapper/host routing is visible before capability queries or GUI attachment.
+        log::info!(
+            "plugin.init: host_context host=\"{}\" process=\"{}\" format={} clap_host_name=\"{}\"",
+            instance.host_context.host.display_name,
+            instance.host_context.host.process_name,
+            instance.host_context.plugin_format.as_str(),
+            instance.clap_host_name.as_deref().unwrap_or("")
+        );
+
+        // Freeze capabilities during CLAP init. Host extension queries are allowed from this
+        // point onward, and later get_extension callbacks can answer without taking the core lock.
+        let audio_ports = core.audio_ports();
+        let configurable_audio_ports = core.configurable_audio_ports();
+        let note_ports = core.note_ports();
+        let parameters = core.params();
+        let inactive_processor = match core.initialize_processor() {
+            Ok(processor) => processor,
+            Err(error) => {
+                log::warn!("plugin.init: inactive processor creation failed: {error}");
+                instance
+                    .host_extensions_initialized
+                    .store(false, Ordering::Release);
+                return false;
+            }
+        };
+        let state = core.state();
+        let gui = core.gui();
+        let render = core.render();
+        let tail = core.tail();
+        let latency = core.latency();
+        debug_assert!(
+            latency.is_some(),
+            "plugins should provide a latency extension because wrapper builds, especially AAX, expect it during activation; return zero latency when no delay is required"
+        );
+        if cfg!(not(debug_assertions)) && latency.is_none() {
+            log::warn!(
+                "plugin.init: plugin has no latency extension; exposing zero-latency wrapper fallback"
+            );
+        }
+        let capabilities = PluginCapabilities {
+            audio_ports: audio_ports.is_some(),
+            configurable_audio_ports: configurable_audio_ports.is_some(),
+            note_ports: note_ports.is_some(),
+            state: state.is_some(),
+            gui: gui.is_some(),
+            render: render.is_some(),
+            tail: tail.is_some(),
+            latency: latency.is_some(),
+        };
+        let runtime = PluginRuntime {
+            capabilities,
+            audio_ports,
+            configurable_audio_ports,
+            note_ports,
+            parameters,
+            state,
+            gui,
+            render,
+            tail,
+            latency,
+        };
+        if instance.runtime.set(runtime).is_err() {
+            log::warn!("plugin.init: runtime was already initialized");
+            instance
+                .host_extensions_initialized
+                .store(false, Ordering::Release);
+            return false;
+        }
+        instance.put_inactive_processor_blocking(inactive_processor);
+        *instance.core.lock() = Some(core);
         true
     })
 }
@@ -898,7 +965,11 @@ unsafe extern "C" fn plugin_destroy(plugin: *const clap_plugin) {
             .host_extensions_initialized
             .store(false, Ordering::Release);
 
-        if let Some(gui) = &instance.gui {
+        if let Some(gui) = instance
+            .runtime
+            .get()
+            .and_then(|runtime| runtime.gui.clone())
+        {
             if let Some(_gui_callback) = instance.gui_callback_busy.try_lock() {
                 if instance.enter_gui_lifecycle_thread("destroy") {
                     gui.main_thread().destroy();
@@ -912,15 +983,28 @@ unsafe extern "C" fn plugin_destroy(plugin: *const clap_plugin) {
         }
 
         if let Some(processor) = instance.take_processor_blocking() {
-            match instance.core.lock().deactivate(processor) {
-                Ok(inactive) => drop(inactive),
-                Err(error) => log::warn!("plugin.destroy: plugin deactivate failed: {error}"),
+            let mut core = instance.core.lock();
+            if let Some(core) = core.as_mut() {
+                match core.deactivate(processor) {
+                    Ok(inactive) => drop(inactive),
+                    Err(error) => log::warn!("plugin.destroy: plugin deactivate failed: {error}"),
+                }
+            } else {
+                log::warn!("plugin.destroy: plugin core is not initialized");
+                drop(processor);
             }
-        } else if let Some(inactive) = instance.take_inactive_processor_blocking() {
+        } else {
+            let inactive = if instance.runtime.get().is_some() {
+                instance.take_inactive_processor_blocking()
+            } else {
+                instance.try_take_inactive_processor().flatten()
+            };
             drop(inactive);
         }
 
-        instance.core.lock().destroy();
+        if let Some(core) = instance.core.lock().as_mut() {
+            core.destroy();
+        }
 
         drop(guard);
         let data = unsafe { (*plugin).plugin_data } as *mut PluginInstanceState;
@@ -952,6 +1036,10 @@ unsafe extern "C" fn plugin_activate(
             log::warn!("plugin.activate: processor already exists or audio callback is busy");
             return false;
         }
+        let Some(runtime) = instance.runtime.get() else {
+            log::warn!("plugin.activate: plugin instance is not initialized");
+            return false;
+        };
 
         let Some(inactive_processor) = instance.take_inactive_processor_blocking() else {
             log::warn!("plugin.activate: inactive processor is unavailable");
@@ -959,12 +1047,17 @@ unsafe extern "C" fn plugin_activate(
         };
 
         let mut core = instance.core.lock();
+        let Some(core) = core.as_mut() else {
+            log::warn!("plugin.activate: plugin core is not initialized");
+            drop(inactive_processor);
+            return false;
+        };
         let processor = match core.activate(
             ActivateContext {
                 sample_rate,
                 min_frames_count,
                 max_frames_count,
-                host_tail: instance
+                host_tail: runtime
                     .capabilities
                     .tail
                     .then(|| instance.host_tail.create_handle())
@@ -974,7 +1067,7 @@ unsafe extern "C" fn plugin_activate(
         ) {
             Ok(result) => {
                 if result.notifications.latency_changed {
-                    if instance.capabilities.latency {
+                    if runtime.capabilities.latency {
                         instance.host_latency.changed();
                     } else {
                         log::warn!(
@@ -1012,7 +1105,13 @@ unsafe extern "C" fn plugin_deactivate(plugin: *const clap_plugin) {
         // concurrently, wait here to avoid missing the teardown.
         let _guard = instance.enter_lifecycle_blocking();
         if let Some(processor) = instance.take_processor_blocking() {
-            match instance.core.lock().deactivate(processor) {
+            let mut core = instance.core.lock();
+            let Some(core) = core.as_mut() else {
+                log::warn!("plugin.deactivate: plugin core is not initialized");
+                drop(processor);
+                return;
+            };
+            match core.deactivate(processor) {
                 Ok(inactive) => instance.put_inactive_processor_blocking(inactive),
                 Err(error) => {
                     log::warn!("plugin.deactivate: plugin deactivate failed: {error}");
@@ -1139,24 +1238,30 @@ unsafe extern "C" fn plugin_get_extension(
             wrac_log::rtwarn!("plugin.get_extension: missing plugin instance");
             return ptr::null();
         };
-        if id == CLAP_EXT_AUDIO_PORTS && instance.capabilities.audio_ports {
+        let Some(runtime) = instance.runtime.get() else {
+            // Some wrapper backends may probe from native object construction paths. Returning
+            // null keeps those calls non-blocking and avoids exposing half-frozen capabilities.
+            wrac_log::rtwarn!("plugin.get_extension: plugin instance is not initialized");
+            return ptr::null();
+        };
+        if id == CLAP_EXT_AUDIO_PORTS && runtime.capabilities.audio_ports {
             &audio_ports::AUDIO_PORTS as *const _ as *const c_void
         } else if (id == CLAP_EXT_CONFIGURABLE_AUDIO_PORTS
             || id == CLAP_EXT_CONFIGURABLE_AUDIO_PORTS_COMPAT)
-            && instance.capabilities.configurable_audio_ports
+            && runtime.capabilities.configurable_audio_ports
         {
             &configurable_audio_ports::CONFIGURABLE_AUDIO_PORTS as *const _ as *const c_void
-        } else if id == CLAP_EXT_NOTE_PORTS && instance.capabilities.note_ports {
+        } else if id == CLAP_EXT_NOTE_PORTS && runtime.capabilities.note_ports {
             &note_ports::NOTE_PORTS as *const _ as *const c_void
         } else if id == CLAP_EXT_PARAMS {
             &params_extension::PARAMS as *const _ as *const c_void
-        } else if id == CLAP_EXT_STATE && instance.capabilities.state {
+        } else if id == CLAP_EXT_STATE && runtime.capabilities.state {
             &state_extension::STATE as *const _ as *const c_void
-        } else if id == CLAP_EXT_GUI && instance.capabilities.gui {
+        } else if id == CLAP_EXT_GUI && runtime.capabilities.gui {
             &gui_extension::GUI as *const _ as *const c_void
-        } else if id == CLAP_EXT_RENDER && instance.capabilities.render {
+        } else if id == CLAP_EXT_RENDER && runtime.capabilities.render {
             &render_extension::RENDER as *const _ as *const c_void
-        } else if id == CLAP_EXT_TAIL && instance.capabilities.tail {
+        } else if id == CLAP_EXT_TAIL && runtime.capabilities.tail {
             &tail_extension::TAIL as *const _ as *const c_void
         } else if id == CLAP_EXT_LATENCY {
             // Keep this pointer non-null even when `PluginInstance::latency()` returned
@@ -1164,7 +1269,7 @@ unsafe extern "C" fn plugin_get_extension(
             // unconditionally during activation, so exposing capability absence as a
             // null CLAP extension pointer can crash before WRAC code gets a chance to
             // diagnose the product bug. The product-facing contract is still enforced
-            // at instance creation by the debug assertion above; this fallback exists
+            // during plugin initialization by the debug assertion above; this fallback exists
             // only to keep release wrapper builds from failing at the ABI boundary.
             &latency_extension::LATENCY as *const _ as *const c_void
         } else if id == CLAP_PLUGIN_AS_VST3 {
@@ -1181,7 +1286,12 @@ unsafe extern "C" fn plugin_on_main_thread(plugin: *const clap_plugin) {
             log::warn!("plugin.on_main_thread: missing plugin instance");
             return;
         };
-        instance.core.lock().on_main_thread();
+        let mut core = instance.core.lock();
+        let Some(core) = core.as_mut() else {
+            log::warn!("plugin.on_main_thread: plugin core is not initialized");
+            return;
+        };
+        core.on_main_thread();
     });
 }
 
@@ -1223,6 +1333,7 @@ mod tests {
             activate_latency_changed: false,
             request_host_lifecycle: false,
             request_host_ports: false,
+            count_create_plugin: false,
         },
     };
     static ZERO_LATENCY_REGISTRATION: EntryRegistration =
@@ -1233,6 +1344,7 @@ mod tests {
             activate_latency_changed: true,
             request_host_lifecycle: false,
             request_host_ports: false,
+            count_create_plugin: false,
         },
     };
     static ACTIVATE_LATENCY_CHANGED_REGISTRATION: EntryRegistration =
@@ -1243,6 +1355,7 @@ mod tests {
             activate_latency_changed: false,
             request_host_lifecycle: true,
             request_host_ports: false,
+            count_create_plugin: false,
         },
     };
     static REQUEST_HOST_PORTS_ENTRY: TestEntry = TestEntry {
@@ -1250,12 +1363,23 @@ mod tests {
             activate_latency_changed: false,
             request_host_lifecycle: false,
             request_host_ports: true,
+            count_create_plugin: false,
+        },
+    };
+    static DEFER_CREATE_ENTRY: TestEntry = TestEntry {
+        factory: TestFactory {
+            activate_latency_changed: false,
+            request_host_lifecycle: false,
+            request_host_ports: false,
+            count_create_plugin: true,
         },
     };
     static REQUEST_HOST_LIFECYCLE_REGISTRATION: EntryRegistration =
         EntryRegistration::new(&REQUEST_HOST_LIFECYCLE_ENTRY);
     static REQUEST_HOST_PORTS_REGISTRATION: EntryRegistration =
         EntryRegistration::new(&REQUEST_HOST_PORTS_ENTRY);
+    static DEFER_CREATE_REGISTRATION: EntryRegistration =
+        EntryRegistration::new(&DEFER_CREATE_ENTRY);
 
     static LATENCY_CHANGED_COUNT: AtomicU32 = AtomicU32::new(0);
     static REQUEST_RESTART_COUNT: AtomicU32 = AtomicU32::new(0);
@@ -1267,10 +1391,12 @@ mod tests {
     static NOTE_PORTS_RESCAN_COUNT: AtomicU32 = AtomicU32::new(0);
     static ON_MAIN_THREAD_COUNT: AtomicU32 = AtomicU32::new(0);
     static DESTROY_COUNT: AtomicU32 = AtomicU32::new(0);
+    static CREATE_PLUGIN_COUNT: AtomicU32 = AtomicU32::new(0);
 
     #[test]
     fn zero_latency_exposes_latency_extension() {
         let instance = test_instance(&ZERO_LATENCY_REGISTRATION, ptr::null());
+        assert!(unsafe { plugin_init(&instance.plugin as *const clap_plugin) });
         let extension = unsafe {
             plugin_get_extension(
                 &instance.plugin as *const clap_plugin,
@@ -1325,6 +1451,7 @@ mod tests {
     fn plugin_on_main_thread_calls_instance_hook() {
         ON_MAIN_THREAD_COUNT.store(0, Ordering::Relaxed);
         let instance = test_instance(&ZERO_LATENCY_REGISTRATION, ptr::null());
+        assert!(unsafe { plugin_init(&instance.plugin as *const clap_plugin) });
 
         unsafe {
             plugin_on_main_thread(&instance.plugin as *const clap_plugin);
@@ -1337,6 +1464,7 @@ mod tests {
     fn plugin_destroy_calls_instance_hook() {
         DESTROY_COUNT.store(0, Ordering::Relaxed);
         let instance = test_instance(&ZERO_LATENCY_REGISTRATION, ptr::null());
+        assert!(unsafe { plugin_init(&instance.plugin as *const clap_plugin) });
         let plugin = &instance.plugin as *const clap_plugin;
         let _instance = Box::into_raw(instance);
 
@@ -1345,6 +1473,16 @@ mod tests {
         }
 
         assert_eq!(DESTROY_COUNT.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn factory_create_plugin_defers_product_construction_until_plugin_init() {
+        CREATE_PLUGIN_COUNT.store(0, Ordering::Relaxed);
+        let instance = test_instance(&DEFER_CREATE_REGISTRATION, ptr::null());
+
+        assert_eq!(CREATE_PLUGIN_COUNT.load(Ordering::Relaxed), 0);
+        assert!(unsafe { plugin_init(&instance.plugin as *const clap_plugin) });
+        assert_eq!(CREATE_PLUGIN_COUNT.load(Ordering::Relaxed), 1);
     }
 
     #[test]
@@ -1528,6 +1666,7 @@ mod tests {
         activate_latency_changed: bool,
         request_host_lifecycle: bool,
         request_host_ports: bool,
+        count_create_plugin: bool,
     }
 
     impl PluginFactory for TestFactory {
@@ -1544,6 +1683,9 @@ mod tests {
             plugin_id: &str,
             context: PluginInstanceContext,
         ) -> Option<Box<dyn PluginInstance>> {
+            if self.count_create_plugin {
+                CREATE_PLUGIN_COUNT.fetch_add(1, Ordering::Relaxed);
+            }
             (plugin_id == TEST_DESCRIPTOR.id).then(|| {
                 Box::new(TestPlugin {
                     activate_latency_changed: self.activate_latency_changed,

--- a/crates/wrac_clap_adapter/src/abi/audio_ports.rs
+++ b/crates/wrac_clap_adapter/src/abi/audio_ports.rs
@@ -23,7 +23,11 @@ unsafe extern "C" fn audio_ports_count(plugin: *const clap_plugin, is_input: boo
             wrac_log::rtwarn!("audio_ports.count: missing plugin instance is_input={is_input}");
             return 0;
         };
-        let Some(audio_ports) = instance.audio_ports.as_ref() else {
+        let Some(audio_ports) = instance
+            .runtime
+            .get()
+            .and_then(|runtime| runtime.audio_ports.as_ref())
+        else {
             wrac_log::rtwarn!("audio_ports.count: plugin has no audio ports is_input={is_input}");
             return 0;
         };
@@ -50,7 +54,11 @@ unsafe extern "C" fn audio_ports_get(
             );
             return false;
         };
-        let Some(audio_ports) = instance.audio_ports.as_ref() else {
+        let Some(audio_ports) = instance
+            .runtime
+            .get()
+            .and_then(|runtime| runtime.audio_ports.as_ref())
+        else {
             wrac_log::rtwarn!(
                 "audio_ports.get: plugin has no audio ports index={index} is_input={is_input}"
             );

--- a/crates/wrac_clap_adapter/src/abi/configurable_audio_ports.rs
+++ b/crates/wrac_clap_adapter/src/abi/configurable_audio_ports.rs
@@ -45,7 +45,11 @@ unsafe extern "C" fn configurable_audio_ports_can_apply_configuration(
             return false;
         };
 
-        let Some(configurable_audio_ports) = instance.configurable_audio_ports.as_ref() else {
+        let Some(configurable_audio_ports) = instance
+            .runtime
+            .get()
+            .and_then(|runtime| runtime.configurable_audio_ports.as_ref())
+        else {
             log::debug!(
                 "configurable_audio_ports.can_apply: plugin has no configurable audio ports"
             );
@@ -76,7 +80,11 @@ unsafe extern "C" fn configurable_audio_ports_apply_configuration(
             return false;
         };
 
-        let Some(configurable_audio_ports) = instance.configurable_audio_ports.as_ref() else {
+        let Some(configurable_audio_ports) = instance
+            .runtime
+            .get()
+            .and_then(|runtime| runtime.configurable_audio_ports.as_ref())
+        else {
             log::debug!("configurable_audio_ports.apply: plugin has no configurable audio ports");
             return false;
         };

--- a/crates/wrac_clap_adapter/src/abi/gui_extension.rs
+++ b/crates/wrac_clap_adapter/src/abi/gui_extension.rs
@@ -329,7 +329,10 @@ unsafe fn plugin_gui_query(plugin: *const clap_plugin) -> Option<Arc<dyn PluginG
         log::warn!("gui.query: missing plugin instance");
         return None;
     };
-    let gui = instance.gui.clone();
+    let gui = instance
+        .runtime
+        .get()
+        .and_then(|runtime| runtime.gui.clone());
     if gui.is_none() {
         log::debug!("gui.query: plugin has no GUI");
     }
@@ -370,7 +373,11 @@ unsafe fn plugin_gui_mutation(
     };
     // Extract only the capability handle to avoid coupling GUI callbacks to the
     // `PluginInstance` lifecycle/state lock (the GUI runtime has its own thread rules).
-    let Some(gui) = instance.gui.clone() else {
+    let Some(gui) = instance
+        .runtime
+        .get()
+        .and_then(|runtime| runtime.gui.clone())
+    else {
         log::debug!("gui.{callback_name}: plugin has no GUI");
         return None;
     };

--- a/crates/wrac_clap_adapter/src/abi/latency_extension.rs
+++ b/crates/wrac_clap_adapter/src/abi/latency_extension.rs
@@ -18,7 +18,11 @@ unsafe extern "C" fn latency_get(plugin: *const clap_plugin) -> u32 {
             log::warn!("latency.get: missing plugin instance");
             return 0;
         };
-        let Some(latency) = instance.latency.as_ref() else {
+        let Some(latency) = instance
+            .runtime
+            .get()
+            .and_then(|runtime| runtime.latency.as_ref())
+        else {
             // The implementation error is reported at plugin creation by a debug assertion and
             // this one release warning. `latency.get` can be polled continuously by wrappers/hosts,
             // so keep the ABI fallback visible without flooding logs.

--- a/crates/wrac_clap_adapter/src/abi/note_ports.rs
+++ b/crates/wrac_clap_adapter/src/abi/note_ports.rs
@@ -15,7 +15,11 @@ unsafe extern "C" fn note_ports_count(plugin: *const clap_plugin, is_input: bool
             wrac_log::rtwarn!("note_ports.count: missing plugin instance is_input={is_input}");
             return 0;
         };
-        let Some(note_ports) = instance.note_ports.as_ref() else {
+        let Some(note_ports) = instance
+            .runtime
+            .get()
+            .and_then(|runtime| runtime.note_ports.as_ref())
+        else {
             return 0;
         };
         note_ports.note_port_count(is_input)
@@ -41,7 +45,11 @@ unsafe extern "C" fn note_ports_get(
             );
             return false;
         };
-        let Some(note_ports) = instance.note_ports.as_ref() else {
+        let Some(note_ports) = instance
+            .runtime
+            .get()
+            .and_then(|runtime| runtime.note_ports.as_ref())
+        else {
             return false;
         };
         let port = note_ports.note_port_info(index, is_input).or_else(|| {

--- a/crates/wrac_clap_adapter/src/abi/params_extension.rs
+++ b/crates/wrac_clap_adapter/src/abi/params_extension.rs
@@ -31,7 +31,7 @@ pub(super) static PARAMS: clap_plugin_params = clap_plugin_params {
 };
 
 // VST3/AU/AAX wrappers may invoke parameter queries outside the CLAP `[main-thread]` assumption.
-// The parameters capability reads the Arc fixed at instance creation and does not touch
+// The parameters capability reads the Arc fixed during plugin initialization and does not touch
 // GUI/runtime ownership or lifecycle mutation.
 unsafe extern "C" fn params_count(plugin: *const clap_plugin) -> u32 {
     ffi_u32(|| {
@@ -39,7 +39,11 @@ unsafe extern "C" fn params_count(plugin: *const clap_plugin) -> u32 {
             log::warn!("params.count: missing plugin instance");
             return 0;
         };
-        let count = instance.parameters.count();
+        let Some(runtime) = instance.runtime.get() else {
+            log::warn!("params.count: plugin instance is not initialized");
+            return 0;
+        };
+        let count = runtime.parameters.count();
         log::debug!(
             "params.count: count={count} thread={:?}",
             std::thread::current().id()
@@ -62,7 +66,11 @@ unsafe extern "C" fn params_get_info(
             log::warn!("params.get_info: missing plugin instance index={param_index}");
             return false;
         };
-        let Some(info) = instance.parameters.get_info(param_index) else {
+        let Some(runtime) = instance.runtime.get() else {
+            log::warn!("params.get_info: plugin instance is not initialized index={param_index}");
+            return false;
+        };
+        let Some(info) = runtime.parameters.get_info(param_index) else {
             log::warn!("params.get_info: invalid index={param_index}");
             return false;
         };
@@ -121,7 +129,11 @@ unsafe extern "C" fn params_get_value(
             log::warn!("params.get_value: missing plugin instance param_id={param_id}");
             return false;
         };
-        let Ok(value) = instance.parameters.get_value(param_id) else {
+        let Some(runtime) = instance.runtime.get() else {
+            log::warn!("params.get_value: plugin instance is not initialized param_id={param_id}");
+            return false;
+        };
+        let Ok(value) = runtime.parameters.get_value(param_id) else {
             log::warn!("params.get_value: invalid param_id={param_id}");
             return false;
         };
@@ -148,7 +160,13 @@ unsafe extern "C" fn params_value_to_text(
             log::warn!("params.value_to_text: missing plugin instance param_id={param_id}");
             return false;
         };
-        let Ok(text) = instance.parameters.value_to_text(param_id, value) else {
+        let Some(runtime) = instance.runtime.get() else {
+            log::warn!(
+                "params.value_to_text: plugin instance is not initialized param_id={param_id}"
+            );
+            return false;
+        };
+        let Ok(text) = runtime.parameters.value_to_text(param_id, value) else {
             log::warn!("params.value_to_text: invalid param_id={param_id} value={value}");
             return false;
         };
@@ -179,7 +197,13 @@ unsafe extern "C" fn params_text_to_value(
             log::warn!("params.text_to_value: invalid utf8 param_id={param_id}");
             return false;
         };
-        let Ok(value) = instance.parameters.text_to_value(param_id, text) else {
+        let Some(runtime) = instance.runtime.get() else {
+            log::warn!(
+                "params.text_to_value: plugin instance is not initialized param_id={param_id}"
+            );
+            return false;
+        };
+        let Ok(value) = runtime.parameters.text_to_value(param_id, text) else {
             log::warn!("params.text_to_value: invalid param_id={param_id} text={text}");
             return false;
         };

--- a/crates/wrac_clap_adapter/src/abi/render_extension.rs
+++ b/crates/wrac_clap_adapter/src/abi/render_extension.rs
@@ -18,7 +18,11 @@ unsafe extern "C" fn render_has_hard_realtime_requirement(plugin: *const clap_pl
             log::warn!("render.has_hard_realtime_requirement: missing plugin instance");
             return false;
         };
-        let Some(render) = instance.render.as_ref() else {
+        let Some(render) = instance
+            .runtime
+            .get()
+            .and_then(|runtime| runtime.render.as_ref())
+        else {
             log::warn!("render.has_hard_realtime_requirement: plugin has no render support");
             return false;
         };
@@ -32,7 +36,11 @@ unsafe extern "C" fn render_set(plugin: *const clap_plugin, mode: clap_plugin_re
             log::warn!("render.set: missing plugin instance mode={mode}");
             return false;
         };
-        let Some(render) = instance.render.as_ref() else {
+        let Some(render) = instance
+            .runtime
+            .get()
+            .and_then(|runtime| runtime.render.as_ref())
+        else {
             log::warn!("render.set: plugin has no render support mode={mode}");
             return false;
         };

--- a/crates/wrac_clap_adapter/src/abi/state_extension.rs
+++ b/crates/wrac_clap_adapter/src/abi/state_extension.rs
@@ -14,7 +14,7 @@ const MAX_STATE_BYTES: usize = 64 * 1024 * 1024;
 
 // State callbacks may arrive while the plugin is active, depending on the host format.
 // Waiting for or giving up on the `PluginInstance` write lock here could silently drop a project save,
-// so only the thread-safe state capability fixed at instance creation is called.
+// so only the thread-safe state capability fixed during plugin initialization is called.
 unsafe extern "C" fn state_save(plugin: *const clap_plugin, stream: *const clap_ostream) -> bool {
     ffi_bool(|| {
         if stream.is_null() {
@@ -25,7 +25,11 @@ unsafe extern "C" fn state_save(plugin: *const clap_plugin, stream: *const clap_
             log::warn!("state.save: missing plugin instance");
             return false;
         };
-        let Some(state_support) = instance.state.as_ref() else {
+        let Some(state_support) = instance
+            .runtime
+            .get()
+            .and_then(|runtime| runtime.state.as_ref())
+        else {
             log::debug!("state.save: plugin has no state support");
             return false;
         };
@@ -68,7 +72,11 @@ unsafe extern "C" fn state_load(plugin: *const clap_plugin, stream: *const clap_
             return false;
         };
 
-        let Some(state_support) = instance.state.as_ref() else {
+        let Some(state_support) = instance
+            .runtime
+            .get()
+            .and_then(|runtime| runtime.state.as_ref())
+        else {
             log::debug!("state.load: plugin has no state support");
             return false;
         };

--- a/crates/wrac_clap_adapter/src/abi/tail_extension.rs
+++ b/crates/wrac_clap_adapter/src/abi/tail_extension.rs
@@ -14,7 +14,11 @@ unsafe extern "C" fn tail_get(plugin: *const clap_plugin) -> u32 {
             wrac_log::rtwarn!("tail.get: missing plugin instance");
             return 0;
         };
-        let Some(tail) = instance.tail.as_ref() else {
+        let Some(tail) = instance
+            .runtime
+            .get()
+            .and_then(|runtime| runtime.tail.as_ref())
+        else {
             wrac_log::rtwarn!("tail.get: plugin has no tail support");
             return 0;
         };

--- a/crates/wrac_clap_adapter/src/api/core.rs
+++ b/crates/wrac_clap_adapter/src/api/core.rs
@@ -61,7 +61,7 @@ pub struct PluginInstanceContext {
 pub trait PluginInstance: Send + 'static {
     /// Initializes the processor lifecycle in its inactive state.
     ///
-    /// The adapter calls this once during plugin instance creation. It may call
+    /// The adapter calls this once during plugin initialization. It may call
     /// it again after `activate` returns an error, because `activate` consumes
     /// the previous inactive processor before attempting to create an active one.
     /// Implementations must therefore return a fresh inactive processor each time.
@@ -92,64 +92,64 @@ pub trait PluginInstance: Send + 'static {
     /// `[main-thread]`
     fn on_main_thread(&mut self) {}
 
-    /// Returns the CLAP audio-ports extension during plugin instance creation.
+    /// Returns the CLAP audio-ports extension during plugin initialization.
     ///
-    /// Called once before CLAP callbacks are exposed to the host.
+    /// Called once from `plugin.init` before CLAP extension callbacks are exposed to the host.
     fn audio_ports(&self) -> Option<Arc<dyn PluginAudioPortsExtension>> {
         None
     }
 
-    /// Returns the CLAP configurable-audio-ports extension during plugin instance creation.
+    /// Returns the CLAP configurable-audio-ports extension during plugin initialization.
     ///
-    /// Called once before CLAP callbacks are exposed to the host.
+    /// Called once from `plugin.init` before CLAP extension callbacks are exposed to the host.
     fn configurable_audio_ports(&self) -> Option<Arc<dyn PluginConfigurableAudioPortsExtension>> {
         None
     }
 
-    /// Returns the CLAP note-ports extension during plugin instance creation.
+    /// Returns the CLAP note-ports extension during plugin initialization.
     ///
-    /// Called once before CLAP callbacks are exposed to the host.
+    /// Called once from `plugin.init` before CLAP extension callbacks are exposed to the host.
     fn note_ports(&self) -> Option<Arc<dyn PluginNotePortsExtension>> {
         None
     }
 
-    /// Returns the parameter query surface during plugin instance creation.
+    /// Returns the parameter query surface during plugin initialization.
     ///
-    /// Called once before CLAP callbacks are exposed to the host. Plugins without
+    /// Called once from `plugin.init` before CLAP callbacks are exposed to the host. Plugins without
     /// parameters return a query object whose count is zero.
     fn params(&self) -> Arc<dyn PluginParamsQuery>;
 
-    /// Returns the CLAP state extension during plugin instance creation.
+    /// Returns the CLAP state extension during plugin initialization.
     ///
-    /// Called once before CLAP callbacks are exposed to the host.
+    /// Called once from `plugin.init` before CLAP extension callbacks are exposed to the host.
     fn state(&self) -> Option<Arc<dyn PluginStateExtension>> {
         None
     }
 
-    /// Returns the CLAP GUI extension during plugin instance creation.
+    /// Returns the CLAP GUI extension during plugin initialization.
     ///
-    /// Called once before CLAP callbacks are exposed to the host.
+    /// Called once from `plugin.init` before CLAP extension callbacks are exposed to the host.
     fn gui(&self) -> Option<Arc<dyn PluginGuiExtension>> {
         None
     }
 
-    /// Returns the CLAP render extension during plugin instance creation.
+    /// Returns the CLAP render extension during plugin initialization.
     ///
-    /// Called once before CLAP callbacks are exposed to the host.
+    /// Called once from `plugin.init` before CLAP extension callbacks are exposed to the host.
     fn render(&self) -> Option<Arc<dyn PluginRenderExtension>> {
         None
     }
 
-    /// Returns the CLAP tail extension during plugin instance creation.
+    /// Returns the CLAP tail extension during plugin initialization.
     ///
-    /// Called once before CLAP callbacks are exposed to the host.
+    /// Called once from `plugin.init` before CLAP extension callbacks are exposed to the host.
     fn tail(&self) -> Option<Arc<dyn PluginTailExtension>> {
         None
     }
 
-    /// Returns the CLAP latency extension during plugin instance creation.
+    /// Returns the CLAP latency extension during plugin initialization.
     ///
-    /// Called once before CLAP callbacks are exposed to the host.
+    /// Called once from `plugin.init` before CLAP extension callbacks are exposed to the host.
     fn latency(&self) -> Option<Arc<dyn PluginLatencyExtension>> {
         None
     }

--- a/crates/wrac_clap_adapter/src/host_lifecycle.rs
+++ b/crates/wrac_clap_adapter/src/host_lifecycle.rs
@@ -1,21 +1,40 @@
 use clap_sys::host::clap_host;
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
 
 use crate::HostLifecycle;
 
 pub(crate) struct HostLifecycleProxy {
     callbacks: HostLifecycleCallbacks,
+    initialized: Arc<AtomicBool>,
 }
 
 impl HostLifecycleProxy {
-    pub(crate) fn new(host: *const clap_host) -> Self {
+    pub(crate) fn new(host: *const clap_host, initialized: Arc<AtomicBool>) -> Self {
         Self {
             callbacks: HostLifecycleCallbacks::new(host),
+            initialized,
+        }
+    }
+
+    fn is_available(&self, callback_name: &'static str) -> bool {
+        if self.initialized.load(Ordering::Acquire) {
+            true
+        } else {
+            log::debug!("host.{callback_name}: host lifecycle unavailable before plugin.init");
+            false
         }
     }
 }
 
 impl HostLifecycle for HostLifecycleProxy {
     fn request_restart(&self) {
+        if !self.is_available("request_restart") {
+            return;
+        }
+
         let Some(request_restart) = self.callbacks.request_restart else {
             log::debug!("host.request_restart: callback unavailable");
             return;
@@ -27,6 +46,10 @@ impl HostLifecycle for HostLifecycleProxy {
     }
 
     fn request_process(&self) {
+        if !self.is_available("request_process") {
+            return;
+        }
+
         let Some(request_process) = self.callbacks.request_process else {
             log::debug!("host.request_process: callback unavailable");
             return;
@@ -38,6 +61,10 @@ impl HostLifecycle for HostLifecycleProxy {
     }
 
     fn request_callback(&self) {
+        if !self.is_available("request_callback") {
+            return;
+        }
+
         let Some(request_callback) = self.callbacks.request_callback else {
             log::debug!("host.request_callback: callback unavailable");
             return;
@@ -57,8 +84,9 @@ struct HostLifecycleCallbacks {
     request_callback: Option<unsafe extern "C" fn(host: *const clap_host)>,
 }
 
-// The CLAP host pointer is owned by the host for the plugin instance lifetime. The public trait
-// mirrors CLAP's host lifecycle callbacks and does not add scheduling or thread correction.
+// The CLAP host pointer is owned by the host for the plugin instance lifetime. Lifecycle
+// callbacks are gated until capability freeze completes so product constructors cannot trigger
+// init-time host re-entry before plugin extensions are visible.
 unsafe impl Send for HostLifecycleCallbacks {}
 unsafe impl Sync for HostLifecycleCallbacks {}
 


### PR DESCRIPTION
## Summary
- defer WRAC product instance construction from `clap.plugin-factory.create_plugin` to `plugin.init`
- keep `create_plugin` responsible for the CLAP ABI shell only
- freeze extension capabilities during `plugin.init` and reject pre-init callbacks without blocking
- document the lifecycle behavior in `wrac_clap_adapter` README

## Why
`clap-wrapper` enters `plugin.init` before collecting CLAP extensions for VST3/AU/AAX wrappers. Constructing product code from `plugin.init` lets product constructors receive host proxies only after the wrapper has entered the CLAP initialization phase, while avoiding deadlocks from pre-init or init-time re-entry.

## Validation
- `cargo fmt --check`
- `cargo test -p wrac_clap_adapter`
- `cargo check -p wrac_gain_plugin`
- `cargo clippy -p wrac_clap_adapter --all-targets -- -D warnings`
