### PR TITLE
Drain realtime logs on RunLoop timers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3126,6 +3126,8 @@ version = "0.1.0"
 dependencies = [
  "env_logger",
  "log",
+ "novonotes_run_loop",
+ "run_loop_timer",
  "time",
 ]
 
@@ -3154,6 +3156,7 @@ dependencies = [
  "windows-sys 0.59.0",
  "wrac_clap_adapter",
  "wrac_host_context",
+ "wrac_log",
  "wxp",
 ]
 

--- a/crates/wrac_log/Cargo.toml
+++ b/crates/wrac_log/Cargo.toml
@@ -7,6 +7,8 @@ publish = false
 [dependencies]
 env_logger = "0.11"
 log = "0.4"
+novonotes_run_loop = { workspace = true }
+run_loop_timer = { workspace = true }
 time = { version = "0.3", features = ["formatting", "local-offset", "macros"] }
 
 [lints.rust]

--- a/crates/wrac_log/src/file_logger.rs
+++ b/crates/wrac_log/src/file_logger.rs
@@ -436,7 +436,7 @@ fn init_stderr(dotenv_rust_log: Option<&str>) {
     apply_default_filter(&mut builder, dotenv_rust_log);
     builder.target(Target::Stderr);
     let _ = builder.try_init();
-    crate::rt::start_drain_if_enabled();
+    crate::rt::init_rt_buffer();
 }
 
 fn init_with_file(log_file: impl AsRef<Path>, dotenv_rust_log: Option<&str>) {
@@ -457,7 +457,7 @@ fn init_with_file(log_file: impl AsRef<Path>, dotenv_rust_log: Option<&str>) {
             apply_default_filter(&mut builder, dotenv_rust_log);
             builder.target(Target::Pipe(Box::new(FileAndStderr::new(file))));
             let _ = builder.try_init();
-            crate::rt::start_drain_if_enabled();
+            crate::rt::init_rt_buffer();
         }
         Err(error) => {
             eprintln!("Failed to open log file '{}': {error}", log_file.display());

--- a/crates/wrac_log/src/file_logger.rs
+++ b/crates/wrac_log/src/file_logger.rs
@@ -19,7 +19,7 @@ static CURRENT_LOG_FILE: OnceLock<Option<PathBuf>> = OnceLock::new();
 ///
 /// Prefer calling the macro so `manifest_dir` is captured from the plugin crate,
 /// not from `wrac_log`.
-pub fn init_impl(manifest_dir: Option<&'static str>, app_name: &str) -> crate::LogSession {
+pub fn init_impl(manifest_dir: Option<&'static str>, app_name: &str) {
     INIT.call_once(|| {
         let dotenv_rust_log = rust_log_from_debug_dotenv(manifest_dir);
 
@@ -54,7 +54,6 @@ pub fn init_impl(manifest_dir: Option<&'static str>, app_name: &str) -> crate::L
         let _ = app_name;
         init_stderr(dotenv_rust_log.as_deref());
     });
-    crate::rt::LogSession::start()
 }
 
 /// Returns the directory currently used for file logging.
@@ -437,6 +436,7 @@ fn init_stderr(dotenv_rust_log: Option<&str>) {
     apply_default_filter(&mut builder, dotenv_rust_log);
     builder.target(Target::Stderr);
     let _ = builder.try_init();
+    crate::rt::start_drain_if_enabled();
 }
 
 fn init_with_file(log_file: impl AsRef<Path>, dotenv_rust_log: Option<&str>) {
@@ -457,6 +457,7 @@ fn init_with_file(log_file: impl AsRef<Path>, dotenv_rust_log: Option<&str>) {
             apply_default_filter(&mut builder, dotenv_rust_log);
             builder.target(Target::Pipe(Box::new(FileAndStderr::new(file))));
             let _ = builder.try_init();
+            crate::rt::start_drain_if_enabled();
         }
         Err(error) => {
             eprintln!("Failed to open log file '{}': {error}", log_file.display());
@@ -478,9 +479,6 @@ fn announce_log_output(destination: &str) {
 }
 
 fn apply_default_filter(builder: &mut Builder, dotenv_rust_log: Option<&str>) {
-    #[cfg(not(debug_assertions))]
-    let _ = dotenv_rust_log;
-
     if std::env::var("RUST_LOG").is_err() {
         #[cfg(debug_assertions)]
         if let Some(rust_log) = dotenv_rust_log.filter(|value| !value.trim().is_empty()) {
@@ -530,7 +528,6 @@ impl Write for FileAndStderr {
     }
 }
 
-#[cfg(debug_assertions)]
 fn get_test_name() -> String {
     std::thread::current()
         .name()

--- a/crates/wrac_log/src/lib.rs
+++ b/crates/wrac_log/src/lib.rs
@@ -17,9 +17,9 @@ pub use file_logger::{
 /// Plugin code should not call or rely on this symbol directly; use the `rt*`
 /// logging macros instead.
 pub use rt::write_rt_log as __write_rt_log;
-pub use rt::{LogSession, RtDrainConfig, drain_rt_logs_once, init_rt_log_drain_once};
+pub use rt::{RtDrainConfig, drain_rt_logs_once, init_rt_log_drain_once};
 
-/// Initializes logging for a WRAC plugin and returns a session guard.
+/// Initializes logging for a WRAC plugin.
 ///
 /// This macro must be called from the plugin crate so `CARGO_MANIFEST_DIR` points at
 /// the caller. In debug builds, the default log directory is resolved as
@@ -27,8 +27,6 @@ pub use rt::{LogSession, RtDrainConfig, drain_rt_logs_once, init_rt_log_drain_on
 /// crate would resolve that path relative to `wrac_log` instead.
 ///
 /// Initialization is process-wide and idempotent. The first call wins.
-/// Keep the returned [`LogSession`] alive for the plugin instance lifetime so
-/// realtime log draining stops only after the last instance is dropped.
 ///
 /// Output destination priority:
 /// 1. `WRAC_LOG_DIR`

--- a/crates/wrac_log/src/lib.rs
+++ b/crates/wrac_log/src/lib.rs
@@ -17,7 +17,7 @@ pub use file_logger::{
 /// Plugin code should not call or rely on this symbol directly; use the `rt*`
 /// logging macros instead.
 pub use rt::write_rt_log as __write_rt_log;
-pub use rt::{RtDrain, attach_rt_drain, drain_rt_logs_once};
+pub use rt::{RtDrainingRunLoopGuard, attach_rt_drain, drain_rt_logs_once};
 
 /// Initializes logging for a WRAC plugin.
 ///

--- a/crates/wrac_log/src/lib.rs
+++ b/crates/wrac_log/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! Regular logs are written through the `log` facade. Realtime audio threads must use
 //! the `rt*` macros, which write into a fixed-size global buffer drained later from a
-//! non-realtime worker.
+//! non-realtime run loop timer.
 
 mod file_logger;
 mod rt;
@@ -17,7 +17,7 @@ pub use file_logger::{
 /// Plugin code should not call or rely on this symbol directly; use the `rt*`
 /// logging macros instead.
 pub use rt::write_rt_log as __write_rt_log;
-pub use rt::{RtDrainConfig, drain_rt_logs_once, init_rt_log_drain_once};
+pub use rt::{RtDrain, attach_rt_drain, drain_rt_logs_once};
 
 /// Initializes logging for a WRAC plugin.
 ///

--- a/crates/wrac_log/src/rt.rs
+++ b/crates/wrac_log/src/rt.rs
@@ -18,13 +18,24 @@ thread_local! {
     static RT_DRAIN_TIMER: RefCell<Weak<RtDrainInner>> = const { RefCell::new(Weak::new()) };
 }
 
-/// Keeps realtime log draining attached to a run loop.
+/// Keeps realtime log draining attached to a [`novonotes_run_loop::RunLoopGuard`].
 ///
-/// Keep this guard alive for the same lifetime as the [`novonotes_run_loop::RunLoopGuard`]
-/// used to create it. Dropping the final guard stops the timer and drains any
-/// remaining realtime log records once on the current thread.
-#[must_use = "keep RtDrain alive while its RunLoop is alive"]
-pub struct RtDrain {
+/// Dropping this guard stops the drain timer before releasing the wrapped run loop
+/// guard, then drains any remaining realtime log records once on the current thread.
+#[must_use = "keep RtDrainingRunLoopGuard alive while its RunLoop is alive"]
+pub struct RtDrainingRunLoopGuard {
+    _rt_drain: RtDrain,
+    guard: novonotes_run_loop::RunLoopGuard,
+}
+
+impl RtDrainingRunLoopGuard {
+    /// Returns the run-loop-thread-local capability for the wrapped guard.
+    pub fn local(&self) -> &novonotes_run_loop::RunLoopLocal {
+        self.guard.local()
+    }
+}
+
+struct RtDrain {
     _inner: Rc<RtDrainInner>,
 }
 
@@ -39,11 +50,19 @@ impl Drop for RtDrainInner {
     }
 }
 
-/// Attaches realtime log draining to the given run loop.
+/// Attaches realtime log draining to the given run loop guard.
 ///
 /// Multiple calls on the same run-loop thread share one timer. The timer keeps
 /// running until the last returned guard is dropped.
-pub fn attach_rt_drain(run_loop: &novonotes_run_loop::RunLoopLocal) -> RtDrain {
+pub fn attach_rt_drain(guard: novonotes_run_loop::RunLoopGuard) -> RtDrainingRunLoopGuard {
+    let rt_drain = attach_rt_drain_to_local(guard.local());
+    RtDrainingRunLoopGuard {
+        _rt_drain: rt_drain,
+        guard,
+    }
+}
+
+fn attach_rt_drain_to_local(run_loop: &novonotes_run_loop::RunLoopLocal) -> RtDrain {
     let _ = rt_log();
     let inner = RT_DRAIN_TIMER.with(|slot| {
         if let Some(inner) = slot.borrow().upgrade() {
@@ -337,16 +356,21 @@ mod tests {
 
     #[test]
     fn rt_drain_guards_share_one_run_loop_timer() {
-        let run_loop_guard = novonotes_run_loop::RunLoop::init().expect("init test RunLoop");
+        let first_run_loop_guard = novonotes_run_loop::RunLoop::init().expect("init test RunLoop");
+        let second_run_loop_guard =
+            novonotes_run_loop::RunLoop::init().expect("share test RunLoop");
 
-        let first_drain = attach_rt_drain(run_loop_guard.local());
-        let second_drain = attach_rt_drain(run_loop_guard.local());
+        let first_drain = attach_rt_drain(first_run_loop_guard);
+        let second_drain = attach_rt_drain(second_run_loop_guard);
 
-        assert!(Rc::ptr_eq(&first_drain._inner, &second_drain._inner));
-        assert_eq!(Rc::strong_count(&first_drain._inner), 2);
+        assert!(Rc::ptr_eq(
+            &first_drain._rt_drain._inner,
+            &second_drain._rt_drain._inner
+        ));
+        assert_eq!(Rc::strong_count(&first_drain._rt_drain._inner), 2);
 
         drop(first_drain);
-        assert_eq!(Rc::strong_count(&second_drain._inner), 1);
+        assert_eq!(Rc::strong_count(&second_drain._rt_drain._inner), 1);
 
         drop(second_drain);
     }

--- a/crates/wrac_log/src/rt.rs
+++ b/crates/wrac_log/src/rt.rs
@@ -1,56 +1,63 @@
 use log::Level;
 use std::array;
+use std::cell::RefCell;
 use std::fmt::{self, Write as _};
+use std::rc::{Rc, Weak};
 use std::sync::OnceLock;
 use std::sync::atomic::{AtomicU8, AtomicU64, AtomicUsize, Ordering};
-use std::thread;
 use std::time::Duration;
 
 const RT_LOG_CAPACITY: usize = 4096;
 const RT_MESSAGE_CAPACITY: usize = 256;
 const RT_TARGET_CAPACITY: usize = 96;
+const RT_DRAIN_INTERVAL: Duration = Duration::from_millis(100);
 
 static RT_LOG: OnceLock<RtLogInner> = OnceLock::new();
-static RT_DRAIN_WORKER: OnceLock<()> = OnceLock::new();
 
-/// Configuration for the background realtime log drain worker.
-pub struct RtDrainConfig {
-    interval: Duration,
+thread_local! {
+    static RT_DRAIN_TIMER: RefCell<Weak<RtDrainInner>> = const { RefCell::new(Weak::new()) };
 }
 
-impl Default for RtDrainConfig {
-    fn default() -> Self {
-        Self {
-            interval: Duration::from_millis(100),
-        }
-    }
-}
-
-impl RtDrainConfig {
-    /// Sets how often the background worker drains realtime logs.
-    pub fn with_interval(mut self, interval: Duration) -> Self {
-        self.interval = interval;
-        self
-    }
-}
-
-/// Starts the realtime log drain worker once for the current process.
+/// Keeps realtime log draining attached to a run loop.
 ///
-/// This is called automatically by [`crate::init!`] in debug builds and when
-/// `WRAC_RT_LOG` is set. Calling it directly is useful for tests or custom host
-/// integration.
-pub fn init_rt_log_drain_once(config: RtDrainConfig) {
-    RT_DRAIN_WORKER.get_or_init(|| {
-        let interval = config.interval;
-        let _ = thread::Builder::new()
-            .name("wrac-rt-log-drain".to_string())
-            .spawn(move || {
-                loop {
-                    thread::sleep(interval);
-                    drain_rt_logs_once();
-                }
-            });
+/// Keep this guard alive for the same lifetime as the [`novonotes_run_loop::RunLoopGuard`]
+/// used to create it. Dropping the final guard stops the timer and drains any
+/// remaining realtime log records once on the current thread.
+#[must_use = "keep RtDrain alive while its RunLoop is alive"]
+pub struct RtDrain {
+    _inner: Rc<RtDrainInner>,
+}
+
+struct RtDrainInner {
+    timer: run_loop_timer::Timer,
+}
+
+impl Drop for RtDrainInner {
+    fn drop(&mut self) {
+        self.timer.stop();
+        drain_existing_rt_logs_once();
+    }
+}
+
+/// Attaches realtime log draining to the given run loop.
+///
+/// Multiple calls on the same run-loop thread share one timer. The timer keeps
+/// running until the last returned guard is dropped.
+pub fn attach_rt_drain(run_loop: &novonotes_run_loop::RunLoopLocal) -> RtDrain {
+    let _ = rt_log();
+    let inner = RT_DRAIN_TIMER.with(|slot| {
+        if let Some(inner) = slot.borrow().upgrade() {
+            return inner;
+        }
+
+        let timer = run_loop_timer::Timer::new(RT_DRAIN_INTERVAL, drain_existing_rt_logs_once);
+        timer.start(run_loop);
+        let inner = Rc::new(RtDrainInner { timer });
+        *slot.borrow_mut() = Rc::downgrade(&inner);
+        inner
     });
+    drain_existing_rt_logs_once();
+    RtDrain { _inner: inner }
 }
 
 /// Drains the global realtime log once on the current thread.
@@ -58,14 +65,16 @@ pub fn drain_rt_logs_once() {
     rt_log().drain_to_log();
 }
 
-pub(crate) fn start_drain_if_enabled() {
+fn drain_existing_rt_logs_once() {
+    if let Some(rt_log) = RT_LOG.get() {
+        rt_log.drain_to_log();
+    }
+}
+
+pub(crate) fn init_rt_buffer() {
     // Initialize from the non-realtime setup path so the first RT log write only
     // touches atomics and the fixed buffer.
     let _ = rt_log();
-
-    if cfg!(debug_assertions) || std::env::var_os("WRAC_RT_LOG").is_some() {
-        init_rt_log_drain_once(RtDrainConfig::default());
-    }
 }
 
 /// Writes one realtime log record into the fixed-size global buffer.
@@ -324,5 +333,21 @@ mod tests {
             std::str::from_utf8(message.as_bytes()).unwrap().len(),
             message.len,
         );
+    }
+
+    #[test]
+    fn rt_drain_guards_share_one_run_loop_timer() {
+        let run_loop_guard = novonotes_run_loop::RunLoop::init().expect("init test RunLoop");
+
+        let first_drain = attach_rt_drain(run_loop_guard.local());
+        let second_drain = attach_rt_drain(run_loop_guard.local());
+
+        assert!(Rc::ptr_eq(&first_drain._inner, &second_drain._inner));
+        assert_eq!(Rc::strong_count(&first_drain._inner), 2);
+
+        drop(first_drain);
+        assert_eq!(Rc::strong_count(&second_drain._inner), 1);
+
+        drop(second_drain);
     }
 }

--- a/crates/wrac_log/src/rt.rs
+++ b/crates/wrac_log/src/rt.rs
@@ -1,9 +1,9 @@
 use log::Level;
 use std::array;
 use std::fmt::{self, Write as _};
-use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, AtomicUsize, Ordering};
-use std::sync::{Mutex, OnceLock};
-use std::thread::{self, JoinHandle};
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicU8, AtomicU64, AtomicUsize, Ordering};
+use std::thread;
 use std::time::Duration;
 
 const RT_LOG_CAPACITY: usize = 4096;
@@ -11,29 +11,7 @@ const RT_MESSAGE_CAPACITY: usize = 256;
 const RT_TARGET_CAPACITY: usize = 96;
 
 static RT_LOG: OnceLock<RtLogInner> = OnceLock::new();
-static RT_DRAIN_STATE: Mutex<RtDrainState> = Mutex::new(RtDrainState::new());
-
-/// Keeps realtime log draining alive for one plugin instance.
-///
-/// Dropping the last session stops the background drain worker before the plugin
-/// binary can be unloaded by the host.
-#[must_use = "keep LogSession alive for the plugin instance lifetime"]
-pub struct LogSession {
-    _private: (),
-}
-
-impl LogSession {
-    pub(crate) fn start() -> Self {
-        start_log_session();
-        Self { _private: () }
-    }
-}
-
-impl Drop for LogSession {
-    fn drop(&mut self) {
-        release_log_session();
-    }
-}
+static RT_DRAIN_WORKER: OnceLock<()> = OnceLock::new();
 
 /// Configuration for the background realtime log drain worker.
 pub struct RtDrainConfig {
@@ -62,51 +40,17 @@ impl RtDrainConfig {
 /// `WRAC_RT_LOG` is set. Calling it directly is useful for tests or custom host
 /// integration.
 pub fn init_rt_log_drain_once(config: RtDrainConfig) {
-    let Ok(mut state) = RT_DRAIN_STATE.lock() else {
-        return;
-    };
-    state.start_worker_if_absent(config);
-}
-
-fn release_log_session() {
-    let Ok(mut state) = RT_DRAIN_STATE.lock() else {
-        return;
-    };
-    if state.session_count == 0 {
-        return;
-    }
-    state.session_count -= 1;
-    if state.session_count != 0 {
-        return;
-    }
-    if let Some(worker) = state.worker.take() {
-        // Keep the lifecycle state locked until the old worker exits. Otherwise a
-        // new session could skip startup against a worker that is about to be removed.
-        stop_drain_worker(worker);
-    } else {
-        drain_existing_rt_logs_once();
-    }
-}
-
-#[cfg(test)]
-fn shutdown_rt_log_drain() {
-    if let Ok(mut state) = RT_DRAIN_STATE.lock() {
-        if let Some(worker) = state.worker.take() {
-            stop_drain_worker(worker);
-        } else {
-            drain_existing_rt_logs_once();
-        }
-    }
-}
-
-fn stop_drain_worker(worker: RtDrainWorker) {
-    worker.stop_requested.store(true, Ordering::Release);
-    let thread = worker.handle.thread().clone();
-    thread.unpark();
-    if thread.id() != thread::current().id() {
-        let _ = worker.handle.join();
-    }
-    drain_existing_rt_logs_once();
+    RT_DRAIN_WORKER.get_or_init(|| {
+        let interval = config.interval;
+        let _ = thread::Builder::new()
+            .name("wrac-rt-log-drain".to_string())
+            .spawn(move || {
+                loop {
+                    thread::sleep(interval);
+                    drain_rt_logs_once();
+                }
+            });
+    });
 }
 
 /// Drains the global realtime log once on the current thread.
@@ -114,25 +58,13 @@ pub fn drain_rt_logs_once() {
     rt_log().drain_to_log();
 }
 
-fn drain_existing_rt_logs_once() {
-    if let Some(rt_log) = RT_LOG.get() {
-        rt_log.drain_to_log();
-    }
-}
-
-fn start_log_session() {
+pub(crate) fn start_drain_if_enabled() {
     // Initialize from the non-realtime setup path so the first RT log write only
     // touches atomics and the fixed buffer.
     let _ = rt_log();
 
-    let drain_config = (cfg!(debug_assertions) || std::env::var_os("WRAC_RT_LOG").is_some())
-        .then(RtDrainConfig::default);
-    let Ok(mut state) = RT_DRAIN_STATE.lock() else {
-        return;
-    };
-    state.session_count += 1;
-    if let Some(config) = drain_config {
-        state.start_worker_if_absent(config);
+    if cfg!(debug_assertions) || std::env::var_os("WRAC_RT_LOG").is_some() {
+        init_rt_log_drain_once(RtDrainConfig::default());
     }
 }
 
@@ -143,54 +75,6 @@ fn start_log_session() {
 /// the `rt*` logging macros instead.
 pub fn write_rt_log(level: Level, target: &'static str, args: fmt::Arguments<'_>) {
     rt_log().write_fmt(level, target, args);
-}
-
-struct RtDrainWorker {
-    stop_requested: std::sync::Arc<AtomicBool>,
-    handle: JoinHandle<()>,
-}
-
-struct RtDrainState {
-    session_count: usize,
-    worker: Option<RtDrainWorker>,
-}
-
-impl RtDrainState {
-    const fn new() -> Self {
-        Self {
-            session_count: 0,
-            worker: None,
-        }
-    }
-
-    fn start_worker_if_absent(&mut self, config: RtDrainConfig) {
-        if self.worker.is_some() {
-            return;
-        }
-
-        let interval = config.interval;
-        let stop_requested = std::sync::Arc::new(AtomicBool::new(false));
-        let thread_stop_requested = stop_requested.clone();
-        let Ok(handle) = thread::Builder::new()
-            .name("wrac-rt-log-drain".to_string())
-            .spawn(move || {
-                while !thread_stop_requested.load(Ordering::Acquire) {
-                    thread::park_timeout(interval);
-                    if thread_stop_requested.load(Ordering::Acquire) {
-                        break;
-                    }
-                    drain_existing_rt_logs_once();
-                }
-                drain_existing_rt_logs_once();
-            })
-        else {
-            return;
-        };
-        self.worker = Some(RtDrainWorker {
-            stop_requested,
-            handle,
-        });
-    }
 }
 
 fn rt_log() -> &'static RtLogInner {
@@ -415,29 +299,6 @@ fn u8_to_level(level: u8) -> Level {
 mod tests {
     use super::*;
 
-    static SESSION_TEST_MUTEX: Mutex<()> = Mutex::new(());
-
-    fn reset_sessions_for_test() {
-        shutdown_rt_log_drain();
-        if let Ok(mut state) = RT_DRAIN_STATE.lock() {
-            state.session_count = 0;
-        }
-    }
-
-    fn drain_worker_is_running() -> bool {
-        RT_DRAIN_STATE
-            .lock()
-            .map(|state| state.worker.is_some())
-            .unwrap_or(false)
-    }
-
-    fn log_session_count() -> usize {
-        RT_DRAIN_STATE
-            .lock()
-            .map(|state| state.session_count)
-            .unwrap_or_default()
-    }
-
     #[test]
     fn drain_stops_before_unpublished_slot() {
         let log = RtLogInner::new();
@@ -463,34 +324,5 @@ mod tests {
             std::str::from_utf8(message.as_bytes()).unwrap().len(),
             message.len,
         );
-    }
-
-    #[test]
-    fn log_session_stops_drain_worker_after_last_drop() {
-        let _guard = SESSION_TEST_MUTEX
-            .lock()
-            .expect("session test mutex poisoned");
-        reset_sessions_for_test();
-
-        let first_session = LogSession::start();
-        let second_session = LogSession::start();
-
-        assert_eq!(log_session_count(), 2);
-        assert!(drain_worker_is_running());
-
-        drop(first_session);
-        assert_eq!(log_session_count(), 1);
-        assert!(drain_worker_is_running());
-
-        drop(second_session);
-        assert_eq!(log_session_count(), 0);
-        assert!(!drain_worker_is_running());
-
-        let restarted_session = LogSession::start();
-        assert_eq!(log_session_count(), 1);
-        assert!(drain_worker_is_running());
-
-        drop(restarted_session);
-        reset_sessions_for_test();
     }
 }

--- a/crates/wrac_wxp_gui/Cargo.toml
+++ b/crates/wrac_wxp_gui/Cargo.toml
@@ -19,6 +19,7 @@ serde_json = "1.0"
 url = "2"
 wrac_clap_adapter = { workspace = true }
 wrac_host_context = { workspace = true }
+wrac_log = { workspace = true }
 wxp = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]

--- a/crates/wrac_wxp_gui/src/runtime.rs
+++ b/crates/wrac_wxp_gui/src/runtime.rs
@@ -16,6 +16,7 @@ thread_local! {
     // Keep the `!Send` run-loop guard on the GUI thread. `GuiThreadLease` is only a
     // cross-thread token; it releases this guard by dispatching back to the owner thread.
     static GUI_RUN_LOOP_GUARD: RefCell<Option<RunLoopGuard>> = const { RefCell::new(None) };
+    static GUI_RT_DRAIN: RefCell<Option<wrac_log::RtDrain>> = const { RefCell::new(None) };
 }
 
 static NEXT_GUI_ID: AtomicU64 = AtomicU64::new(1);
@@ -270,9 +271,14 @@ impl GuiThreadLease {
                 log::debug!("wxp GUI thread lease: RunLoop::init failed");
                 PluginError::UnsupportedHostGuiThreadingModel
             })?;
+            let rt_drain = wrac_log::attach_rt_drain(guard.local());
             GUI_RUN_LOOP_GUARD.with(|stored_guard| {
                 debug_assert!(stored_guard.borrow().is_none());
                 *stored_guard.borrow_mut() = Some(guard);
+            });
+            GUI_RT_DRAIN.with(|stored_drain| {
+                debug_assert!(stored_drain.borrow().is_none());
+                *stored_drain.borrow_mut() = Some(rt_drain);
             });
         }
 
@@ -333,6 +339,11 @@ fn release_gui_thread_lease() {
         }
     };
     if should_drop_guard {
+        GUI_RT_DRAIN.with(|stored_drain| {
+            let drain = stored_drain.borrow_mut().take();
+            debug_assert!(drain.is_some());
+            drop(drain);
+        });
         GUI_RUN_LOOP_GUARD.with(|stored_guard| {
             let guard = stored_guard.borrow_mut().take();
             debug_assert!(guard.is_some());

--- a/crates/wrac_wxp_gui/src/runtime.rs
+++ b/crates/wrac_wxp_gui/src/runtime.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::thread::ThreadId;
 
-use novonotes_run_loop::{RunLoop, RunLoopGuard, RunLoopLocal};
+use novonotes_run_loop::{RunLoop, RunLoopLocal};
 use parking_lot::Mutex;
 use wrac_clap_adapter::{GuiConfig, GuiSize, PluginError, PluginResult};
 
@@ -15,8 +15,9 @@ thread_local! {
     static GUI_RUNTIMES: RefCell<HashMap<u64, GuiRuntimeEntry>> = RefCell::new(HashMap::new());
     // Keep the `!Send` run-loop guard on the GUI thread. `GuiThreadLease` is only a
     // cross-thread token; it releases this guard by dispatching back to the owner thread.
-    static GUI_RUN_LOOP_GUARD: RefCell<Option<RunLoopGuard>> = const { RefCell::new(None) };
-    static GUI_RT_DRAIN: RefCell<Option<wrac_log::RtDrain>> = const { RefCell::new(None) };
+    static GUI_RUN_LOOP_GUARD: RefCell<Option<wrac_log::RtDrainingRunLoopGuard>> = const {
+        RefCell::new(None)
+    };
 }
 
 static NEXT_GUI_ID: AtomicU64 = AtomicU64::new(1);
@@ -45,9 +46,9 @@ struct GuiRuntimeEntry {
 /// RAII token representing a reference to the GUI thread's run loop.
 ///
 /// The token is `Send + Sync` because `WxpGuiController` is shared with host callbacks,
-/// but the `!Send` [`RunLoopGuard`] itself stays in GUI-thread TLS. Dropping this token
-/// from another host thread blocks until the reference has been released on the owning
-/// GUI thread.
+/// but the `!Send` run-loop guard itself stays in GUI-thread TLS. Dropping this token
+/// from another host thread blocks until the reference has been released on the
+/// owning GUI thread.
 pub(crate) struct GuiThreadLease {
     owner: ThreadId,
     is_active: bool,
@@ -271,14 +272,10 @@ impl GuiThreadLease {
                 log::debug!("wxp GUI thread lease: RunLoop::init failed");
                 PluginError::UnsupportedHostGuiThreadingModel
             })?;
-            let rt_drain = wrac_log::attach_rt_drain(guard.local());
+            let guard = wrac_log::attach_rt_drain(guard);
             GUI_RUN_LOOP_GUARD.with(|stored_guard| {
                 debug_assert!(stored_guard.borrow().is_none());
                 *stored_guard.borrow_mut() = Some(guard);
-            });
-            GUI_RT_DRAIN.with(|stored_drain| {
-                debug_assert!(stored_drain.borrow().is_none());
-                *stored_drain.borrow_mut() = Some(rt_drain);
             });
         }
 
@@ -339,11 +336,6 @@ fn release_gui_thread_lease() {
         }
     };
     if should_drop_guard {
-        GUI_RT_DRAIN.with(|stored_drain| {
-            let drain = stored_drain.borrow_mut().take();
-            debug_assert!(drain.is_some());
-            drop(drain);
-        });
         GUI_RUN_LOOP_GUARD.with(|stored_guard| {
             let guard = stored_guard.borrow_mut().take();
             debug_assert!(guard.is_some());

--- a/plugins/wrac-gain/src-plugin/src/plugin.rs
+++ b/plugins/wrac-gain/src-plugin/src/plugin.rs
@@ -92,9 +92,6 @@ impl PluginFactory for WracGainFactory {
 /// re-entrantly during lifecycle callbacks, requiring them to be reachable without
 /// acquiring the `&mut self` lock on `PluginInstance`.
 pub(crate) struct WracGainPlugin {
-    // Keep realtime log draining tied to this plugin instance. The last dropped
-    // session stops the drain worker before the plugin binary can be unloaded.
-    _log_session: wrac_log::LogSession,
     // The descriptor is instance data, not a global primary descriptor. This matters for
     // multi-product bundles where the same binary can expose more than one plugin id.
     descriptor: PluginDescriptor,
@@ -114,11 +111,7 @@ pub(crate) struct WracGainPlugin {
 }
 
 impl WracGainPlugin {
-    pub(crate) fn new(
-        context: PluginInstanceContext,
-        descriptor: PluginDescriptor,
-        log_session: wrac_log::LogSession,
-    ) -> Self {
+    pub(crate) fn new(context: PluginInstanceContext, descriptor: PluginDescriptor) -> Self {
         let shared = Arc::new(SharedState::new());
         let audio_layout = Arc::new(AudioLayoutStore::new(2));
         let audio_ports = Arc::new(WracGainAudioPorts::new(audio_layout.clone()));
@@ -143,7 +136,6 @@ impl WracGainPlugin {
         ));
 
         Self {
-            _log_session: log_session,
             descriptor,
             shared,
             audio_layout,
@@ -163,7 +155,7 @@ pub(crate) fn create_plugin_core(
     context: PluginInstanceContext,
     descriptor: PluginDescriptor,
 ) -> Box<dyn PluginInstance> {
-    let log_session = wrac_log::init!(descriptor.name);
+    wrac_log::init!(descriptor.name);
 
     log::debug!(
         "creating plugin core: id={}, name={}",
@@ -184,7 +176,7 @@ pub(crate) fn create_plugin_core(
             parameter.flags.is_bypass
         );
     }
-    Box::new(WracGainPlugin::new(context, descriptor, log_session))
+    Box::new(WracGainPlugin::new(context, descriptor))
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- revert the previous LogSession/background-worker lifecycle change
- keep `wrac_log::init!` focused on logger and realtime buffer initialization
- add `wrac_log::attach_rt_drain(&RunLoopLocal)` backed by a shared RunLoop timer
- attach the realtime drain to the WRAC WXP GUI RunLoop lease

## Verification
- `git diff --check`
- `cargo xtask quality`
- `cargo fmt --all --check`
- `cargo test -p wrac_log`
- `cargo check -p wrac_wxp_gui`
- `cargo test --workspace`