### PR TITLE
Improve xtask execution log readability

### DIFF
--- a/crates/wrac_xtask/src/commands.rs
+++ b/crates/wrac_xtask/src/commands.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use crate::Result;
+use crate::XtaskOutputLanguage;
 use crate::cli::{InstallScope, UninstallScope};
 use crate::context::Context;
 use crate::metadata::PluginMetadata;
@@ -121,20 +122,53 @@ pub(crate) fn uninstall_plugin_target(
     let mut missing = 0usize;
     for path in installed_artifacts(ctx, scope, target)? {
         if !path.exists() {
-            println!("  なし: {}", path.display());
+            println!(
+                "  {}: {}",
+                missing_label(ctx.output_language),
+                path.display()
+            );
             missing += 1;
             continue;
         }
 
         if dry_run {
-            println!("  削除予定: {}", path.display());
+            println!(
+                "  {}: {}",
+                would_remove_label(ctx.output_language),
+                path.display()
+            );
         } else {
-            println!("  削除: {}", path.display());
+            println!(
+                "  {}: {}",
+                removing_label(ctx.output_language),
+                path.display()
+            );
             remove_if_exists(&path)?;
         }
         removed += 1;
     }
     Ok((removed, missing))
+}
+
+fn missing_label(language: XtaskOutputLanguage) -> &'static str {
+    match language {
+        XtaskOutputLanguage::English => "Not found",
+        XtaskOutputLanguage::Japanese => "なし",
+    }
+}
+
+fn would_remove_label(language: XtaskOutputLanguage) -> &'static str {
+    match language {
+        XtaskOutputLanguage::English => "Would remove",
+        XtaskOutputLanguage::Japanese => "削除予定",
+    }
+}
+
+fn removing_label(language: XtaskOutputLanguage) -> &'static str {
+    match language {
+        XtaskOutputLanguage::English => "Removing",
+        XtaskOutputLanguage::Japanese => "削除",
+    }
 }
 
 pub(crate) fn install_dir(

--- a/crates/wrac_xtask/src/commands.rs
+++ b/crates/wrac_xtask/src/commands.rs
@@ -11,7 +11,8 @@ use crate::metadata::PluginMetadata;
 use crate::profile::BuildProfile;
 use crate::targets::{Platform, PluginFormat, PluginTarget, Target};
 use crate::util::{
-    common_program_files, copy_path, ensure_exists, home_dir, local_app_data, remove_if_exists, run,
+    common_program_files, copy_path, ensure_exists, home_dir, local_app_data, print_section,
+    print_success, remove_if_exists, run_with_language,
 };
 
 mod build;
@@ -40,10 +41,20 @@ pub(crate) fn launch(ctx: &Context, profile: BuildProfile, plugin_id: Option<&st
         .into());
     }
 
-    println!("Launching standalone artifact: {}", artifact.display());
+    print_section(ctx.output_language, "Launch standalone", "standalone 起動");
+    print_success(
+        ctx.output_language,
+        &format!("Launching standalone artifact: {}", artifact.display()),
+        &format!("standalone artifact: {}", artifact.display()),
+    );
     match ctx.platform {
-        Platform::Macos => run(Command::new("open").arg("-W").arg("-n").arg(&artifact))?,
-        Platform::Windows | Platform::Linux => run(&mut Command::new(&artifact))?,
+        Platform::Macos => run_with_language(
+            Command::new("open").arg("-W").arg("-n").arg(&artifact),
+            ctx.output_language,
+        )?,
+        Platform::Windows | Platform::Linux => {
+            run_with_language(&mut Command::new(&artifact), ctx.output_language)?
+        }
     }
     Ok(())
 }
@@ -93,19 +104,22 @@ pub(crate) fn install_plugin_target(
         PluginTarget::Clap => install_artifact(
             &ctx.clap_bundle(profile),
             &install_dir(ctx, scope, PluginFormat::Clap)?,
+            ctx.output_language,
         )?,
         PluginTarget::Vst3 => install_artifact(
             &ctx.vst3_bundle(profile),
             &install_dir(ctx, scope, PluginFormat::Vst3)?,
+            ctx.output_language,
         )?,
         PluginTarget::Aax => install_artifact(
             &ctx.aax_bundle(profile),
             &install_dir(ctx, scope, PluginFormat::Aax)?,
+            ctx.output_language,
         )?,
         PluginTarget::Au => {
             let install_dir = install_dir(ctx, scope, PluginFormat::Au)?;
             for artifact in ctx.au_bundles(profile) {
-                install_artifact(&artifact, &install_dir)?;
+                install_artifact(&artifact, &install_dir, ctx.output_language)?;
             }
         }
     }
@@ -253,7 +267,11 @@ pub(crate) fn install_dir(
     Ok(dir)
 }
 
