### PR TITLE
Fixed an issue that caused a crash after scanning.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - windows-latest
+          - windows-2022
           - macos-latest
 
     steps:
@@ -100,7 +100,7 @@ jobs:
               test -f "target/wrac-plugins/wrac-gain/wrac/plugins/release/WRAC Gain.clap"
               test -d "target/wrac-plugins/wrac-gain/wrac/plugins/release/WRAC Gain.vst3"
               test -x "target/wrac-plugins/wrac-gain/wrac/standalone/release/WRAC Gain Standalone"
-          - os: windows-latest
+          - os: windows-2022
             build-targets: clap,vst3,standalone
             validate-targets: clap,vst3
             verify: |
@@ -178,7 +178,7 @@ jobs:
       matrix:
         os:
           - macos-latest
-          - windows-latest
+          - windows-2022
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - windows-2022
+          - windows-latest
           - macos-latest
 
     steps:
@@ -100,7 +100,7 @@ jobs:
               test -f "target/wrac-plugins/wrac-gain/wrac/plugins/release/WRAC Gain.clap"
               test -d "target/wrac-plugins/wrac-gain/wrac/plugins/release/WRAC Gain.vst3"
               test -x "target/wrac-plugins/wrac-gain/wrac/standalone/release/WRAC Gain Standalone"
-          - os: windows-2022
+          - os: windows-latest
             build-targets: clap,vst3,standalone
             validate-targets: clap,vst3
             verify: |
@@ -178,7 +178,7 @@ jobs:
       matrix:
         os:
           - macos-latest
-          - windows-2022
+          - windows-latest
 
     steps:
       - name: Checkout repository

--- a/crates/wrac_log/src/file_logger.rs
+++ b/crates/wrac_log/src/file_logger.rs
@@ -19,7 +19,7 @@ static CURRENT_LOG_FILE: OnceLock<Option<PathBuf>> = OnceLock::new();
 ///
 /// Prefer calling the macro so `manifest_dir` is captured from the plugin crate,
 /// not from `wrac_log`.
