### PR TITLE
Tie realtime log drain to log sessions

### DIFF
--- a/crates/wrac_log/src/file_logger.rs
+++ b/crates/wrac_log/src/file_logger.rs
@@ -19,7 +19,7 @@ static CURRENT_LOG_FILE: OnceLock<Option<PathBuf>> = OnceLock::new();
 ///
 /// Prefer calling the macro so `manifest_dir` is captured from the plugin crate,
 /// not from `wrac_log`.
-pub fn init_impl(manifest_dir: Option<&'static str>, app_name: &str) {
+pub fn init_impl(manifest_dir: Option<&'static str>, app_name: &str) -> crate::LogSession {
     INIT.call_once(|| {
         let dotenv_rust_log = rust_log_from_debug_dotenv(manifest_dir);
 
@@ -54,6 +54,7 @@ pub fn init_impl(manifest_dir: Option<&'static str>, app_name: &str) {
         let _ = app_name;
         init_stderr(dotenv_rust_log.as_deref());
     });
+    crate::rt::LogSession::start()
 }
 
 /// Returns the directory currently used for file logging.
@@ -436,7 +437,6 @@ fn init_stderr(dotenv_rust_log: Option<&str>) {
     apply_default_filter(&mut builder, dotenv_rust_log);
     builder.target(Target::Stderr);
     let _ = builder.try_init();
-    crate::rt::start_drain_if_enabled();
 }
 
 fn init_with_file(log_file: impl AsRef<Path>, dotenv_rust_log: Option<&str>) {
@@ -457,7 +457,6 @@ fn init_with_file(log_file: impl AsRef<Path>, dotenv_rust_log: Option<&str>) {
             apply_default_filter(&mut builder, dotenv_rust_log);
             builder.target(Target::Pipe(Box::new(FileAndStderr::new(file))));
             let _ = builder.try_init();
-            crate::rt::start_drain_if_enabled();
         }
         Err(error) => {
             eprintln!("Failed to open log file '{}': {error}", log_file.display());
@@ -479,6 +478,9 @@ fn announce_log_output(destination: &str) {
 }
 
 fn apply_default_filter(builder: &mut Builder, dotenv_rust_log: Option<&str>) {
+    #[cfg(not(debug_assertions))]
+    let _ = dotenv_rust_log;
+
     if std::env::var("RUST_LOG").is_err() {
         #[cfg(debug_assertions)]
         if let Some(rust_log) = dotenv_rust_log.filter(|value| !value.trim().is_empty()) {
@@ -528,6 +530,7 @@ impl Write for FileAndStderr {
     }
 }
 
+#[cfg(debug_assertions)]
 fn get_test_name() -> String {
     std::thread::current()
         .name()

--- a/crates/wrac_log/src/lib.rs
+++ b/crates/wrac_log/src/lib.rs
@@ -17,9 +17,9 @@ pub use file_logger::{
 /// Plugin code should not call or rely on this symbol directly; use the `rt*`
 /// logging macros instead.
 pub use rt::write_rt_log as __write_rt_log;
-pub use rt::{RtDrainConfig, drain_rt_logs_once, init_rt_log_drain_once};
+pub use rt::{LogSession, RtDrainConfig, drain_rt_logs_once, init_rt_log_drain_once};
 
-/// Initializes logging for a WRAC plugin.
+/// Initializes logging for a WRAC plugin and returns a session guard.
 ///
 /// This macro must be called from the plugin crate so `CARGO_MANIFEST_DIR` points at
 /// the caller. In debug builds, the default log directory is resolved as
@@ -27,6 +27,8 @@ pub use rt::{RtDrainConfig, drain_rt_logs_once, init_rt_log_drain_once};
 /// crate would resolve that path relative to `wrac_log` instead.
 ///
 /// Initialization is process-wide and idempotent. The first call wins.
+/// Keep the returned [`LogSession`] alive for the plugin instance lifetime so
+/// realtime log draining stops only after the last instance is dropped.
 ///
 /// Output destination priority:
 /// 1. `WRAC_LOG_DIR`

--- a/crates/wrac_log/src/rt.rs
+++ b/crates/wrac_log/src/rt.rs
@@ -11,8 +11,7 @@ const RT_MESSAGE_CAPACITY: usize = 256;
 const RT_TARGET_CAPACITY: usize = 96;
 
 static RT_LOG: OnceLock<RtLogInner> = OnceLock::new();
-static RT_DRAIN_WORKER: Mutex<Option<RtDrainWorker>> = Mutex::new(None);
-static RT_LOG_SESSION_COUNT: AtomicUsize = AtomicUsize::new(0);
+static RT_DRAIN_STATE: Mutex<RtDrainState> = Mutex::new(RtDrainState::new());
 
 /// Keeps realtime log draining alive for one plugin instance.
 ///
@@ -25,10 +24,7 @@ pub struct LogSession {
 
 impl LogSession {
     pub(crate) fn start() -> Self {
-        let previous_count = RT_LOG_SESSION_COUNT.fetch_add(1, Ordering::AcqRel);
-        if previous_count == 0 {
-            start_drain_if_enabled();
-        }
+        start_log_session();
         Self { _private: () }
     }
 }
@@ -66,69 +62,44 @@ impl RtDrainConfig {
 /// `WRAC_RT_LOG` is set. Calling it directly is useful for tests or custom host
 /// integration.
 pub fn init_rt_log_drain_once(config: RtDrainConfig) {
-    let Ok(mut worker) = RT_DRAIN_WORKER.lock() else {
+    let Ok(mut state) = RT_DRAIN_STATE.lock() else {
         return;
     };
-    if worker.is_some() {
-        return;
-    }
-
-    let interval = config.interval;
-    let stop_requested = std::sync::Arc::new(AtomicBool::new(false));
-    let thread_stop_requested = stop_requested.clone();
-    let Ok(handle) = thread::Builder::new()
-        .name("wrac-rt-log-drain".to_string())
-        .spawn(move || {
-            while !thread_stop_requested.load(Ordering::Acquire) {
-                thread::park_timeout(interval);
-                if thread_stop_requested.load(Ordering::Acquire) {
-                    break;
-                }
-                drain_existing_rt_logs_once();
-            }
-            drain_existing_rt_logs_once();
-        })
-    else {
-        return;
-    };
-    *worker = Some(RtDrainWorker {
-        stop_requested,
-        handle,
-    });
+    state.start_worker_if_absent(config);
 }
 
 fn release_log_session() {
-    let mut current_count = RT_LOG_SESSION_COUNT.load(Ordering::Acquire);
-    loop {
-        if current_count == 0 {
-            return;
-        }
-        match RT_LOG_SESSION_COUNT.compare_exchange_weak(
-            current_count,
-            current_count - 1,
-            Ordering::AcqRel,
-            Ordering::Acquire,
-        ) {
-            Ok(1) => {
-                shutdown_rt_log_drain();
-                return;
-            }
-            Ok(_) => return,
-            Err(next_count) => current_count = next_count,
+    let Ok(mut state) = RT_DRAIN_STATE.lock() else {
+        return;
+    };
+    if state.session_count == 0 {
+        return;
+    }
+    state.session_count -= 1;
+    if state.session_count != 0 {
+        return;
+    }
+    if let Some(worker) = state.worker.take() {
+        // Keep the lifecycle state locked until the old worker exits. Otherwise a
+        // new session could skip startup against a worker that is about to be removed.
+        stop_drain_worker(worker);
+    } else {
+        drain_existing_rt_logs_once();
+    }
+}
+
+#[cfg(test)]
+fn shutdown_rt_log_drain() {
+    if let Ok(mut state) = RT_DRAIN_STATE.lock() {
+        if let Some(worker) = state.worker.take() {
+            stop_drain_worker(worker);
+        } else {
+            drain_existing_rt_logs_once();
         }
     }
 }
 
-fn shutdown_rt_log_drain() {
-    let worker = RT_DRAIN_WORKER
-        .lock()
-        .ok()
-        .and_then(|mut worker| worker.take());
-    let Some(worker) = worker else {
-        drain_existing_rt_logs_once();
-        return;
-    };
-
+fn stop_drain_worker(worker: RtDrainWorker) {
     worker.stop_requested.store(true, Ordering::Release);
     let thread = worker.handle.thread().clone();
     thread.unpark();
@@ -149,13 +120,19 @@ fn drain_existing_rt_logs_once() {
     }
 }
 
-pub(crate) fn start_drain_if_enabled() {
+fn start_log_session() {
     // Initialize from the non-realtime setup path so the first RT log write only
     // touches atomics and the fixed buffer.
     let _ = rt_log();
 
-    if cfg!(debug_assertions) || std::env::var_os("WRAC_RT_LOG").is_some() {
-        init_rt_log_drain_once(RtDrainConfig::default());
+    let drain_config = (cfg!(debug_assertions) || std::env::var_os("WRAC_RT_LOG").is_some())
+        .then(RtDrainConfig::default);
+    let Ok(mut state) = RT_DRAIN_STATE.lock() else {
+        return;
+    };
+    state.session_count += 1;
+    if let Some(config) = drain_config {
+        state.start_worker_if_absent(config);
     }
 }
 
@@ -171,6 +148,49 @@ pub fn write_rt_log(level: Level, target: &'static str, args: fmt::Arguments<'_>
 struct RtDrainWorker {
     stop_requested: std::sync::Arc<AtomicBool>,
     handle: JoinHandle<()>,
+}
+
+struct RtDrainState {
+    session_count: usize,
+    worker: Option<RtDrainWorker>,
+}
+
+impl RtDrainState {
+    const fn new() -> Self {
+        Self {
+            session_count: 0,
+            worker: None,
+        }
+    }
+
+    fn start_worker_if_absent(&mut self, config: RtDrainConfig) {
+        if self.worker.is_some() {
+            return;
+        }
+
+        let interval = config.interval;
+        let stop_requested = std::sync::Arc::new(AtomicBool::new(false));
+        let thread_stop_requested = stop_requested.clone();
+        let Ok(handle) = thread::Builder::new()
+            .name("wrac-rt-log-drain".to_string())
+            .spawn(move || {
+                while !thread_stop_requested.load(Ordering::Acquire) {
+                    thread::park_timeout(interval);
+                    if thread_stop_requested.load(Ordering::Acquire) {
+                        break;
+                    }
+                    drain_existing_rt_logs_once();
+                }
+                drain_existing_rt_logs_once();
+            })
+        else {
+            return;
+        };
+        self.worker = Some(RtDrainWorker {
+            stop_requested,
+            handle,
+        });
+    }
 }
 
 fn rt_log() -> &'static RtLogInner {
@@ -398,17 +418,24 @@ mod tests {
     static SESSION_TEST_MUTEX: Mutex<()> = Mutex::new(());
 
     fn reset_sessions_for_test() {
-        while RT_LOG_SESSION_COUNT.load(Ordering::Acquire) > 0 {
-            release_log_session();
-        }
         shutdown_rt_log_drain();
+        if let Ok(mut state) = RT_DRAIN_STATE.lock() {
+            state.session_count = 0;
+        }
     }
 
     fn drain_worker_is_running() -> bool {
-        RT_DRAIN_WORKER
+        RT_DRAIN_STATE
             .lock()
-            .map(|worker| worker.is_some())
+            .map(|state| state.worker.is_some())
             .unwrap_or(false)
+    }
+
+    fn log_session_count() -> usize {
+        RT_DRAIN_STATE
+            .lock()
+            .map(|state| state.session_count)
+            .unwrap_or_default()
     }
 
     #[test]
@@ -448,19 +475,19 @@ mod tests {
         let first_session = LogSession::start();
         let second_session = LogSession::start();
 
-        assert_eq!(RT_LOG_SESSION_COUNT.load(Ordering::Acquire), 2);
+        assert_eq!(log_session_count(), 2);
         assert!(drain_worker_is_running());
 
         drop(first_session);
-        assert_eq!(RT_LOG_SESSION_COUNT.load(Ordering::Acquire), 1);
+        assert_eq!(log_session_count(), 1);
         assert!(drain_worker_is_running());
 
         drop(second_session);
-        assert_eq!(RT_LOG_SESSION_COUNT.load(Ordering::Acquire), 0);
+        assert_eq!(log_session_count(), 0);
         assert!(!drain_worker_is_running());
 
         let restarted_session = LogSession::start();
-        assert_eq!(RT_LOG_SESSION_COUNT.load(Ordering::Acquire), 1);
+        assert_eq!(log_session_count(), 1);
         assert!(drain_worker_is_running());
 
         drop(restarted_session);

--- a/crates/wrac_log/src/rt.rs
+++ b/crates/wrac_log/src/rt.rs
@@ -1,9 +1,9 @@
 use log::Level;
 use std::array;
 use std::fmt::{self, Write as _};
-use std::sync::OnceLock;
-use std::sync::atomic::{AtomicU8, AtomicU64, AtomicUsize, Ordering};
-use std::thread;
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Mutex, OnceLock};
+use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
 const RT_LOG_CAPACITY: usize = 4096;
@@ -11,7 +11,33 @@ const RT_MESSAGE_CAPACITY: usize = 256;
 const RT_TARGET_CAPACITY: usize = 96;
 
 static RT_LOG: OnceLock<RtLogInner> = OnceLock::new();
-static RT_DRAIN_WORKER: OnceLock<()> = OnceLock::new();
+static RT_DRAIN_WORKER: Mutex<Option<RtDrainWorker>> = Mutex::new(None);
+static RT_LOG_SESSION_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+/// Keeps realtime log draining alive for one plugin instance.
+///
+/// Dropping the last session stops the background drain worker before the plugin
+/// binary can be unloaded by the host.
+#[must_use = "keep LogSession alive for the plugin instance lifetime"]
+pub struct LogSession {
+    _private: (),
+}
+
+impl LogSession {
+    pub(crate) fn start() -> Self {
+        let previous_count = RT_LOG_SESSION_COUNT.fetch_add(1, Ordering::AcqRel);
+        if previous_count == 0 {
+            start_drain_if_enabled();
+        }
+        Self { _private: () }
+    }
+}
+
+impl Drop for LogSession {
+    fn drop(&mut self) {
+        release_log_session();
+    }
+}
 
 /// Configuration for the background realtime log drain worker.
 pub struct RtDrainConfig {
@@ -40,22 +66,87 @@ impl RtDrainConfig {
 /// `WRAC_RT_LOG` is set. Calling it directly is useful for tests or custom host
 /// integration.
 pub fn init_rt_log_drain_once(config: RtDrainConfig) {
-    RT_DRAIN_WORKER.get_or_init(|| {
-        let interval = config.interval;
-        let _ = thread::Builder::new()
-            .name("wrac-rt-log-drain".to_string())
-            .spawn(move || {
-                loop {
-                    thread::sleep(interval);
-                    drain_rt_logs_once();
+    let Ok(mut worker) = RT_DRAIN_WORKER.lock() else {
+        return;
+    };
+    if worker.is_some() {
+        return;
+    }
+
+    let interval = config.interval;
+    let stop_requested = std::sync::Arc::new(AtomicBool::new(false));
+    let thread_stop_requested = stop_requested.clone();
+    let Ok(handle) = thread::Builder::new()
+        .name("wrac-rt-log-drain".to_string())
+        .spawn(move || {
+            while !thread_stop_requested.load(Ordering::Acquire) {
+                thread::park_timeout(interval);
+                if thread_stop_requested.load(Ordering::Acquire) {
+                    break;
                 }
-            });
+                drain_existing_rt_logs_once();
+            }
+            drain_existing_rt_logs_once();
+        })
+    else {
+        return;
+    };
+    *worker = Some(RtDrainWorker {
+        stop_requested,
+        handle,
     });
+}
+
+fn release_log_session() {
+    let mut current_count = RT_LOG_SESSION_COUNT.load(Ordering::Acquire);
+    loop {
+        if current_count == 0 {
+            return;
+        }
+        match RT_LOG_SESSION_COUNT.compare_exchange_weak(
+            current_count,
+            current_count - 1,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        ) {
+            Ok(1) => {
+                shutdown_rt_log_drain();
+                return;
+            }
+            Ok(_) => return,
+            Err(next_count) => current_count = next_count,
+        }
+    }
+}
+
+fn shutdown_rt_log_drain() {
+    let worker = RT_DRAIN_WORKER
+        .lock()
+        .ok()
+        .and_then(|mut worker| worker.take());
+    let Some(worker) = worker else {
+        drain_existing_rt_logs_once();
+        return;
+    };
+
+    worker.stop_requested.store(true, Ordering::Release);
+    let thread = worker.handle.thread().clone();
+    thread.unpark();
+    if thread.id() != thread::current().id() {
+        let _ = worker.handle.join();
+    }
+    drain_existing_rt_logs_once();
 }
 
 /// Drains the global realtime log once on the current thread.
 pub fn drain_rt_logs_once() {
     rt_log().drain_to_log();
+}
+
+fn drain_existing_rt_logs_once() {
+    if let Some(rt_log) = RT_LOG.get() {
+        rt_log.drain_to_log();
+    }
 }
 
 pub(crate) fn start_drain_if_enabled() {
@@ -75,6 +166,11 @@ pub(crate) fn start_drain_if_enabled() {
 /// the `rt*` logging macros instead.
 pub fn write_rt_log(level: Level, target: &'static str, args: fmt::Arguments<'_>) {
     rt_log().write_fmt(level, target, args);
+}
+
+struct RtDrainWorker {
+    stop_requested: std::sync::Arc<AtomicBool>,
+    handle: JoinHandle<()>,
 }
 
 fn rt_log() -> &'static RtLogInner {
@@ -299,6 +395,22 @@ fn u8_to_level(level: u8) -> Level {
 mod tests {
     use super::*;
 
+    static SESSION_TEST_MUTEX: Mutex<()> = Mutex::new(());
+
+    fn reset_sessions_for_test() {
+        while RT_LOG_SESSION_COUNT.load(Ordering::Acquire) > 0 {
+            release_log_session();
+        }
+        shutdown_rt_log_drain();
+    }
+
+    fn drain_worker_is_running() -> bool {
+        RT_DRAIN_WORKER
+            .lock()
+            .map(|worker| worker.is_some())
+            .unwrap_or(false)
+    }
+
     #[test]
     fn drain_stops_before_unpublished_slot() {
         let log = RtLogInner::new();
@@ -324,5 +436,34 @@ mod tests {
             std::str::from_utf8(message.as_bytes()).unwrap().len(),
             message.len,
         );
+    }
+
+    #[test]
+    fn log_session_stops_drain_worker_after_last_drop() {
+        let _guard = SESSION_TEST_MUTEX
+            .lock()
+            .expect("session test mutex poisoned");
+        reset_sessions_for_test();
+
+        let first_session = LogSession::start();
+        let second_session = LogSession::start();
+
+        assert_eq!(RT_LOG_SESSION_COUNT.load(Ordering::Acquire), 2);
+        assert!(drain_worker_is_running());
+
+        drop(first_session);
+        assert_eq!(RT_LOG_SESSION_COUNT.load(Ordering::Acquire), 1);
+        assert!(drain_worker_is_running());
+
+        drop(second_session);
+        assert_eq!(RT_LOG_SESSION_COUNT.load(Ordering::Acquire), 0);
+        assert!(!drain_worker_is_running());
+
+        let restarted_session = LogSession::start();
+        assert_eq!(RT_LOG_SESSION_COUNT.load(Ordering::Acquire), 1);
+        assert!(drain_worker_is_running());
+
+        drop(restarted_session);
+        reset_sessions_for_test();
     }
 }

--- a/plugins/wrac-gain/src-plugin/src/plugin.rs
+++ b/plugins/wrac-gain/src-plugin/src/plugin.rs
@@ -92,6 +92,9 @@ impl PluginFactory for WracGainFactory {
 /// re-entrantly during lifecycle callbacks, requiring them to be reachable without
 /// acquiring the `&mut self` lock on `PluginInstance`.
 pub(crate) struct WracGainPlugin {
+    // Keep realtime log draining tied to this plugin instance. The last dropped
+    // session stops the drain worker before the plugin binary can be unloaded.
+    _log_session: wrac_log::LogSession,
     // The descriptor is instance data, not a global primary descriptor. This matters for
     // multi-product bundles where the same binary can expose more than one plugin id.
     descriptor: PluginDescriptor,
@@ -111,7 +114,11 @@ pub(crate) struct WracGainPlugin {
 }
 
 impl WracGainPlugin {
-    pub(crate) fn new(context: PluginInstanceContext, descriptor: PluginDescriptor) -> Self {
+    pub(crate) fn new(
+        context: PluginInstanceContext,
+        descriptor: PluginDescriptor,
+        log_session: wrac_log::LogSession,
+    ) -> Self {
         let shared = Arc::new(SharedState::new());
         let audio_layout = Arc::new(AudioLayoutStore::new(2));
         let audio_ports = Arc::new(WracGainAudioPorts::new(audio_layout.clone()));
@@ -136,6 +143,7 @@ impl WracGainPlugin {
         ));
 
         Self {
+            _log_session: log_session,
             descriptor,
             shared,
             audio_layout,
@@ -155,7 +163,7 @@ pub(crate) fn create_plugin_core(
     context: PluginInstanceContext,
     descriptor: PluginDescriptor,
 ) -> Box<dyn PluginInstance> {
-    wrac_log::init!(descriptor.name);
+    let log_session = wrac_log::init!(descriptor.name);
 
     log::debug!(
         "creating plugin core: id={}, name={}",
@@ -176,7 +184,7 @@ pub(crate) fn create_plugin_core(
             parameter.flags.is_bypass
         );
     }
-    Box::new(WracGainPlugin::new(context, descriptor))
+    Box::new(WracGainPlugin::new(context, descriptor, log_session))
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- make `wrac_log::init!` return a `LogSession` guard
- stop the realtime log drain worker when the final session is dropped
- keep the WRAC Gain session guard on the plugin instance

## Verification
- `cargo fmt --all --check`
- `cargo test -p wrac_log`
- `cargo check -p wrac_gain_plugin --lib`
- `cargo xtask quality`
- `cargo test --workspace`
- `cargo check -p wrac_log --release`