-pub(crate) fn install_artifact(artifact: &Path, destination_dir: &Path) -> Result<()> {
+pub(crate) fn install_artifact(
+    artifact: &Path,
+    destination_dir: &Path,
+    language: XtaskOutputLanguage,
+) -> Result<()> {
     ensure_exists(artifact, "install artifact")?;
     fs::create_dir_all(destination_dir)?;
     let destination = destination_dir.join(
@@ -265,7 +283,11 @@ pub(crate) fn install_artifact(artifact: &Path, destination_dir: &Path) -> Resul
     // Remove the destination first, then copy the whole artifact so the installed result matches the build output exactly.
     remove_if_exists(&destination)?;
     copy_path(artifact, &destination)?;
-    println!("Installed: {}", destination.display());
+    print_success(
+        language,
+        &format!("Installed: {}", destination.display()),
+        &format!("インストール: {}", destination.display()),
+    );
     Ok(())
 }
 
@@ -430,20 +452,21 @@ pub(crate) fn print_outputs(
     targets: &[Target],
     standalone_plugin_id: Option<&str>,
 ) -> Result<()> {
+    print_section(ctx.output_language, "Artifacts", "成果物");
     for target in targets {
         match target {
-            Target::Clap => println!("CLAP: {}", ctx.clap_bundle(profile).display()),
-            Target::Vst3 => println!("VST3: {}", ctx.vst3_bundle(profile).display()),
-            Target::Aax => println!("AAX: {}", ctx.aax_bundle(profile).display()),
+            Target::Clap => println!("  ✅ CLAP: {}", ctx.clap_bundle(profile).display()),
+            Target::Vst3 => println!("  ✅ VST3: {}", ctx.vst3_bundle(profile).display()),
+            Target::Aax => println!("  ✅ AAX: {}", ctx.aax_bundle(profile).display()),
             Target::Au => {
                 for artifact in ctx.au_bundles(profile) {
-                    println!("AU: {}", artifact.display());
+                    println!("  ✅ AU: {}", artifact.display());
                 }
             }
             Target::Standalone => {
                 for (_, plugin) in standalone_products(ctx, standalone_plugin_id)? {
                     let artifact = ctx.standalone_artifact_for(profile, plugin);
-                    println!("Standalone: {}", artifact.display());
+                    println!("  ✅ Standalone: {}", artifact.display());
                 }
             }
         }
@@ -492,17 +515,20 @@ fn macos_clap_info_plist(metadata: &PluginMetadata) -> String {
     )
 }
 
-fn codesign(path: &Path) -> Result<()> {
-    run(Command::new("codesign")
-        .arg("--force")
-        .arg("--sign")
-        .arg("-")
-        .arg("--timestamp=none")
-        .arg(path))?;
+fn codesign(path: &Path, language: XtaskOutputLanguage) -> Result<()> {
+    run_with_language(
+        Command::new("codesign")
+            .arg("--force")
+            .arg("--sign")
+            .arg("-")
+            .arg("--timestamp=none")
+            .arg(path),
+        language,
+    )?;
     Ok(())
 }
 
-fn codesign_nested_macos_bundle(bundle: &Path) -> Result<()> {
+fn codesign_nested_macos_bundle(bundle: &Path, language: XtaskOutputLanguage) -> Result<()> {
     let plugins_dir = bundle.join("Contents").join("PlugIns");
     if plugins_dir.exists() {
         for entry in fs::read_dir(&plugins_dir)? {
@@ -511,11 +537,11 @@ fn codesign_nested_macos_bundle(bundle: &Path) -> Result<()> {
                 .extension()
                 .is_some_and(|extension| extension == "clap")
             {
-                codesign(&path)?;
+                codesign(&path, language)?;
             }
         }
     }
-    codesign(bundle)?;
+    codesign(bundle, language)?;
     Ok(())
 }
 

--- a/crates/wrac_xtask/src/commands.rs
+++ b/crates/wrac_xtask/src/commands.rs
@@ -121,15 +121,15 @@ pub(crate) fn uninstall_plugin_target(
     let mut missing = 0usize;
     for path in installed_artifacts(ctx, scope, target)? {
         if !path.exists() {
-            println!("Not found: {}", path.display());
+            println!("  なし: {}", path.display());
             missing += 1;
             continue;
         }
 
         if dry_run {
-            println!("Would remove: {}", path.display());
+            println!("  削除予定: {}", path.display());
         } else {
-            println!("Removing: {}", path.display());
+            println!("  削除: {}", path.display());
             remove_if_exists(&path)?;
         }
         removed += 1;

--- a/crates/wrac_xtask/src/commands/build.rs
+++ b/crates/wrac_xtask/src/commands/build.rs
@@ -6,15 +6,15 @@ use std::process::Command;
 
 use serde_json::Value;
 
-use crate::Result;
 use crate::context::Context;
 use crate::metadata::PluginProductMetadata;
 use crate::profile::BuildProfile;
 use crate::targets::Platform;
 use crate::util::{
-    ensure_exists, env_value_or, on_off, remove_if_exists, run, run_output,
-    run_with_optional_xcbeautify,
+    ensure_exists, env_value_or, on_off, print_section, print_skip, remove_if_exists,
+    run_output_with_language, run_with_language, run_with_optional_xcbeautify_language,
 };
+use crate::{Result, XtaskOutputLanguage};
 
 use super::{
     aax_sdk_root, codesign, codesign_nested_macos_bundle, ensure_aax_sdk_input,
@@ -23,16 +23,27 @@ use super::{
 };
 
 pub(crate) fn build_gui(ctx: &Context) -> Result<()> {
-    println!("Building GUI...");
+    print_section(ctx.output_language, "Build GUI", "GUI ビルド");
     let package_json = ctx.gui_dir().join("package.json");
     if !package_json.exists() {
-        println!("No src-gui/package.json found; skipping GUI build.");
+        print_skip(
+            ctx.output_language,
+            "No src-gui/package.json found; skipping GUI build.",
+            "src-gui/package.json がないため GUI ビルドをスキップ",
+        );
         return Ok(());
     }
     if !has_package_script(&package_json, "build")? {
-        println!(
-            "No build script found in {}; skipping GUI build.",
-            package_json.display()
+        print_skip(
+            ctx.output_language,
+            &format!(
+                "No build script found in {}; skipping GUI build.",
+                package_json.display()
+            ),
+            &format!(
+                "{} に build script がないため GUI ビルドをスキップ",
+                package_json.display()
+            ),
         );
         return Ok(());
     }
@@ -40,12 +51,18 @@ pub(crate) fn build_gui(ctx: &Context) -> Result<()> {
     if !is_pnpm_workspace(ctx) {
         // Standalone template projects keep the frontend package under src-gui
         // without a repository-level package.json.
-        run(Command::new(command_for_platform(ctx.platform, "npm"))
-            .arg("install")
-            .current_dir(ctx.gui_dir()))?;
-        run(Command::new(command_for_platform(ctx.platform, "npm"))
-            .args(["run", "build"])
-            .current_dir(ctx.gui_dir()))?;
+        run_with_language(
+            Command::new(command_for_platform(ctx.platform, "npm"))
+                .arg("install")
+                .current_dir(ctx.gui_dir()),
+            ctx.output_language,
+        )?;
+        run_with_language(
+            Command::new(command_for_platform(ctx.platform, "npm"))
+                .args(["run", "build"])
+                .current_dir(ctx.gui_dir()),
+            ctx.output_language,
+        )?;
         return Ok(());
     }
 
@@ -53,17 +70,26 @@ pub(crate) fn build_gui(ctx: &Context) -> Result<()> {
     let dependency_names = workspace_dependency_names(&package);
     // build.rs embeds src-gui/dist into the plugin binary. Workspace packages such as
     // @novonotes/webview-bridge also need their dist before the GUI typecheck runs.
-    run(Command::new(command_for_platform(ctx.platform, "pnpm"))
-        .arg("install")
-        .current_dir(&ctx.root))?;
+    run_with_language(
+        Command::new(command_for_platform(ctx.platform, "pnpm"))
+            .arg("install")
+            .current_dir(&ctx.root),
+        ctx.output_language,
+    )?;
     for dependency_name in dependency_names {
-        run(Command::new(command_for_platform(ctx.platform, "pnpm"))
-            .args(["--filter", &dependency_name, "run", "--if-present", "build"])
-            .current_dir(&ctx.root))?;
+        run_with_language(
+            Command::new(command_for_platform(ctx.platform, "pnpm"))
+                .args(["--filter", &dependency_name, "run", "--if-present", "build"])
+                .current_dir(&ctx.root),
+            ctx.output_language,
+        )?;
     }
-    run(Command::new(command_for_platform(ctx.platform, "pnpm"))
-        .args(["--filter", &package_name, "run", "build"])
-        .current_dir(&ctx.root))?;
+    run_with_language(
+        Command::new(command_for_platform(ctx.platform, "pnpm"))
+            .args(["--filter", &package_name, "run", "build"])
+            .current_dir(&ctx.root),
+        ctx.output_language,
+    )?;
     Ok(())
 }
 
@@ -177,7 +203,11 @@ pub(crate) fn build_rust_plugin(
     profile: BuildProfile,
     build: RustPluginBuild,
 ) -> Result<()> {
-    println!("Building Rust plugin ({})...", build.label());
+    print_section(
+        ctx.output_language,
+        &format!("Build Rust plugin ({})", build.label()),
+        &format!("Rust plugin ビルド ({})", build.label()),
+    );
     let mut command = Command::new("cargo");
     command
         .arg("build")
@@ -195,7 +225,7 @@ pub(crate) fn build_rust_plugin(
             env_value_or("MACOSX_DEPLOYMENT_TARGET", "11.0"),
         );
     }
-    run(command.current_dir(&ctx.root))?;
+    run_with_language(command.current_dir(&ctx.root), ctx.output_language)?;
 
     ensure_exists(
         &build.dynamic_library(ctx, profile),
@@ -210,7 +240,7 @@ pub(crate) fn build_rust_plugin(
 }
 
 pub(crate) fn package_clap(ctx: &Context, profile: BuildProfile) -> Result<()> {
-    println!("Packaging CLAP...");
+    print_section(ctx.output_language, "Package CLAP", "CLAP packaging");
     let bundle = ctx.clap_bundle(profile);
     remove_if_exists(&bundle)?;
     fs::create_dir_all(ctx.plugins_dir(profile))?;
@@ -232,12 +262,15 @@ pub(crate) fn package_clap(ctx: &Context, profile: BuildProfile) -> Result<()> {
                 ctx.dynamic_library(profile),
                 macos.join(&ctx.metadata.bundle_name),
             )?;
-            run(Command::new("install_name_tool")
-                .arg("-id")
-                .arg(format!("@loader_path/{}", ctx.metadata.bundle_name))
-                .arg(macos.join(&ctx.metadata.bundle_name))
-                .current_dir(&ctx.root))?;
-            codesign(&bundle)?;
+            run_with_language(
+                Command::new("install_name_tool")
+                    .arg("-id")
+                    .arg(format!("@loader_path/{}", ctx.metadata.bundle_name))
+                    .arg(macos.join(&ctx.metadata.bundle_name))
+                    .current_dir(&ctx.root),
+                ctx.output_language,
+            )?;
+            codesign(&bundle, ctx.output_language)?;
         }
         Platform::Windows | Platform::Linux => {
             // On Windows/Linux the CLAP artifact is a dynamic library with the .clap extension.
@@ -445,10 +478,18 @@ pub(crate) fn configure_wrapper(
     }
 
     if cmake_configure_is_current(&build_dir, &args, &ctx.wrapper_dir)? {
-        println!(
-            "CMake configure is up to date for {} ({})",
-            build.purpose(),
-            profile.cmake_config()
+        print_skip(
+            ctx.output_language,
+            &format!(
+                "CMake configure is up to date for {} ({})",
+                build.purpose(),
+                profile.cmake_config()
+            ),
+            &format!(
+                "CMake configure は最新です: {} ({})",
+                build.purpose(),
+                profile.cmake_config()
+            ),
         );
         return Ok(());
     }
@@ -461,7 +502,7 @@ pub(crate) fn configure_wrapper(
             env_value_or("MACOSX_DEPLOYMENT_TARGET", "11.0"),
         );
     }
-    run(configure.current_dir(&ctx.root))?;
+    run_with_language(configure.current_dir(&ctx.root), ctx.output_language)?;
     write_cmake_configure_stamp(&build_dir, &args, &ctx.wrapper_dir)?;
     Ok(())
 }
@@ -499,9 +540,9 @@ pub(crate) fn build_wrapper_target(
 
         let build_cmd = build_cmd.current_dir(&ctx.root);
         if ctx.platform == Platform::Macos {
-            run_with_optional_xcbeautify(build_cmd)?;
+            run_with_optional_xcbeautify_language(build_cmd, ctx.output_language)?;
         } else {
-            run(build_cmd)?;
+            run_with_language(build_cmd, ctx.output_language)?;
         }
     }
 
@@ -510,14 +551,14 @@ pub(crate) fn build_wrapper_target(
             ensure_exists(&ctx.vst3_bundle(profile), "VST3 artifact")?;
             if ctx.platform == Platform::Macos {
                 // macOS hosts may reject unsigned bundles; apply an ad-hoc signature for development.
-                codesign_nested_macos_bundle(&ctx.vst3_bundle(profile))?;
+                codesign_nested_macos_bundle(&ctx.vst3_bundle(profile), ctx.output_language)?;
             }
         }
         WrapperTarget::Au => {
             for artifact in ctx.au_bundles(profile) {
                 ensure_exists(&artifact, "AU artifact")?;
                 // AU components are loaded via AudioComponentRegistrar, so they must be signed even for local builds.
-                codesign_nested_macos_bundle(&artifact)?;
+                codesign_nested_macos_bundle(&artifact, ctx.output_language)?;
             }
         }
         WrapperTarget::Aax => {
@@ -525,7 +566,7 @@ pub(crate) fn build_wrapper_target(
             if ctx.platform == Platform::Macos {
                 // AAX developer validation loads the bundle directly, so keep the
                 // local artifact ad-hoc signed before the validator sees it.
-                codesign_nested_macos_bundle(&ctx.aax_bundle(profile))?;
+                codesign_nested_macos_bundle(&ctx.aax_bundle(profile), ctx.output_language)?;
             }
         }
         WrapperTarget::Standalone => {
@@ -534,7 +575,7 @@ pub(crate) fn build_wrapper_target(
                 ensure_exists(&artifact, "standalone artifact")?;
                 if ctx.platform == Platform::Macos {
                     // Apply the same Gatekeeper/loader treatment to the standalone app as to plugin bundles.
-                    codesign_nested_macos_bundle(&artifact)?;
+                    codesign_nested_macos_bundle(&artifact, ctx.output_language)?;
                 }
             }
         }
@@ -608,7 +649,7 @@ fn windows_cmake_generator() -> Result<String> {
 
     ensure_visual_studio_msbuild_available()?;
     let generator = latest_cmake_visual_studio_generator()?;
-    println!("Using CMake generator: {generator}");
+    println!("  ✅ CMake generator: {generator}");
     Ok(generator)
 }
 
@@ -623,7 +664,7 @@ fn ensure_visual_studio_msbuild_available() -> Result<()> {
         "-property",
         "installationPath",
     ]);
-    let output = run_output(&mut vswhere)?;
+    let output = run_output_with_language(&mut vswhere, XtaskOutputLanguage::English)?;
     let installation_path = String::from_utf8(output.stdout)?;
     if installation_path.trim().is_empty() {
         return Err("Visual Studio with MSBuild was not found by vswhere".into());
@@ -645,7 +686,10 @@ fn vswhere_command() -> PathBuf {
 }
 
 fn latest_cmake_visual_studio_generator() -> Result<String> {
-    let output = run_output(Command::new("cmake").arg("--help"))?;
+    let output = run_output_with_language(
+        Command::new("cmake").arg("--help"),
+        XtaskOutputLanguage::English,
+    )?;
     let help = String::from_utf8(output.stdout)?;
     select_latest_visual_studio_generator(&help)
         .ok_or_else(|| "CMake does not list any Visual Studio generator".into())

--- a/crates/wrac_xtask/src/commands/validation.rs
+++ b/crates/wrac_xtask/src/commands/validation.rs
@@ -12,7 +12,8 @@ use crate::context::Context;
 use crate::profile::BuildProfile;
 use crate::targets::{Platform, ValidateTarget};
 use crate::util::{
-    copy_path, ensure_exists, remove_if_exists, run, run_output, run_with_optional_xcbeautify,
+    copy_path, ensure_exists, print_section, print_skip, print_success, remove_if_exists,
+    run_output_with_language, run_with_language, run_with_optional_xcbeautify_language,
 };
 use crate::validation::validate_wrac_rules;
 
@@ -82,31 +83,35 @@ pub(crate) fn validate_plugin_target(
                 .skip_test_filter
                 .as_deref()
             {
-                println!(
-                    "CLAP validator skip filter: {filter} ({})",
-                    ctx.metadata
-                        .validation
-                        .clap_validator
-                        .skip_reason
-                        .as_deref()
-                        .unwrap_or("no reason provided")
+                let reason = ctx
+                    .metadata
+                    .validation
+                    .clap_validator
+                    .skip_reason
+                    .as_deref()
+                    .unwrap_or("no reason provided");
+                print_skip(
+                    ctx.output_language,
+                    &format!("CLAP validator skip filter: {filter} ({reason})"),
+                    &format!("CLAP validator skip filter: {filter} ({reason})"),
                 );
                 command
                     .arg("--test-filter")
                     .arg(filter)
                     .arg("--invert-filter");
             }
-            run(command.current_dir(&ctx.root))?;
+            run_with_language(command.current_dir(&ctx.root), ctx.output_language)?;
         }
         ValidateTarget::Vst3 => {
             let vst3 = ctx.vst3_bundle(profile);
             ensure_exists(&vst3, "VST3 artifact")?;
             let validator = ensure_vst3_validator(ctx)?;
-            let output = run_output(
+            let output = run_output_with_language(
                 Command::new(validator)
                     .env("WRAC_PLUGIN_VALIDATOR", "1")
                     .arg(&vst3)
                     .current_dir(&ctx.root),
+                ctx.output_language,
             )?;
             let stdout = String::from_utf8_lossy(&output.stdout);
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -131,14 +136,17 @@ pub(crate) fn validate_plugin_target(
                 .status();
 
             for plugin in &ctx.metadata.plugins {
-                run(Command::new("/usr/bin/auval")
-                    .args([
-                        "-v",
-                        &plugin.auv2_type,
-                        &plugin.auv2_subtype,
-                        &ctx.metadata.auv2_manufacturer_code,
-                    ])
-                    .current_dir(&ctx.root))?;
+                run_with_language(
+                    Command::new("/usr/bin/auval")
+                        .args([
+                            "-v",
+                            &plugin.auv2_type,
+                            &plugin.auv2_subtype,
+                            &ctx.metadata.auv2_manufacturer_code,
+                        ])
+                        .current_dir(&ctx.root),
+                    ctx.output_language,
+                )?;
             }
         }
         ValidateTarget::Aax => {
@@ -175,7 +183,11 @@ fn validate_vst3_component_ids(
         .into());
     }
 
-    println!("VST3 component IDs match plugins.vst3_component_id");
+    print_success(
+        ctx.output_language,
+        "VST3 component IDs match plugins.vst3_component_id",
+        "VST3 component ID は plugins.vst3_component_id と一致",
+    );
     Ok(())
 }
 
@@ -203,19 +215,34 @@ fn run_aax_validator(ctx: &Context, aax: &Path) -> Result<()> {
     fs::create_dir_all(&results_dir)?;
     let aax = stage_aax_for_validator(&results_dir, aax)?;
 
-    println!("Running AAX validator for: {}", aax.display());
+    print_section(ctx.output_language, "AAX validator", "AAX validator");
     println!(
-        "AAX validation runs {} selected validator tests.",
+        "  {}: {}",
+        match ctx.output_language {
+            crate::XtaskOutputLanguage::English => "Target",
+            crate::XtaskOutputLanguage::Japanese => "対象",
+        },
+        aax.display()
+    );
+    println!(
+        "  {}: {}",
+        match ctx.output_language {
+            crate::XtaskOutputLanguage::English => "Selected tests",
+            crate::XtaskOutputLanguage::Japanese => "実行 test",
+        },
         AAX_VALIDATOR_REQUIRED_TESTS.len()
     );
     for (test_id, reason) in AAX_VALIDATOR_SKIPPED_TESTS {
-        println!("Skipping {test_id}: {reason}.");
+        print_skip(
+            ctx.output_language,
+            &format!("Skipping {test_id}: {reason}."),
+            &format!("{test_id}: {reason}"),
+        );
     }
-    println!();
 
     run_aax_validator_dtt(ctx, &aax, &results_dir)?;
 
-    assert_aax_validator_results(&results_dir)
+    assert_aax_validator_results(ctx, &results_dir)
 }
 
 fn run_aax_validator_dtt(ctx: &Context, aax: &Path, results_dir: &Path) -> Result<()> {
@@ -223,7 +250,7 @@ fn run_aax_validator_dtt(ctx: &Context, aax: &Path, results_dir: &Path) -> Resul
     let aax_search_dir = aax
         .parent()
         .ok_or_else(|| format!("AAX bundle path has no parent directory: {}", aax.display()))?;
-    println!("========== Running command ==========");
+    print_section(ctx.output_language, "Running command", "コマンド実行");
     println!("$ {}", dtt.display());
 
     for (index, test_id) in AAX_VALIDATOR_REQUIRED_TESTS.iter().enumerate() {
@@ -331,7 +358,7 @@ fn find_aax_validator_dtt_result(test_dir: &Path, test_id: &str) -> Result<PathB
     }
 }
 
-fn assert_aax_validator_results(results_dir: &Path) -> Result<()> {
+fn assert_aax_validator_results(ctx: &Context, results_dir: &Path) -> Result<()> {
     let mut failed = Vec::new();
     for (index, test_id) in AAX_VALIDATOR_REQUIRED_TESTS.iter().enumerate() {
         let result_path = aax_validator_result_path(results_dir, index, test_id);
@@ -340,11 +367,24 @@ fn assert_aax_validator_results(results_dir: &Path) -> Result<()> {
         // and artifacts can be audited against.
         let status = aax_validator_result_status(&result_path)?;
         if status == "E_COMPLETED_PASS" {
-            println!("AAX validator PASS: {test_id}");
+            print_success(
+                ctx.output_language,
+                &format!("AAX validator PASS: {test_id}"),
+                &format!("AAX validator 成功: {test_id}"),
+            );
         } else {
             println!(
-                "AAX validator FAIL: {test_id} ({status}); see {}",
-                result_path.display()
+                "  ❌ {}",
+                match ctx.output_language {
+                    crate::XtaskOutputLanguage::English => format!(
+                        "AAX validator FAIL: {test_id} ({status}); see {}",
+                        result_path.display()
+                    ),
+                    crate::XtaskOutputLanguage::Japanese => format!(
+                        "AAX validator 失敗: {test_id} ({status}); 詳細 {}",
+                        result_path.display()
+                    ),
+                }
             );
             failed.push(format!("{test_id} ({status})"));
         }
@@ -366,7 +406,7 @@ fn wait_for_aax_validator_process(mut child: Child, timeout: Duration) -> Result
             return Ok(child.wait_with_output()?);
         }
         if started_at.elapsed() >= timeout {
-            // Keep timeouts outside `run()` so failed DTT processes still have their
+            // Keep timeouts outside `run_with_language()` so failed DTT processes still have their
             // stdout/stderr printed. That output is usually the only clue when the
             // validator hangs while loading a bundle.
             child.kill()?;
@@ -551,10 +591,13 @@ fn ensure_aax_validator_dtt(ctx: &Context) -> Result<PathBuf> {
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .status();
-        run(Command::new("chmod")
-            .arg("+x")
-            .arg(&dtt)
-            .current_dir(&ctx.root))?;
+        run_with_language(
+            Command::new("chmod")
+                .arg("+x")
+                .arg(&dtt)
+                .current_dir(&ctx.root),
+            ctx.output_language,
+        )?;
     }
     Ok(dtt)
 }
@@ -623,20 +666,26 @@ fn aax_validator_dsh_root(ctx: &Context) -> Result<PathBuf> {
         // Windows validator downloads are zip archives. GitHub-hosted Windows runners
         // provide 7-Zip, and using it here avoids relying on tar implementations that
         // only support tar streams.
-        run(Command::new("7z")
-            .arg("x")
-            .arg(&archive)
-            .arg(format!("-o{}", extracted_root.display()))
-            .arg("-y")
-            .current_dir(&ctx.root))?;
+        run_with_language(
+            Command::new("7z")
+                .arg("x")
+                .arg(&archive)
+                .arg(format!("-o{}", extracted_root.display()))
+                .arg("-y")
+                .current_dir(&ctx.root),
+            ctx.output_language,
+        )?;
     } else {
-        run(Command::new("tar")
-            .arg("-xf")
-            .arg(&archive)
-            .arg("--strip-components=1")
-            .arg("-C")
-            .arg(&extracted_root)
-            .current_dir(&ctx.root))?;
+        run_with_language(
+            Command::new("tar")
+                .arg("-xf")
+                .arg(&archive)
+                .arg("--strip-components=1")
+                .arg("-C")
+                .arg(&extracted_root)
+                .current_dir(&ctx.root),
+            ctx.output_language,
+        )?;
     }
     Ok(extracted_root)
 }
@@ -700,37 +749,49 @@ fn ensure_clap_validator(ctx: &Context) -> Result<PathBuf> {
         let url = format!(
             "https://github.com/free-audio/clap-validator/releases/download/{CLAP_VALIDATOR_VERSION}/{archive_name}"
         );
-        run(Command::new("curl")
-            .args(["-L", "--fail", "-o"])
-            .arg(&archive)
-            .arg(url)
-            .current_dir(&ctx.root))?;
+        run_with_language(
+            Command::new("curl")
+                .args(["-L", "--fail", "-o"])
+                .arg(&archive)
+                .arg(url)
+                .current_dir(&ctx.root),
+            ctx.output_language,
+        )?;
     }
 
     if archive_name.ends_with(".zip") {
         // Windows runners provide bsdtar as `tar`, and it can extract zip files.
         // Using it here keeps argument passing identical to the tar.gz path.
-        run(Command::new("tar")
-            .arg("-xf")
-            .arg(&archive)
-            .arg("-C")
-            .arg(&validator_dir)
-            .current_dir(&ctx.root))?;
+        run_with_language(
+            Command::new("tar")
+                .arg("-xf")
+                .arg(&archive)
+                .arg("-C")
+                .arg(&validator_dir)
+                .current_dir(&ctx.root),
+            ctx.output_language,
+        )?;
     } else {
-        run(Command::new("tar")
-            .args(["-xzf"])
-            .arg(&archive)
-            .arg("-C")
-            .arg(&validator_dir)
-            .current_dir(&ctx.root))?;
+        run_with_language(
+            Command::new("tar")
+                .args(["-xzf"])
+                .arg(&archive)
+                .arg("-C")
+                .arg(&validator_dir)
+                .current_dir(&ctx.root),
+            ctx.output_language,
+        )?;
     }
 
     ensure_exists(&validator, "CLAP validator")?;
     if ctx.platform != Platform::Windows {
-        run(Command::new("chmod")
-            .arg("+x")
-            .arg(&validator)
-            .current_dir(&ctx.root))?;
+        run_with_language(
+            Command::new("chmod")
+                .arg("+x")
+                .arg(&validator)
+                .current_dir(&ctx.root),
+            ctx.output_language,
+        )?;
     }
     Ok(validator)
 }
@@ -804,7 +865,7 @@ fn ensure_vst3_validator(ctx: &Context) -> Result<PathBuf> {
     if ctx.platform == Platform::Macos {
         configure.arg("-G").arg("Xcode");
     }
-    run(configure.current_dir(&ctx.root))?;
+    run_with_language(configure.current_dir(&ctx.root), ctx.output_language)?;
 
     let mut build = Command::new("cmake");
     build
@@ -824,9 +885,9 @@ fn ensure_vst3_validator(ctx: &Context) -> Result<PathBuf> {
 
     let build = build.current_dir(&ctx.root);
     if ctx.platform == Platform::Macos {
-        run_with_optional_xcbeautify(build)?;
+        run_with_optional_xcbeautify_language(build, ctx.output_language)?;
     } else {
-        run(build)?;
+        run_with_language(build, ctx.output_language)?;
     }
 
     if validator.exists() {

--- a/crates/wrac_xtask/src/context.rs
+++ b/crates/wrac_xtask/src/context.rs
@@ -5,7 +5,7 @@ use cargo_metadata::MetadataCommand;
 use crate::metadata::{PluginMetadata, PluginProductMetadata};
 use crate::profile::BuildProfile;
 use crate::targets::Platform;
-use crate::{Result, WracPluginPackage, XtaskConfig};
+use crate::{Result, WracPluginPackage, XtaskConfig, XtaskOutputLanguage};
 
 pub(crate) struct Context {
     pub(crate) root: PathBuf,
@@ -16,6 +16,7 @@ pub(crate) struct Context {
     pub(crate) target_dir: PathBuf,
     pub(crate) wrapper_dir: PathBuf,
     pub(crate) default_aax_sdk_root: Option<PathBuf>,
+    pub(crate) output_language: XtaskOutputLanguage,
     pub(crate) metadata: PluginMetadata,
 }
 
@@ -51,6 +52,7 @@ impl Context {
             target_dir,
             wrapper_dir,
             default_aax_sdk_root: config.default_aax_sdk_root.clone(),
+            output_language: config.output_language,
             metadata,
         })
     }

--- a/crates/wrac_xtask/src/lib.rs
+++ b/crates/wrac_xtask/src/lib.rs
@@ -45,6 +45,14 @@ pub struct XtaskConfig {
     pub wrapper_dir: PathBuf,
     pub target_namespace: String,
     pub default_aax_sdk_root: Option<PathBuf>,
+    pub output_language: XtaskOutputLanguage,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum XtaskOutputLanguage {
+    #[default]
+    English,
+    Japanese,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/wrac_xtask/src/plan.rs
+++ b/crates/wrac_xtask/src/plan.rs
@@ -6,6 +6,7 @@ use petgraph::graph::{DiGraph, NodeIndex};
 use petgraph::visit::EdgeRef;
 
 use crate::Result;
+use crate::XtaskOutputLanguage;
 use crate::cli::{BuildArgs, InstallArgs, UninstallArgs, ValidateArgs};
 use crate::commands::{
     RustPluginBuild, WrapperBuild, WrapperTarget, build_gui, build_rust_plugin,
@@ -17,8 +18,14 @@ use crate::context::Context;
 use crate::profile::BuildProfile;
 use crate::targets::{PluginTarget, Target, ValidateTarget};
 
+mod output;
 mod target_resolution;
 
+use self::output::{
+    completed_label, dependencies_heading, dry_run_message, execution_heading, failed_label,
+    plan_heading, result_heading, skip_reason, skipped_label, status_label, success_label,
+    uninstall_summary,
+};
 use self::target_resolution::{
     resolve_build_targets_from_metadata, resolve_plugin_targets_from_metadata,
     resolve_validate_targets_from_metadata,
@@ -69,8 +76,8 @@ struct Task {
 }
 
 impl Task {
-    fn label(&self) -> String {
-        self.kind.label()
+    fn label(&self, language: XtaskOutputLanguage) -> String {
+        self.kind.label(language)
     }
 }
 
@@ -115,14 +122,29 @@ enum TaskKind {
 }
 
 impl TaskKind {
-    fn label(&self) -> String {
-        match self {
-            Self::Clean => "生成済み成果物を削除".to_string(),
-            Self::BuildGui => "GUI をビルド".to_string(),
-            Self::BuildRustDefault => "Rust プラグインライブラリをビルド".to_string(),
-            Self::BuildRustStandalone => "Rust standalone ライブラリをビルド".to_string(),
-            Self::PackageClap => "CLAP bundle をパッケージ".to_string(),
-            Self::ConfigureWrapperPlugins { vst3, au } => {
+    fn label(&self, language: XtaskOutputLanguage) -> String {
+        match (language, self) {
+            (XtaskOutputLanguage::English, Self::Clean) => "clean generated artifacts".to_string(),
+            (XtaskOutputLanguage::Japanese, Self::Clean) => "生成済み成果物を削除".to_string(),
+            (XtaskOutputLanguage::English, Self::BuildGui) => "build GUI".to_string(),
+            (XtaskOutputLanguage::Japanese, Self::BuildGui) => "GUI をビルド".to_string(),
+            (XtaskOutputLanguage::English, Self::BuildRustDefault) => {
+                "build Rust plugin library".to_string()
+            }
+            (XtaskOutputLanguage::Japanese, Self::BuildRustDefault) => {
+                "Rust プラグインライブラリをビルド".to_string()
+            }
+            (XtaskOutputLanguage::English, Self::BuildRustStandalone) => {
+                "build Rust standalone library".to_string()
+            }
+            (XtaskOutputLanguage::Japanese, Self::BuildRustStandalone) => {
+                "Rust standalone ライブラリをビルド".to_string()
+            }
+            (XtaskOutputLanguage::English, Self::PackageClap) => "package CLAP bundle".to_string(),
+            (XtaskOutputLanguage::Japanese, Self::PackageClap) => {
+                "CLAP bundle をパッケージ".to_string()
+            }
+            (language, Self::ConfigureWrapperPlugins { vst3, au }) => {
                 let mut formats = Vec::new();
                 if *vst3 {
                     formats.push("VST3");
@@ -130,41 +152,110 @@ impl TaskKind {
                 if *au {
                     formats.push("AU");
                 }
-                format!("clap-wrapper を設定 ({})", formats.join(", "))
+                match language {
+                    XtaskOutputLanguage::English => {
+                        format!("configure clap-wrapper ({})", formats.join(", "))
+                    }
+                    XtaskOutputLanguage::Japanese => {
+                        format!("clap-wrapper を設定 ({})", formats.join(", "))
+                    }
+                }
             }
-            Self::ConfigureWrapperAax => "clap-wrapper を設定 (AAX)".to_string(),
-            Self::ConfigureWrapperStandalone => "clap-wrapper を設定 (standalone)".to_string(),
-            Self::BuildVst3Bundle => "VST3 bundle をビルド".to_string(),
-            Self::BuildAuBundle => "AU bundle をビルド".to_string(),
-            Self::BuildAaxBundle => "AAX bundle をビルド".to_string(),
-            Self::BuildStandaloneBundle { plugin_id } => match plugin_id {
-                Some(plugin_id) => format!("standalone 成果物をビルド ({plugin_id})"),
-                None => "standalone 成果物をビルド".to_string(),
-            },
-            Self::CheckInstallScope { target, scope } => {
+            (XtaskOutputLanguage::English, Self::ConfigureWrapperAax) => {
+                "configure clap-wrapper (AAX)".to_string()
+            }
+            (XtaskOutputLanguage::Japanese, Self::ConfigureWrapperAax) => {
+                "clap-wrapper を設定 (AAX)".to_string()
+            }
+            (XtaskOutputLanguage::English, Self::ConfigureWrapperStandalone) => {
+                "configure clap-wrapper (standalone)".to_string()
+            }
+            (XtaskOutputLanguage::Japanese, Self::ConfigureWrapperStandalone) => {
+                "clap-wrapper を設定 (standalone)".to_string()
+            }
+            (XtaskOutputLanguage::English, Self::BuildVst3Bundle) => {
+                "build VST3 bundle".to_string()
+            }
+            (XtaskOutputLanguage::Japanese, Self::BuildVst3Bundle) => {
+                "VST3 bundle をビルド".to_string()
+            }
+            (XtaskOutputLanguage::English, Self::BuildAuBundle) => "build AU bundle".to_string(),
+            (XtaskOutputLanguage::Japanese, Self::BuildAuBundle) => {
+                "AU bundle をビルド".to_string()
+            }
+            (XtaskOutputLanguage::English, Self::BuildAaxBundle) => "build AAX bundle".to_string(),
+            (XtaskOutputLanguage::Japanese, Self::BuildAaxBundle) => {
+                "AAX bundle をビルド".to_string()
+            }
+            (XtaskOutputLanguage::English, Self::BuildStandaloneBundle { plugin_id }) => {
+                match plugin_id {
+                    Some(plugin_id) => format!("build standalone artifact ({plugin_id})"),
+                    None => "build standalone artifact".to_string(),
+                }
+            }
+            (XtaskOutputLanguage::Japanese, Self::BuildStandaloneBundle { plugin_id }) => {
+                match plugin_id {
+                    Some(plugin_id) => format!("standalone 成果物をビルド ({plugin_id})"),
+                    None => "standalone 成果物をビルド".to_string(),
+                }
+            }
+            (XtaskOutputLanguage::English, Self::CheckInstallScope { target, scope }) => {
+                format!("check install scope for {} ({scope:?})", target.display())
+            }
+            (XtaskOutputLanguage::Japanese, Self::CheckInstallScope { target, scope }) => {
                 format!("{} のインストール先を確認 ({scope:?})", target.display())
             }
-            Self::InstallBundle { target, scope } => {
+            (XtaskOutputLanguage::English, Self::InstallBundle { target, scope }) => {
+                format!("install {} ({scope:?})", target.display())
+            }
+            (XtaskOutputLanguage::Japanese, Self::InstallBundle { target, scope }) => {
                 format!("{} をインストール ({scope:?})", target.display())
             }
-            Self::UninstallBundle {
-                target, dry_run, ..
-            } => {
+            (
+                XtaskOutputLanguage::English,
+                Self::UninstallBundle {
+                    target, dry_run, ..
+                },
+            ) => {
+                if *dry_run {
+                    format!("plan uninstall {}", target.display())
+                } else {
+                    format!("uninstall {}", target.display())
+                }
+            }
+            (
+                XtaskOutputLanguage::Japanese,
+                Self::UninstallBundle {
+                    target, dry_run, ..
+                },
+            ) => {
                 if *dry_run {
                     format!("{} のアンインストール内容を確認", target.display())
                 } else {
                     format!("{} をアンインストール", target.display())
                 }
             }
-            Self::ValidateWracRules { targets } => {
+            (language, Self::ValidateWracRules { targets }) => {
                 let targets = targets
                     .iter()
                     .map(|target| target.display())
                     .collect::<Vec<_>>()
                     .join(", ");
-                format!("WRAC production-readiness checks を実行 ({targets})")
+                match language {
+                    XtaskOutputLanguage::English => {
+                        format!("run WRAC production-readiness checks ({targets})")
+                    }
+                    XtaskOutputLanguage::Japanese => {
+                        format!("WRAC production-readiness checks を実行 ({targets})")
+                    }
+                }
             }
-            Self::ValidateBundle { target } => format!("{} を検証", target.display()),
+            (XtaskOutputLanguage::English, Self::ValidateBundle { target }) => {
+                format!("validate {}", target.display())
+            }
+            (XtaskOutputLanguage::Japanese, Self::ValidateBundle { target }) => {
+                format!("{} を検証", target.display())
+            }
         }
     }
 }
@@ -638,7 +729,8 @@ fn execute_plan(
     policy: FailurePolicy,
 ) -> Result<()> {
     let ordered = graph.ordered()?;
-    print_plan(&graph, &ordered, dry_run);
+    let language = ctx.output_language;
+    print_plan(&graph, &ordered, dry_run, language);
     if dry_run {
         return Ok(());
     }
@@ -666,10 +758,7 @@ fn execute_plan(
             .collect::<Vec<_>>();
         if !failed_deps.is_empty() {
             println!("{}\n  ⏭️ スキップ", graph.graph[index].id);
-            println!(
-                "  理由: 依存タスクが失敗またはスキップされました ({})",
-                failed_deps.join(", ")
-            );
+            println!("  {}", skip_reason(language, &failed_deps));
             println!();
             statuses.insert(index, TaskStatus::Skipped);
             continue;
@@ -678,21 +767,21 @@ fn execute_plan(
         println!(
             "{}\n  {}",
             graph.graph[index].id,
-            graph.graph[index].label()
+            graph.graph[index].label(language)
         );
         match run_task(ctx, profile, &graph.graph[index].kind) {
             Ok(()) => {
-                println!("  ✅ 完了");
+                println!("  ✅ {}", completed_label(language));
                 println!();
                 statuses.insert(index, TaskStatus::Ok);
             }
             Err(err) => {
-                println!("  ❌ 失敗");
+                println!("  ❌ {}", failed_label(language));
                 println!("  Error: {err}");
                 statuses.insert(index, TaskStatus::Failed);
                 failures.push(format!("{}: {err}", graph.graph[index].id));
                 if matches!(policy, FailurePolicy::FailFast) {
-                    print_summary(&graph, &statuses);
+                    print_summary(&graph, &statuses, language);
                     return Err(failures.join("\n").into());
                 }
                 println!();
@@ -700,7 +789,7 @@ fn execute_plan(
         }
     }
 
-    print_summary(&graph, &statuses);
+    print_summary(&graph, &statuses, language);
     if failures.is_empty() {
         Ok(())
     } else {
@@ -773,17 +862,13 @@ fn run_task(ctx: &Context, profile: BuildProfile, kind: &TaskKind) -> Result<()>
             let (removed, missing) = uninstall_plugin_target(ctx, *scope, *target, *dry_run)?;
             if *dry_run {
                 println!(
-                    "  内訳: {} {}、{}",
-                    target.display(),
-                    count_with_unit(removed, "件削除予定"),
-                    count_with_unit(missing, "件なし"),
+                    "  {}",
+                    uninstall_summary(ctx.output_language, *target, removed, missing, true)
                 );
             } else {
                 println!(
-                    "  内訳: {} {}、{}",
-                    target.display(),
-                    count_with_unit(removed, "件削除"),
-                    count_with_unit(missing, "件なし"),
+                    "  {}",
+                    uninstall_summary(ctx.output_language, *target, removed, missing, false)
                 );
             }
             Ok(())
@@ -795,14 +880,19 @@ fn run_task(ctx: &Context, profile: BuildProfile, kind: &TaskKind) -> Result<()>
     }
 }
 
-fn print_plan(graph: &TaskGraph, ordered: &[NodeIndex], dry_run: bool) {
-    println!("== 実行計画 ==\n");
+fn print_plan(
+    graph: &TaskGraph,
+    ordered: &[NodeIndex],
+    dry_run: bool,
+    language: XtaskOutputLanguage,
+) {
+    println!("== {} ==\n", plan_heading(language));
     for (position, index) in ordered.iter().enumerate() {
         println!(
             "{}. {}  {}",
             position + 1,
             graph.graph[*index].id,
-            graph.graph[*index].label()
+            graph.graph[*index].label(language)
         );
     }
     let dependencies = ordered
@@ -817,49 +907,46 @@ fn print_plan(graph: &TaskGraph, ordered: &[NodeIndex], dry_run: bool) {
         })
         .collect::<Vec<_>>();
     if !dependencies.is_empty() {
-        println!("\n== 依存関係 ==\n");
+        println!("\n== {} ==\n", dependencies_heading(language));
     }
     for (index, deps) in dependencies {
         println!("{} <- {}", graph.graph[*index].id, deps.join(", "));
     }
     if dry_run {
-        println!("\n--dry-run が指定されているため、実行はスキップしました。");
+        println!("\n{}", dry_run_message(language));
     } else {
-        println!("\n== 実行 ==\n");
+        println!("\n== {} ==\n", execution_heading(language));
     }
 }
 
-fn print_summary(graph: &TaskGraph, statuses: &HashMap<NodeIndex, TaskStatus>) {
+fn print_summary(
+    graph: &TaskGraph,
+    statuses: &HashMap<NodeIndex, TaskStatus>,
+    language: XtaskOutputLanguage,
+) {
     let mut counts = HashMap::<TaskStatus, usize>::new();
     for status in statuses.values() {
         *counts.entry(*status).or_default() += 1;
     }
     println!(
-        "== 結果 ==\n\n✅ 成功 {} / ❌ 失敗 {} / ⏭️ スキップ {}",
+        "== {} ==\n\n✅ {} {} / ❌ {} {} / ⏭️ {} {}",
+        result_heading(language),
+        success_label(language),
         counts.get(&TaskStatus::Ok).copied().unwrap_or(0),
+        failed_label(language),
         counts.get(&TaskStatus::Failed).copied().unwrap_or(0),
+        skipped_label(language),
         counts.get(&TaskStatus::Skipped).copied().unwrap_or(0)
     );
     for (index, status) in statuses {
         if matches!(status, TaskStatus::Failed | TaskStatus::Skipped) {
-            println!("{}: {}", status.label(), graph.graph[*index].id);
+            println!(
+                "{}: {}",
+                status_label(language, *status),
+                graph.graph[*index].id
+            );
         }
     }
-}
-
-impl TaskStatus {
-    fn label(self) -> &'static str {
-        match self {
-            Self::Planned => "未実行",
-            Self::Ok => "成功",
-            Self::Failed => "失敗",
-            Self::Skipped => "スキップ",
-        }
-    }
-}
-
-fn count_with_unit(count: usize, unit: &str) -> String {
-    format!("{count}{unit}")
 }
 
 fn package_task_id(ctx: &Context, task: &str) -> TaskId {

--- a/crates/wrac_xtask/src/plan.rs
+++ b/crates/wrac_xtask/src/plan.rs
@@ -813,7 +813,7 @@ fn print_plan(graph: &TaskGraph, ordered: &[NodeIndex], dry_run: bool) {
                 .neighbors_directed(*index, Direction::Incoming)
                 .map(|dep| graph.graph[dep].id.to_string())
                 .collect::<Vec<_>>();
-            (!deps.is_empty()).then(|| (index, deps))
+            (!deps.is_empty()).then_some((index, deps))
         })
         .collect::<Vec<_>>();
     if !dependencies.is_empty() {

--- a/crates/wrac_xtask/src/plan.rs
+++ b/crates/wrac_xtask/src/plan.rs
@@ -757,7 +757,11 @@ fn execute_plan(
             .map(|dep| graph.graph[dep].id.to_string())
             .collect::<Vec<_>>();
         if !failed_deps.is_empty() {
-            println!("{}\n  ⏭️ スキップ", graph.graph[index].id);
+            println!(
+                "{}\n  ⏭️ {}",
+                graph.graph[index].id,
+                skipped_label(language)
+            );
             println!("  {}", skip_reason(language, &failed_deps));
             println!();
             statuses.insert(index, TaskStatus::Skipped);

--- a/crates/wrac_xtask/src/plan.rs
+++ b/crates/wrac_xtask/src/plan.rs
@@ -117,11 +117,11 @@ enum TaskKind {
 impl TaskKind {
     fn label(&self) -> String {
         match self {
-            Self::Clean => "clean generated artifacts".to_string(),
-            Self::BuildGui => "build GUI".to_string(),
-            Self::BuildRustDefault => "build Rust plugin library".to_string(),
-            Self::BuildRustStandalone => "build Rust standalone library".to_string(),
-            Self::PackageClap => "package CLAP bundle".to_string(),
+            Self::Clean => "生成済み成果物を削除".to_string(),
+            Self::BuildGui => "GUI をビルド".to_string(),
+            Self::BuildRustDefault => "Rust プラグインライブラリをビルド".to_string(),
+            Self::BuildRustStandalone => "Rust standalone ライブラリをビルド".to_string(),
+            Self::PackageClap => "CLAP bundle をパッケージ".to_string(),
             Self::ConfigureWrapperPlugins { vst3, au } => {
                 let mut formats = Vec::new();
                 if *vst3 {
@@ -130,30 +130,30 @@ impl TaskKind {
                 if *au {
                     formats.push("AU");
                 }
-                format!("configure clap-wrapper ({})", formats.join(", "))
+                format!("clap-wrapper を設定 ({})", formats.join(", "))
             }
-            Self::ConfigureWrapperAax => "configure clap-wrapper (AAX)".to_string(),
-            Self::ConfigureWrapperStandalone => "configure clap-wrapper (standalone)".to_string(),
-            Self::BuildVst3Bundle => "build VST3 bundle".to_string(),
-            Self::BuildAuBundle => "build AU bundle".to_string(),
-            Self::BuildAaxBundle => "build AAX bundle".to_string(),
+            Self::ConfigureWrapperAax => "clap-wrapper を設定 (AAX)".to_string(),
+            Self::ConfigureWrapperStandalone => "clap-wrapper を設定 (standalone)".to_string(),
+            Self::BuildVst3Bundle => "VST3 bundle をビルド".to_string(),
+            Self::BuildAuBundle => "AU bundle をビルド".to_string(),
+            Self::BuildAaxBundle => "AAX bundle をビルド".to_string(),
             Self::BuildStandaloneBundle { plugin_id } => match plugin_id {
-                Some(plugin_id) => format!("build standalone artifact ({plugin_id})"),
-                None => "build standalone artifact".to_string(),
+                Some(plugin_id) => format!("standalone 成果物をビルド ({plugin_id})"),
+                None => "standalone 成果物をビルド".to_string(),
             },
             Self::CheckInstallScope { target, scope } => {
-                format!("check install scope for {} ({scope:?})", target.display())
+                format!("{} のインストール先を確認 ({scope:?})", target.display())
             }
             Self::InstallBundle { target, scope } => {
-                format!("install {} ({scope:?})", target.display())
+                format!("{} をインストール ({scope:?})", target.display())
             }
             Self::UninstallBundle {
                 target, dry_run, ..
             } => {
                 if *dry_run {
-                    format!("plan uninstall {}", target.display())
+                    format!("{} のアンインストール内容を確認", target.display())
                 } else {
-                    format!("uninstall {}", target.display())
+                    format!("{} をアンインストール", target.display())
                 }
             }
             Self::ValidateWracRules { targets } => {
@@ -162,9 +162,9 @@ impl TaskKind {
                     .map(|target| target.display())
                     .collect::<Vec<_>>()
                     .join(", ");
-                format!("run WRAC production-readiness checks ({targets})")
+                format!("WRAC production-readiness checks を実行 ({targets})")
             }
-            Self::ValidateBundle { target } => format!("validate {}", target.display()),
+            Self::ValidateBundle { target } => format!("{} を検証", target.display()),
         }
     }
 }
@@ -665,32 +665,37 @@ fn execute_plan(
             .map(|dep| graph.graph[dep].id.to_string())
             .collect::<Vec<_>>();
         if !failed_deps.is_empty() {
+            println!("{}\n  ⏭️ スキップ", graph.graph[index].id);
             println!(
-                "SKIP {}: depends on {}",
-                graph.graph[index].id,
+                "  理由: 依存タスクが失敗またはスキップされました ({})",
                 failed_deps.join(", ")
             );
+            println!();
             statuses.insert(index, TaskStatus::Skipped);
             continue;
         }
 
         println!(
-            "TASK {}: {}",
+            "{}\n  {}",
             graph.graph[index].id,
             graph.graph[index].label()
         );
         match run_task(ctx, profile, &graph.graph[index].kind) {
             Ok(()) => {
+                println!("  ✅ 完了");
+                println!();
                 statuses.insert(index, TaskStatus::Ok);
             }
             Err(err) => {
-                println!("FAILED {}: {err}", graph.graph[index].id);
+                println!("  ❌ 失敗");
+                println!("  Error: {err}");
                 statuses.insert(index, TaskStatus::Failed);
                 failures.push(format!("{}: {err}", graph.graph[index].id));
                 if matches!(policy, FailurePolicy::FailFast) {
                     print_summary(&graph, &statuses);
                     return Err(failures.join("\n").into());
                 }
+                println!();
             }
         }
     }
@@ -768,13 +773,17 @@ fn run_task(ctx: &Context, profile: BuildProfile, kind: &TaskKind) -> Result<()>
             let (removed, missing) = uninstall_plugin_target(ctx, *scope, *target, *dry_run)?;
             if *dry_run {
                 println!(
-                    "Uninstall dry run complete for {}: {removed} would be removed, {missing} not found",
-                    target.display()
+                    "  内訳: {} {}、{}",
+                    target.display(),
+                    count_with_unit(removed, "件削除予定"),
+                    count_with_unit(missing, "件なし"),
                 );
             } else {
                 println!(
-                    "Uninstall complete for {}: {removed} removed, {missing} not found",
-                    target.display()
+                    "  内訳: {} {}、{}",
+                    target.display(),
+                    count_with_unit(removed, "件削除"),
+                    count_with_unit(missing, "件なし"),
                 );
             }
             Ok(())
@@ -787,28 +796,36 @@ fn run_task(ctx: &Context, profile: BuildProfile, kind: &TaskKind) -> Result<()>
 }
 
 fn print_plan(graph: &TaskGraph, ordered: &[NodeIndex], dry_run: bool) {
-    println!("Plan:");
+    println!("== 実行計画 ==\n");
     for (position, index) in ordered.iter().enumerate() {
         println!(
-            "  {}. {} - {}",
+            "{}. {}  {}",
             position + 1,
             graph.graph[*index].id,
             graph.graph[*index].label()
         );
     }
-    println!("Dependencies:");
-    for index in ordered {
-        let deps = graph
-            .graph
-            .neighbors_directed(*index, Direction::Incoming)
-            .map(|dep| graph.graph[dep].id.to_string())
-            .collect::<Vec<_>>();
-        if !deps.is_empty() {
-            println!("  {} <- {}", graph.graph[*index].id, deps.join(", "));
-        }
+    let dependencies = ordered
+        .iter()
+        .filter_map(|index| {
+            let deps = graph
+                .graph
+                .neighbors_directed(*index, Direction::Incoming)
+                .map(|dep| graph.graph[dep].id.to_string())
+                .collect::<Vec<_>>();
+            (!deps.is_empty()).then(|| (index, deps))
+        })
+        .collect::<Vec<_>>();
+    if !dependencies.is_empty() {
+        println!("\n== 依存関係 ==\n");
+    }
+    for (index, deps) in dependencies {
+        println!("{} <- {}", graph.graph[*index].id, deps.join(", "));
     }
     if dry_run {
-        println!("Nothing was executed because --dry-run was set.");
+        println!("\n--dry-run が指定されているため、実行はスキップしました。");
+    } else {
+        println!("\n== 実行 ==\n");
     }
 }
 
@@ -818,16 +835,31 @@ fn print_summary(graph: &TaskGraph, statuses: &HashMap<NodeIndex, TaskStatus>) {
         *counts.entry(*status).or_default() += 1;
     }
     println!(
-        "Task summary: {} ok, {} failed, {} skipped",
+        "== 結果 ==\n\n✅ 成功 {} / ❌ 失敗 {} / ⏭️ スキップ {}",
         counts.get(&TaskStatus::Ok).copied().unwrap_or(0),
         counts.get(&TaskStatus::Failed).copied().unwrap_or(0),
         counts.get(&TaskStatus::Skipped).copied().unwrap_or(0)
     );
     for (index, status) in statuses {
         if matches!(status, TaskStatus::Failed | TaskStatus::Skipped) {
-            println!("  {status:?}: {}", graph.graph[*index].id);
+            println!("{}: {}", status.label(), graph.graph[*index].id);
         }
     }
+}
+
+impl TaskStatus {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Planned => "未実行",
+            Self::Ok => "成功",
+            Self::Failed => "失敗",
+            Self::Skipped => "スキップ",
+        }
+    }
+}
+
+fn count_with_unit(count: usize, unit: &str) -> String {
+    format!("{count}{unit}")
 }
 
 fn package_task_id(ctx: &Context, task: &str) -> TaskId {

--- a/crates/wrac_xtask/src/plan/output.rs
+++ b/crates/wrac_xtask/src/plan/output.rs
@@ -1,0 +1,136 @@
+use crate::XtaskOutputLanguage;
+use crate::targets::PluginTarget;
+
+use super::TaskStatus;
+
+pub(super) fn status_label(language: XtaskOutputLanguage, status: TaskStatus) -> &'static str {
+    match (language, status) {
+        (XtaskOutputLanguage::English, TaskStatus::Planned) => "planned",
+        (XtaskOutputLanguage::Japanese, TaskStatus::Planned) => "未実行",
+        (XtaskOutputLanguage::English, TaskStatus::Ok) => "ok",
+        (XtaskOutputLanguage::Japanese, TaskStatus::Ok) => "成功",
+        (XtaskOutputLanguage::English, TaskStatus::Failed) => "failed",
+        (XtaskOutputLanguage::Japanese, TaskStatus::Failed) => "失敗",
+        (XtaskOutputLanguage::English, TaskStatus::Skipped) => "skipped",
+        (XtaskOutputLanguage::Japanese, TaskStatus::Skipped) => "スキップ",
+    }
+}
+
+pub(super) fn plan_heading(language: XtaskOutputLanguage) -> &'static str {
+    match language {
+        XtaskOutputLanguage::English => "Plan",
+        XtaskOutputLanguage::Japanese => "実行計画",
+    }
+}
+
+pub(super) fn dependencies_heading(language: XtaskOutputLanguage) -> &'static str {
+    match language {
+        XtaskOutputLanguage::English => "Dependencies",
+        XtaskOutputLanguage::Japanese => "依存関係",
+    }
+}
+
+pub(super) fn execution_heading(language: XtaskOutputLanguage) -> &'static str {
+    match language {
+        XtaskOutputLanguage::English => "Execution",
+        XtaskOutputLanguage::Japanese => "実行",
+    }
+}
+
+pub(super) fn result_heading(language: XtaskOutputLanguage) -> &'static str {
+    match language {
+        XtaskOutputLanguage::English => "Result",
+        XtaskOutputLanguage::Japanese => "結果",
+    }
+}
+
+pub(super) fn completed_label(language: XtaskOutputLanguage) -> &'static str {
+    match language {
+        XtaskOutputLanguage::English => "completed",
+        XtaskOutputLanguage::Japanese => "完了",
+    }
+}
+
+pub(super) fn success_label(language: XtaskOutputLanguage) -> &'static str {
+    match language {
+        XtaskOutputLanguage::English => "ok",
+        XtaskOutputLanguage::Japanese => "成功",
+    }
+}
+
+pub(super) fn failed_label(language: XtaskOutputLanguage) -> &'static str {
+    match language {
+        XtaskOutputLanguage::English => "failed",
+        XtaskOutputLanguage::Japanese => "失敗",
+    }
+}
+
+pub(super) fn skipped_label(language: XtaskOutputLanguage) -> &'static str {
+    match language {
+        XtaskOutputLanguage::English => "skipped",
+        XtaskOutputLanguage::Japanese => "スキップ",
+    }
+}
+
+pub(super) fn dry_run_message(language: XtaskOutputLanguage) -> &'static str {
+    match language {
+        XtaskOutputLanguage::English => "Nothing was executed because --dry-run was set.",
+        XtaskOutputLanguage::Japanese => "--dry-run が指定されているため、実行はスキップしました。",
+    }
+}
+
+pub(super) fn skip_reason(language: XtaskOutputLanguage, failed_deps: &[String]) -> String {
+    match language {
+        XtaskOutputLanguage::English => {
+            format!(
+                "Reason: dependency failed or was skipped ({})",
+                failed_deps.join(", ")
+            )
+        }
+        XtaskOutputLanguage::Japanese => {
+            format!(
+                "理由: 依存タスクが失敗またはスキップされました ({})",
+                failed_deps.join(", ")
+            )
+        }
+    }
+}
+
+pub(super) fn uninstall_summary(
+    language: XtaskOutputLanguage,
+    target: PluginTarget,
+    removed: usize,
+    missing: usize,
+    dry_run: bool,
+) -> String {
+    match (language, dry_run) {
+        (XtaskOutputLanguage::English, true) => format!(
+            "Summary: {} {} would be removed, {} not found",
+            target.display(),
+            removed,
+            missing
+        ),
+        (XtaskOutputLanguage::English, false) => format!(
+            "Summary: {} {} removed, {} not found",
+            target.display(),
+            removed,
+            missing
+        ),
+        (XtaskOutputLanguage::Japanese, true) => format!(
+            "内訳: {} {}、{}",
+            target.display(),
+            count_with_unit(removed, "件削除予定"),
+            count_with_unit(missing, "件なし")
+        ),
+        (XtaskOutputLanguage::Japanese, false) => format!(
+            "内訳: {} {}、{}",
+            target.display(),
+            count_with_unit(removed, "件削除"),
+            count_with_unit(missing, "件なし")
+        ),
+    }
+}
+
+fn count_with_unit(count: usize, unit: &str) -> String {
+    format!("{count}{unit}")
+}

--- a/crates/wrac_xtask/src/plan/target_resolution.rs
+++ b/crates/wrac_xtask/src/plan/target_resolution.rs
@@ -1,8 +1,8 @@
 use std::collections::HashSet;
 
-use crate::Result;
 use crate::context::Context;
 use crate::targets::{PluginFormat, PluginTarget, Target, ValidateTarget};
+use crate::{Result, XtaskOutputLanguage};
 
 pub(super) fn resolve_build_targets_from_metadata(
     ctx: &Context,
@@ -103,11 +103,18 @@ fn filter_platform_targets(ctx: &Context, targets: Vec<Target>) -> Vec<Target> {
         .filter(|target| {
             let supported = ctx.platform.supports_target(*target);
             if !supported {
-                println!(
-                    "Skipping {}: not supported on {}.",
-                    target.display(),
-                    ctx.platform.display()
-                );
+                match ctx.output_language {
+                    XtaskOutputLanguage::English => println!(
+                        "  ⏭️ Skipping {}: not supported on {}.",
+                        target.display(),
+                        ctx.platform.display()
+                    ),
+                    XtaskOutputLanguage::Japanese => println!(
+                        "  ⏭️ スキップ {}: {} では未対応",
+                        target.display(),
+                        ctx.platform.display()
+                    ),
+                }
             }
             supported
         })

--- a/crates/wrac_xtask/src/util.rs
+++ b/crates/wrac_xtask/src/util.rs
@@ -7,7 +7,7 @@ use std::process::{Command, Output, Stdio};
 use std::sync::{Arc, Mutex};
 use std::thread;
 
-use crate::Result;
+use crate::{Result, XtaskOutputLanguage};
 
 pub(crate) fn copy_path(from: &Path, to: &Path) -> Result<()> {
     if from.is_dir() {
@@ -41,30 +41,30 @@ pub(crate) fn ensure_exists(path: &Path, description: &str) -> Result<()> {
     }
 }
 
-pub(crate) fn run(command: &mut Command) -> Result<()> {
+pub(crate) fn run_with_language(
+    command: &mut Command,
+    language: XtaskOutputLanguage,
+) -> Result<()> {
     // xtask is a build orchestrator, so seeing the exact external command on failure is important.
     // Run directly via Command without a shell, but print in a form that humans can re-run easily.
-    println!();
-    println!("========== Running command ==========");
+    print_section(language, "Running command", "コマンド実行");
     println!("$ {}", format_command(command));
     let status = command.status()?;
     if !status.success() {
-        return Err(format!(
-            "command failed with status {status}: {}",
-            format_command(command)
-        )
-        .into());
+        return Err(command_failed_message(language, status, &format_command(command)).into());
     }
     Ok(())
 }
 
-pub(crate) fn run_with_optional_xcbeautify(command: &mut Command) -> Result<()> {
+pub(crate) fn run_with_optional_xcbeautify_language(
+    command: &mut Command,
+    language: XtaskOutputLanguage,
+) -> Result<()> {
     if !command_exists("xcbeautify") {
-        return run(command);
+        return run_with_language(command, language);
     }
 
-    println!();
-    println!("========== Running command ==========");
+    print_section(language, "Running command", "コマンド実行");
     println!("$ {} 2>&1 | xcbeautify", format_command(command));
 
     let mut child = command
@@ -74,17 +74,17 @@ pub(crate) fn run_with_optional_xcbeautify(command: &mut Command) -> Result<()> 
     let stdout = child
         .stdout
         .take()
-        .ok_or("failed to capture command stdout")?;
+        .ok_or_else(|| capture_failed_message(language, "stdout"))?;
     let stderr = child
         .stderr
         .take()
-        .ok_or("failed to capture command stderr")?;
+        .ok_or_else(|| capture_failed_message(language, "stderr"))?;
 
     let mut formatter = Command::new("xcbeautify").stdin(Stdio::piped()).spawn()?;
     let formatter_stdin = formatter
         .stdin
         .take()
-        .ok_or("failed to open xcbeautify stdin")?;
+        .ok_or_else(|| xcbeautify_stdin_failed_message(language))?;
     let formatter_stdin = Arc::new(Mutex::new(formatter_stdin));
 
     let stdout_thread = pipe_to_formatter(stdout, Arc::clone(&formatter_stdin));
@@ -93,22 +93,26 @@ pub(crate) fn run_with_optional_xcbeautify(command: &mut Command) -> Result<()> 
     let status = child.wait()?;
     stdout_thread
         .join()
-        .map_err(|_| "stdout pipe thread panicked")??;
+        .map_err(|_| pipe_thread_panicked_message(language, "stdout"))??;
     stderr_thread
         .join()
-        .map_err(|_| "stderr pipe thread panicked")??;
+        .map_err(|_| pipe_thread_panicked_message(language, "stderr"))??;
     drop(formatter_stdin);
 
     let formatter_status = formatter.wait()?;
     if !status.success() {
-        return Err(format!(
-            "command failed with status {status}: {}",
-            format_command(command)
-        )
-        .into());
+        return Err(command_failed_message(language, status, &format_command(command)).into());
     }
     if !formatter_status.success() {
-        return Err(format!("xcbeautify failed with status {formatter_status}").into());
+        return Err(match language {
+            XtaskOutputLanguage::English => {
+                format!("xcbeautify failed with status {formatter_status}")
+            }
+            XtaskOutputLanguage::Japanese => {
+                format!("xcbeautify が失敗しました status={formatter_status}")
+            }
+        }
+        .into());
     }
     Ok(())
 }
@@ -144,20 +148,87 @@ where
     })
 }
 
-pub(crate) fn run_output(command: &mut Command) -> Result<Output> {
-    println!();
-    println!("========== Running command ==========");
+pub(crate) fn run_output_with_language(
+    command: &mut Command,
+    language: XtaskOutputLanguage,
+) -> Result<Output> {
+    print_section(language, "Running command", "コマンド実行");
     println!("$ {}", format_command(command));
     let output = command.output()?;
     if !output.status.success() {
-        return Err(format!(
-            "command failed with status {}: {}",
-            output.status,
-            format_command(command)
-        )
-        .into());
+        return Err(
+            command_failed_message(language, output.status, &format_command(command)).into(),
+        );
     }
     Ok(output)
+}
+
+pub(crate) fn print_section(language: XtaskOutputLanguage, english: &str, japanese: &str) {
+    println!();
+    println!(
+        "== {} ==",
+        match language {
+            XtaskOutputLanguage::English => english,
+            XtaskOutputLanguage::Japanese => japanese,
+        }
+    );
+    println!();
+}
+
+pub(crate) fn print_success(language: XtaskOutputLanguage, english: &str, japanese: &str) {
+    println!(
+        "  ✅ {}",
+        match language {
+            XtaskOutputLanguage::English => english,
+            XtaskOutputLanguage::Japanese => japanese,
+        }
+    );
+}
+
+pub(crate) fn print_skip(language: XtaskOutputLanguage, english: &str, japanese: &str) {
+    println!(
+        "  ⏭️ {}",
+        match language {
+            XtaskOutputLanguage::English => english,
+            XtaskOutputLanguage::Japanese => japanese,
+        }
+    );
+}
+
+fn command_failed_message(
+    language: XtaskOutputLanguage,
+    status: std::process::ExitStatus,
+    command: &str,
+) -> String {
+    match language {
+        XtaskOutputLanguage::English => format!("command failed with status {status}: {command}"),
+        XtaskOutputLanguage::Japanese => {
+            format!("コマンドが失敗しました status={status}: {command}")
+        }
+    }
+}
+
+fn capture_failed_message(language: XtaskOutputLanguage, stream: &str) -> String {
+    match language {
+        XtaskOutputLanguage::English => format!("failed to capture command {stream}"),
+        XtaskOutputLanguage::Japanese => {
+            format!("コマンドの {stream} を capture できませんでした")
+        }
+    }
+}
+
+fn xcbeautify_stdin_failed_message(language: XtaskOutputLanguage) -> String {
+    match language {
+        XtaskOutputLanguage::English => "failed to open xcbeautify stdin".to_string(),
+        XtaskOutputLanguage::Japanese => "xcbeautify stdin を開けませんでした".to_string(),
+    }
+}
+
+fn pipe_thread_panicked_message(language: XtaskOutputLanguage, stream: &str) -> String {
+    match language {
+        XtaskOutputLanguage::English => format!("{stream} pipe thread panicked"),
+        XtaskOutputLanguage::Japanese => format!("{stream} pipe thread が panic しました"),
+    }
 }
 
 fn format_command(command: &Command) -> String {

--- a/crates/wrac_xtask/src/validation.rs
+++ b/crates/wrac_xtask/src/validation.rs
@@ -38,12 +38,18 @@ pub(crate) fn validate_wrac_rules(
 
     // Print the full matrix first. CI logs need to show checks that passed, were disabled,
     // or were skipped; the final error only contains checks that failed.
-    report::print_check_results(&results);
+    report::print_check_results(&results, ctx.output_language);
     let violations = report::failed_violations(&results);
     if violations.is_empty() {
-        println!("WRAC production-readiness checks: passed");
+        println!(
+            "\n  ✅ {}",
+            match ctx.output_language {
+                crate::XtaskOutputLanguage::English => "WRAC production-readiness checks: passed",
+                crate::XtaskOutputLanguage::Japanese => "WRAC production-readiness check: 成功",
+            }
+        );
         return Ok(());
     }
 
-    Err(report::failure_message(&violations).into())
+    Err(report::failure_message(&violations, ctx.output_language).into())
 }

--- a/crates/wrac_xtask/src/validation/report.rs
+++ b/crates/wrac_xtask/src/validation/report.rs
@@ -1,29 +1,84 @@
 use std::fmt::Write as _;
 
+use crate::XtaskOutputLanguage;
+
 use super::checks::{CheckResult, CheckStatus, RuleViolation};
 
-pub(crate) fn print_check_results(results: &[CheckResult]) {
-    println!("WRAC production-readiness checks:");
+pub(crate) fn print_check_results(results: &[CheckResult], language: XtaskOutputLanguage) {
+    println!();
+    println!(
+        "== {} ==",
+        match language {
+            XtaskOutputLanguage::English => "WRAC production-readiness checks",
+            XtaskOutputLanguage::Japanese => "WRAC production-readiness check",
+        }
+    );
+    println!();
     for result in results {
         let product = product_label(&result.plugin_name, &result.plugin_id);
         match &result.status {
-            CheckStatus::Passed => println!("  pass     {} [{}]", result.rule_id, product),
+            CheckStatus::Passed => println!(
+                "  ✅ {} {} [{}]",
+                status_label(language, "pass", "成功"),
+                result.rule_id,
+                product
+            ),
             CheckStatus::Skipped(reason) => {
-                println!("  skipped  {} [{}]", result.rule_id, product);
-                println!("           reason: {reason}");
+                println!(
+                    "  ⏭️ {} {} [{}]",
+                    status_label(language, "skipped", "スキップ"),
+                    result.rule_id,
+                    product
+                );
+                println!("     {}: {reason}", reason_label(language));
             }
             CheckStatus::Disabled(reason) => {
-                println!("  disabled {} [{}]", result.rule_id, product);
-                println!("           reason: {reason}");
+                println!(
+                    "  ⏭️ {} {} [{}]",
+                    status_label(language, "disabled", "無効"),
+                    result.rule_id,
+                    product
+                );
+                println!("     {}: {reason}", reason_label(language));
             }
             CheckStatus::Failed(violations) => {
-                println!("  fail     {} [{}]", result.rule_id, product);
+                println!(
+                    "  ❌ {} {} [{}]",
+                    status_label(language, "fail", "失敗"),
+                    result.rule_id,
+                    product
+                );
                 for violation in violations {
-                    println!("           {}", violation.message);
-                    println!("           Fix: {}", violation.fix);
+                    println!("     {}", violation.message);
+                    println!("     {}: {}", fix_label(language), violation.fix);
                 }
             }
         }
+    }
+}
+
+fn status_label(
+    language: XtaskOutputLanguage,
+    english: &'static str,
+    japanese: &'static str,
+) -> &'static str {
+    match language {
+        XtaskOutputLanguage::English => english,
+        XtaskOutputLanguage::Japanese => japanese,
+    }
+}
+
+fn reason_label(language: XtaskOutputLanguage) -> &'static str {
+    match language {
+        XtaskOutputLanguage::English => "reason",
+        XtaskOutputLanguage::Japanese => "理由",
+    }
+}
+
+fn fix_label(language: XtaskOutputLanguage) -> &'static str {
+    match language {
+        XtaskOutputLanguage::English => "Fix",
+        XtaskOutputLanguage::Japanese => "修正",
     }
 }
 
@@ -39,19 +94,42 @@ pub(crate) fn failed_violations(results: &[CheckResult]) -> Vec<&RuleViolation> 
         .collect()
 }
 
-pub(crate) fn failure_message(violations: &[&RuleViolation]) -> String {
-    let mut message = String::from("WRAC production-readiness checks failed:\n");
+pub(crate) fn failure_message(
+    violations: &[&RuleViolation],
+    language: XtaskOutputLanguage,
+) -> String {
+    let mut message = match language {
+        XtaskOutputLanguage::English => String::from("WRAC production-readiness checks failed:\n"),
+        XtaskOutputLanguage::Japanese => {
+            String::from("WRAC production-readiness check に失敗しました:\n")
+        }
+    };
     for violation in violations {
         let product = product_label(&violation.plugin_name, &violation.plugin_id);
-        let _ = writeln!(
-            message,
-            "\n{}:\n  product {}\n  error {}\n    {}\n    Fix: {}",
-            violation.location.display(),
-            product,
-            violation.rule_id,
-            violation.message,
-            violation.fix
-        );
+        match language {
+            XtaskOutputLanguage::English => {
+                let _ = writeln!(
+                    message,
+                    "\n{}:\n  product {}\n  error {}\n    {}\n    Fix: {}",
+                    violation.location.display(),
+                    product,
+                    violation.rule_id,
+                    violation.message,
+                    violation.fix
+                );
+            }
+            XtaskOutputLanguage::Japanese => {
+                let _ = writeln!(
+                    message,
+                    "\n{}:\n  product {}\n  error {}\n    {}\n    修正: {}",
+                    violation.location.display(),
+                    product,
+                    violation.rule_id,
+                    violation.message,
+                    violation.fix
+                );
+            }
+        }
     }
     message
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -5,7 +5,7 @@
 
 use std::path::Path;
 
-use wrac_xtask::{WracWorkspace, XtaskConfig};
+use wrac_xtask::{WracWorkspace, XtaskConfig, XtaskOutputLanguage};
 
 fn main() -> wrac_xtask::Result<()> {
     let root = Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -17,6 +17,7 @@ fn main() -> wrac_xtask::Result<()> {
         wrapper_dir: root.join("clap_wrapper_builder"),
         target_namespace: "wrac-plugins".to_string(),
         default_aax_sdk_root: None,
+        output_language: XtaskOutputLanguage::English,
         root,
     })?;
     workspace.run(wrac_xtask::command_from_args())


### PR DESCRIPTION
## Summary
- Add localized xtask output language support
- Keep the WRAC template default output in English
- Add compact section headers for plan, dependencies, execution, and results
- Use focused status emoji only for success, failure, and skipped tasks
- Prefix task failure details with `Error:` for grep-friendly logs

## Verification
- `cargo xtask quality`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
- `cargo xtask uninstall -p wrac_gain_plugin --target=clap --dry-run`
- `cargo xtask uninstall -p snapclip_plugin --target=clap --dry-run` in novonotes-products