-pub fn init_impl(manifest_dir: Option<&'static str>, app_name: &str) {
+pub fn init_impl(manifest_dir: Option<&'static str>, app_name: &str) -> crate::LogSession {
     INIT.call_once(|| {
         let dotenv_rust_log = rust_log_from_debug_dotenv(manifest_dir);
 
@@ -54,6 +54,7 @@ pub fn init_impl(manifest_dir: Option<&'static str>, app_name: &str) {
         let _ = app_name;
         init_stderr(dotenv_rust_log.as_deref());
     });
+    crate::rt::LogSession::start()
 }
 
 /// Returns the directory currently used for file logging.
@@ -429,7 +430,6 @@ fn init_stderr(dotenv_rust_log: Option<&str>) {
     apply_default_filter(&mut builder, dotenv_rust_log);
     builder.target(Target::Stderr);
     let _ = builder.try_init();
-    crate::rt::start_drain_if_enabled();
 }
 
 fn init_with_file(log_file: impl AsRef<Path>, dotenv_rust_log: Option<&str>) {
@@ -450,7 +450,6 @@ fn init_with_file(log_file: impl AsRef<Path>, dotenv_rust_log: Option<&str>) {
             apply_default_filter(&mut builder, dotenv_rust_log);
             builder.target(Target::Pipe(Box::new(FileAndStderr::new(file))));
             let _ = builder.try_init();
-            crate::rt::start_drain_if_enabled();
         }
         Err(error) => {
             eprintln!("Failed to open log file '{}': {error}", log_file.display());
@@ -472,6 +471,9 @@ fn announce_log_output(destination: &str) {
 }
 
 fn apply_default_filter(builder: &mut Builder, dotenv_rust_log: Option<&str>) {
+    #[cfg(not(debug_assertions))]
+    let _ = dotenv_rust_log;
+
     if std::env::var("RUST_LOG").is_err() {
         #[cfg(debug_assertions)]
         if let Some(rust_log) = dotenv_rust_log.filter(|value| !value.trim().is_empty()) {
@@ -521,6 +523,7 @@ impl Write for FileAndStderr {
     }
 }
 
+#[cfg(debug_assertions)]
 fn get_test_name() -> String {
     std::thread::current()
         .name()

--- a/crates/wrac_log/src/lib.rs
+++ b/crates/wrac_log/src/lib.rs
@@ -13,7 +13,7 @@ pub use file_logger::{
 };
 #[doc(hidden)]
 pub use rt::write_rt_log as __write_rt_log;
-pub use rt::{RtDrainConfig, drain_rt_logs_once, init_rt_log_drain_once};
+pub use rt::{RtDrainConfig, drain_rt_logs_once, init_rt_log_drain_once, shutdown_rt_log_drain};
 
 /// Initializes logging for a WRAC plugin.
 ///

--- a/crates/wrac_log/src/lib.rs
+++ b/crates/wrac_log/src/lib.rs
@@ -13,9 +13,9 @@ pub use file_logger::{
 };
 #[doc(hidden)]
 pub use rt::write_rt_log as __write_rt_log;
-pub use rt::{RtDrainConfig, drain_rt_logs_once, init_rt_log_drain_once, shutdown_rt_log_drain};
+pub use rt::{LogSession, RtDrainConfig, drain_rt_logs_once, init_rt_log_drain_once};
 
-/// Initializes logging for a WRAC plugin.
+/// Initializes logging for a WRAC plugin and returns a session guard.
 ///
 /// This macro must be called from the plugin crate so `CARGO_MANIFEST_DIR` points at
 /// the caller. In debug builds, the default log directory is resolved as
@@ -23,6 +23,8 @@ pub use rt::{RtDrainConfig, drain_rt_logs_once, init_rt_log_drain_once, shutdown
 /// crate would resolve that path relative to `wrac_log` instead.
 ///
 /// Initialization is process-wide and idempotent. The first call wins.
+/// Keep the returned [`LogSession`] alive for the plugin instance lifetime so
+/// realtime log draining stops only after the last instance is dropped.
 ///
 /// Output destination priority:
 /// 1. `WRAC_LOG_DIR`

--- a/crates/wrac_log/src/rt.rs
+++ b/crates/wrac_log/src/rt.rs
@@ -12,6 +12,32 @@ const RT_TARGET_CAPACITY: usize = 96;
 
 static RT_LOG: OnceLock<RtLogInner> = OnceLock::new();
 static RT_DRAIN_WORKER: Mutex<Option<RtDrainWorker>> = Mutex::new(None);
+static RT_LOG_SESSION_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+/// Keeps realtime log draining alive for one plugin instance.
+///
+/// Dropping the last session stops the background drain worker before the plugin
+/// binary can be unloaded by the host.
+#[must_use = "keep LogSession alive for the plugin instance lifetime"]
+pub struct LogSession {
+    _private: (),
+}
+
+impl LogSession {
+    pub(crate) fn start() -> Self {
+        let previous_count = RT_LOG_SESSION_COUNT.fetch_add(1, Ordering::AcqRel);
+        if previous_count == 0 {
+            start_drain_if_enabled();
+        }
+        Self { _private: () }
+    }
+}
+
+impl Drop for LogSession {
+    fn drop(&mut self) {
+        release_log_session();
+    }
+}
 
 /// Configuration for the background realtime log drain worker.
 pub struct RtDrainConfig {
@@ -71,12 +97,29 @@ pub fn init_rt_log_drain_once(config: RtDrainConfig) {
     });
 }
 
-/// Stops the realtime log drain worker and waits until its thread has exited.
-///
-/// Plugin binaries can be unloaded by hosts after scanning. Any Rust thread left
-/// running from the plugin DLL may resume inside unloaded code, so plugin entry
-/// points should call this from their unload/deinit path.
-pub fn shutdown_rt_log_drain() {
+fn release_log_session() {
+    let mut current_count = RT_LOG_SESSION_COUNT.load(Ordering::Acquire);
+    loop {
+        if current_count == 0 {
+            return;
+        }
+        match RT_LOG_SESSION_COUNT.compare_exchange_weak(
+            current_count,
+            current_count - 1,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        ) {
+            Ok(1) => {
+                shutdown_rt_log_drain();
+                return;
+            }
+            Ok(_) => return,
+            Err(next_count) => current_count = next_count,
+        }
+    }
+}
+
+fn shutdown_rt_log_drain() {
     let worker = RT_DRAIN_WORKER
         .lock()
         .ok()
@@ -348,6 +391,22 @@ fn u8_to_level(level: u8) -> Level {
 mod tests {
     use super::*;
 
+    static SESSION_TEST_MUTEX: Mutex<()> = Mutex::new(());
+
+    fn reset_sessions_for_test() {
+        while RT_LOG_SESSION_COUNT.load(Ordering::Acquire) > 0 {
+            release_log_session();
+        }
+        shutdown_rt_log_drain();
+    }
+
+    fn drain_worker_is_running() -> bool {
+        RT_DRAIN_WORKER
+            .lock()
+            .map(|worker| worker.is_some())
+            .unwrap_or(false)
+    }
+
     #[test]
     fn drain_stops_before_unpublished_slot() {
         let log = RtLogInner::new();
@@ -373,5 +432,34 @@ mod tests {
             std::str::from_utf8(message.as_bytes()).unwrap().len(),
             message.len,
         );
+    }
+
+    #[test]
+    fn log_session_stops_drain_worker_after_last_drop() {
+        let _guard = SESSION_TEST_MUTEX
+            .lock()
+            .expect("session test mutex poisoned");
+        reset_sessions_for_test();
+
+        let first_session = LogSession::start();
+        let second_session = LogSession::start();
+
+        assert_eq!(RT_LOG_SESSION_COUNT.load(Ordering::Acquire), 2);
+        assert!(drain_worker_is_running());
+
+        drop(first_session);
+        assert_eq!(RT_LOG_SESSION_COUNT.load(Ordering::Acquire), 1);
+        assert!(drain_worker_is_running());
+
+        drop(second_session);
+        assert_eq!(RT_LOG_SESSION_COUNT.load(Ordering::Acquire), 0);
+        assert!(!drain_worker_is_running());
+
+        let restarted_session = LogSession::start();
+        assert_eq!(RT_LOG_SESSION_COUNT.load(Ordering::Acquire), 1);
+        assert!(drain_worker_is_running());
+
+        drop(restarted_session);
+        reset_sessions_for_test();
     }
 }

--- a/crates/wrac_log/src/rt.rs
+++ b/crates/wrac_log/src/rt.rs
@@ -1,9 +1,9 @@
 use log::Level;
 use std::array;
 use std::fmt::{self, Write as _};
-use std::sync::OnceLock;
-use std::sync::atomic::{AtomicU8, AtomicU64, AtomicUsize, Ordering};
-use std::thread;
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
 const RT_LOG_CAPACITY: usize = 4096;
@@ -11,7 +11,7 @@ const RT_MESSAGE_CAPACITY: usize = 256;
 const RT_TARGET_CAPACITY: usize = 96;
 
 static RT_LOG: OnceLock<RtLogInner> = OnceLock::new();
-static RT_DRAIN_WORKER: OnceLock<()> = OnceLock::new();
+static RT_DRAIN_WORKER: Mutex<Option<RtDrainWorker>> = Mutex::new(None);
 
 /// Configuration for the background realtime log drain worker.
 pub struct RtDrainConfig {
@@ -34,28 +34,76 @@ impl RtDrainConfig {
     }
 }
 
-/// Starts the realtime log drain worker once for the current process.
+/// Starts the realtime log drain worker when it is not already running.
 ///
 /// This is called automatically by [`crate::init!`] in debug builds and when
 /// `WRAC_RT_LOG` is set. Calling it directly is useful for tests or custom host
 /// integration.
 pub fn init_rt_log_drain_once(config: RtDrainConfig) {
-    RT_DRAIN_WORKER.get_or_init(|| {
-        let interval = config.interval;
-        let _ = thread::Builder::new()
-            .name("wrac-rt-log-drain".to_string())
-            .spawn(move || {
-                loop {
-                    thread::sleep(interval);
-                    drain_rt_logs_once();
+    let Ok(mut worker) = RT_DRAIN_WORKER.lock() else {
+        return;
+    };
+    if worker.is_some() {
+        return;
+    }
+
+    let interval = config.interval;
+    let stop_requested = Arc::new(AtomicBool::new(false));
+    let thread_stop_requested = stop_requested.clone();
+    let Ok(handle) = thread::Builder::new()
+        .name("wrac-rt-log-drain".to_string())
+        .spawn(move || {
+            while !thread_stop_requested.load(Ordering::Acquire) {
+                thread::park_timeout(interval);
+                if thread_stop_requested.load(Ordering::Acquire) {
+                    break;
                 }
-            });
+                drain_existing_rt_logs_once();
+            }
+            drain_existing_rt_logs_once();
+        })
+    else {
+        return;
+    };
+    *worker = Some(RtDrainWorker {
+        stop_requested,
+        handle,
     });
+}
+
+/// Stops the realtime log drain worker and waits until its thread has exited.
+///
+/// Plugin binaries can be unloaded by hosts after scanning. Any Rust thread left
+/// running from the plugin DLL may resume inside unloaded code, so plugin entry
+/// points should call this from their unload/deinit path.
+pub fn shutdown_rt_log_drain() {
+    let worker = RT_DRAIN_WORKER
+        .lock()
+        .ok()
+        .and_then(|mut worker| worker.take());
+    let Some(worker) = worker else {
+        drain_existing_rt_logs_once();
+        return;
+    };
+
+    worker.stop_requested.store(true, Ordering::Release);
+    let thread = worker.handle.thread().clone();
+    thread.unpark();
+    if thread.id() != thread::current().id() {
+        let _ = worker.handle.join();
+    }
+    drain_existing_rt_logs_once();
 }
 
 /// Drains the global realtime log once on the current thread.
 pub fn drain_rt_logs_once() {
     rt_log().drain_to_log();
+}
+
+fn drain_existing_rt_logs_once() {
+    if let Some(rt_log) = RT_LOG.get() {
+        rt_log.drain_to_log();
+    }
 }
 
 pub(crate) fn start_drain_if_enabled() {
@@ -71,6 +119,11 @@ pub(crate) fn start_drain_if_enabled() {
 #[doc(hidden)]
 pub fn write_rt_log(level: Level, target: &'static str, args: fmt::Arguments<'_>) {
     rt_log().write_fmt(level, target, args);
+}
+
+struct RtDrainWorker {
+    stop_requested: Arc<AtomicBool>,
+    handle: JoinHandle<()>,
 }
 
 fn rt_log() -> &'static RtLogInner {

--- a/crates/wrac_xtask/src/commands.rs
+++ b/crates/wrac_xtask/src/commands.rs
@@ -455,7 +455,7 @@ pub(crate) fn configure_wrapper(
         );
     }
 
-    if let Some(generator) = ctx.platform.cmake_generator() {
+    if let Some(generator) = cmake_generator(ctx.platform)? {
         push_cmake_arg(&mut args, "-G");
         push_cmake_arg(&mut args, generator);
     }
@@ -583,6 +583,99 @@ fn cmake_wrapper_targets(ctx: &Context, build: WrapperBuild, target: WrapperTarg
 
 fn push_cmake_arg(args: &mut Vec<OsString>, arg: impl Into<OsString>) {
     args.push(arg.into());
+}
+
+fn cmake_generator(platform: Platform) -> Result<Option<String>> {
+    match platform {
+        Platform::Macos => Ok(platform.cmake_generator().map(ToOwned::to_owned)),
+        Platform::Windows => Ok(Some(windows_cmake_generator()?)),
+        Platform::Linux => Ok(None),
+    }
+}
+
+fn windows_cmake_generator() -> Result<String> {
+    if let Ok(generator) = env::var("WRAC_CMAKE_GENERATOR") {
+        let generator = generator.trim();
+        if !generator.is_empty() {
+            return Ok(generator.to_owned());
+        }
+    }
+
+    ensure_visual_studio_msbuild_available()?;
+    let generator = latest_cmake_visual_studio_generator()?;
+    println!("Using CMake generator: {generator}");
+    Ok(generator)
+}
+
+fn ensure_visual_studio_msbuild_available() -> Result<()> {
+    let mut vswhere = Command::new(vswhere_command());
+    vswhere.args([
+        "-products",
+        "*",
+        "-requires",
+        "Microsoft.Component.MSBuild",
+        "-latest",
+        "-property",
+        "installationPath",
+    ]);
+    let output = run_output(&mut vswhere)?;
+    let installation_path = String::from_utf8(output.stdout)?;
+    if installation_path.trim().is_empty() {
+        return Err("Visual Studio with MSBuild was not found by vswhere".into());
+    }
+    Ok(())
+}
+
+fn vswhere_command() -> PathBuf {
+    env::var_os("ProgramFiles(x86)")
+        .map(PathBuf::from)
+        .map(|program_files_x86| {
+            program_files_x86
+                .join("Microsoft Visual Studio")
+                .join("Installer")
+                .join("vswhere.exe")
+        })
+        .filter(|path| path.exists())
+        .unwrap_or_else(|| PathBuf::from("vswhere"))
+}
+
+fn latest_cmake_visual_studio_generator() -> Result<String> {
+    let output = run_output(Command::new("cmake").arg("--help"))?;
+    let help = String::from_utf8(output.stdout)?;
+    select_latest_visual_studio_generator(&help)
+        .ok_or_else(|| "CMake does not list any Visual Studio generator".into())
+}
+
+fn select_latest_visual_studio_generator(help: &str) -> Option<String> {
+    cmake_visual_studio_generators(help)
+        .into_iter()
+        .filter_map(|generator| {
+            visual_studio_generator_version(&generator).map(|version| (version, generator))
+        })
+        .max_by_key(|(version, _)| *version)
+        .map(|(_, generator)| generator)
+}
+
+fn visual_studio_generator_version(generator: &str) -> Option<u32> {
+    let mut words = generator.split_whitespace();
+    match (words.next(), words.next(), words.next()) {
+        (Some("Visual"), Some("Studio"), Some(version)) => version.parse().ok(),
+        _ => None,
+    }
+}
+
+fn cmake_visual_studio_generators(help: &str) -> Vec<String> {
+    help.lines()
+        .filter_map(|line| {
+            let line = line
+                .trim_start()
+                .strip_prefix("* ")
+                .unwrap_or(line.trim_start());
+            let (name, _) = line.split_once(" = ")?;
+            let name = name.trim();
+            name.starts_with("Visual Studio").then(|| name.to_owned())
+        })
+        .collect()
 }
 
 fn cmake_configure_stamp_path(build_dir: &Path) -> PathBuf {
@@ -1925,6 +2018,44 @@ mod tests {
                 "822011CA37EC5CEF92D7EC7E67207195".to_string(),
                 "FFFF664CB96353E687CC2A7CEB29674B".to_string(),
             ]
+        );
+    }
+
+    #[test]
+    fn parses_visual_studio_generators_from_cmake_help() {
+        let help = r#"
+Generators
+
+The following generators are available on this platform (* marks default):
+* Visual Studio 18 2026        = Generates Visual Studio 2026 project files.
+  Visual Studio 17 2022        = Generates Visual Studio 2022 project files.
+  Ninja                        = Generates build.ninja files.
+"#;
+
+        assert_eq!(
+            cmake_visual_studio_generators(help),
+            vec![
+                "Visual Studio 18 2026".to_owned(),
+                "Visual Studio 17 2022".to_owned(),
+            ]
+        );
+    }
+
+    #[test]
+    fn selects_latest_visual_studio_generator_from_cmake_help() {
+        let help = r#"
+Generators
+
+The following generators are available on this platform (* marks default):
+  Visual Studio 17 2022        = Generates Visual Studio 2022 project files.
+* Visual Studio 16 2019        = Generates Visual Studio 2019 project files.
+  Visual Studio 15 2017 [arch] = Generates Visual Studio 2017 project files.
+  Ninja                        = Generates build.ninja files.
+"#;
+
+        assert_eq!(
+            select_latest_visual_studio_generator(help),
+            Some("Visual Studio 17 2022".to_owned())
         );
     }
 }

--- a/crates/wrac_xtask/src/targets.rs
+++ b/crates/wrac_xtask/src/targets.rs
@@ -184,8 +184,7 @@ impl Platform {
     pub(crate) fn cmake_generator(self) -> Option<&'static str> {
         match self {
             Self::Macos => Some("Xcode"),
-            Self::Windows => Some("Visual Studio 17 2022"),
-            Self::Linux => None,
+            Self::Windows | Self::Linux => None,
         }
     }
 

--- a/plugins/wrac-gain/src-plugin/src/plugin.rs
+++ b/plugins/wrac-gain/src-plugin/src/plugin.rs
@@ -50,6 +50,10 @@ impl PluginEntry for WracGainEntry {
     fn plugin_factory(&self) -> Option<&dyn PluginFactory> {
         Some(&WRAC_GAIN_FACTORY)
     }
+
+    fn deinit(&self) {
+        wrac_log::shutdown_rt_log_drain();
+    }
 }
 
 static WRAC_GAIN_FACTORY: WracGainFactory = WracGainFactory;

--- a/plugins/wrac-gain/src-plugin/src/plugin.rs
+++ b/plugins/wrac-gain/src-plugin/src/plugin.rs
@@ -50,10 +50,6 @@ impl PluginEntry for WracGainEntry {
     fn plugin_factory(&self) -> Option<&dyn PluginFactory> {
         Some(&WRAC_GAIN_FACTORY)
     }
-
-    fn deinit(&self) {
-        wrac_log::shutdown_rt_log_drain();
-    }
 }
 
 static WRAC_GAIN_FACTORY: WracGainFactory = WracGainFactory;
@@ -94,6 +90,9 @@ impl PluginFactory for WracGainFactory {
 /// re-entrantly during lifecycle callbacks, requiring them to be reachable without
 /// acquiring the `&mut self` lock on `PluginCore`.
 pub(crate) struct WracGainPlugin {
+    // Keep realtime log draining tied to this plugin instance. The last dropped
+    // session stops the drain worker before the plugin binary can be unloaded.
+    _log_session: wrac_log::LogSession,
     // The descriptor is instance data, not a global primary descriptor. This matters for
     // multi-product bundles where the same binary can expose more than one plugin id.
     descriptor: PluginDescriptor,
@@ -112,7 +111,11 @@ pub(crate) struct WracGainPlugin {
 }
 
 impl WracGainPlugin {
-    pub(crate) fn new(context: PluginCoreContext, descriptor: PluginDescriptor) -> Self {
+    pub(crate) fn new(
+        context: PluginCoreContext,
+        descriptor: PluginDescriptor,
+        log_session: wrac_log::LogSession,
+    ) -> Self {
         let shared = Arc::new(SharedState::new());
         let audio_layout = Arc::new(AudioLayoutStore::new(2));
         let audio_ports = Arc::new(WracGainAudioPorts::new(audio_layout.clone()));
@@ -135,6 +138,7 @@ impl WracGainPlugin {
         ));
 
         Self {
+            _log_session: log_session,
             descriptor,
             shared,
             audio_layout,
@@ -153,7 +157,7 @@ pub(crate) fn create_plugin_core(
     context: PluginCoreContext,
     descriptor: PluginDescriptor,
 ) -> Box<dyn PluginCore> {
-    wrac_log::init!(descriptor.name);
+    let log_session = wrac_log::init!(descriptor.name);
 
     log::debug!(
         "creating plugin core: id={}, name={}",
@@ -174,7 +178,7 @@ pub(crate) fn create_plugin_core(
             parameter.flags.is_bypass
         );
     }
-    Box::new(WracGainPlugin::new(context, descriptor))
+    Box::new(WracGainPlugin::new(context, descriptor, log_session))
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixed an issue where the logging thread could remain running during DLL unload, causing a crash.

Environment:
Win11 25H2
Studio Pro 8.1
Plugin Format: CLAP