### PR TITLE
Use owned metadata strings in WRAC adapter

### DIFF
--- a/crates/wrac_clap_adapter/src/abi/audio_ports.rs
+++ b/crates/wrac_clap_adapter/src/abi/audio_ports.rs
@@ -75,7 +75,7 @@ unsafe extern "C" fn audio_ports_get(
             (*info).channel_count = port.channel_count;
             (*info).port_type = audio_port_type(port.port_type);
             (*info).in_place_pair = port.in_place_pair.unwrap_or(u32::MAX);
-            fill_c_char_array(&mut (*info).name, port.name);
+            fill_c_char_array(&mut (*info).name, &port.name);
         }
         true
     })

--- a/crates/wrac_clap_adapter/src/abi/gui_extension.rs
+++ b/crates/wrac_clap_adapter/src/abi/gui_extension.rs
@@ -47,7 +47,7 @@ unsafe extern "C" fn gui_is_api_supported(
             log::warn!("gui.is_api_supported: invalid API pointer");
             return false;
         };
-        gui.query().is_api_supported(api, is_floating)
+        gui.api_support().is_api_supported(api, is_floating)
     })
 }
 

--- a/crates/wrac_clap_adapter/src/abi/note_ports.rs
+++ b/crates/wrac_clap_adapter/src/abi/note_ports.rs
@@ -75,7 +75,7 @@ unsafe extern "C" fn note_ports_get(
             (*info).id = port.id;
             (*info).supported_dialects = port.supported_dialects.bits();
             (*info).preferred_dialect = port.preferred_dialect.bits();
-            fill_c_char_array(&mut (*info).name, port.name);
+            fill_c_char_array(&mut (*info).name, &port.name);
         }
         true
     })

--- a/crates/wrac_clap_adapter/src/abi/params_extension.rs
+++ b/crates/wrac_clap_adapter/src/abi/params_extension.rs
@@ -98,8 +98,8 @@ unsafe extern "C" fn params_get_info(
             (*param_info).id = info.id;
             (*param_info).flags = parameter_flags(info.flags);
             (*param_info).cookie = ptr::null_mut();
-            fill_c_char_array(&mut (*param_info).name, info.name);
-            fill_c_char_array(&mut (*param_info).module, info.module);
+            fill_c_char_array(&mut (*param_info).name, &info.name);
+            fill_c_char_array(&mut (*param_info).module, &info.module);
             (*param_info).min_value = info.min_value;
             (*param_info).max_value = info.max_value;
             (*param_info).default_value = info.default_value;

--- a/crates/wrac_clap_adapter/src/api.rs
+++ b/crates/wrac_clap_adapter/src/api.rs
@@ -43,9 +43,10 @@ pub use core::{
 };
 pub use error::{PluginError, PluginResult};
 pub use extensions::{
-    PluginAudioPortsExtension, PluginConfigurableAudioPortsExtension, PluginGuiExtension,
-    PluginGuiMainThreadExtension, PluginGuiQueryExtension, PluginLatencyExtension,
-    PluginNotePortsExtension, PluginRenderExtension, PluginStateExtension, PluginTailExtension,
+    PluginAudioPortsExtension, PluginConfigurableAudioPortsExtension, PluginGuiApiSupportExtension,
+    PluginGuiExtension, PluginGuiMainThreadExtension, PluginGuiQueryExtension,
+    PluginLatencyExtension, PluginNotePortsExtension, PluginRenderExtension, PluginStateExtension,
+    PluginTailExtension,
 };
 pub use host::{
     HostAudioPorts, HostGui, HostLifecycle, HostNotePorts, HostParams, HostState, HostTail,

--- a/crates/wrac_clap_adapter/src/api/extensions.rs
+++ b/crates/wrac_clap_adapter/src/api/extensions.rs
@@ -9,7 +9,10 @@ mod tail;
 
 pub use audio_ports::PluginAudioPortsExtension;
 pub use configurable_audio_ports::PluginConfigurableAudioPortsExtension;
-pub use gui::{PluginGuiExtension, PluginGuiMainThreadExtension, PluginGuiQueryExtension};
+pub use gui::{
+    PluginGuiApiSupportExtension, PluginGuiExtension, PluginGuiMainThreadExtension,
+    PluginGuiQueryExtension,
+};
 pub use latency::PluginLatencyExtension;
 pub use note_ports::PluginNotePortsExtension;
 pub use render::PluginRenderExtension;

--- a/crates/wrac_clap_adapter/src/api/extensions/audio_ports.rs
+++ b/crates/wrac_clap_adapter/src/api/extensions/audio_ports.rs
@@ -2,13 +2,13 @@ use crate::AudioPortInfo;
 
 /// CLAP audio-ports extension.
 ///
-/// Native CLAP marks this extension `[main-thread]`, but WRAC requires audio-thread
-/// compatibility because wrappers may query it from audio/render workers.
-/// Implementations must not block, allocate, or take contended locks.
+/// Count queries may be reached from wrapper code that must stay realtime-safe.
+/// Metadata queries are non-realtime host/control queries and may allocate owned
+/// strings before the ABI layer copies them into CLAP buffers.
 pub trait PluginAudioPortsExtension: Send + Sync + 'static {
     /// Called from CLAP `audio_ports.count`. `[thread-safe]`
     fn audio_port_count(&self, is_input: bool) -> u32;
 
-    /// Called from CLAP `audio_ports.get`. `[thread-safe]`
+    /// Called from CLAP `audio_ports.get`. `[thread-safe & control-thread]`
     fn audio_port_info(&self, index: u32, is_input: bool) -> Option<AudioPortInfo>;
 }

--- a/crates/wrac_clap_adapter/src/api/extensions/gui.rs
+++ b/crates/wrac_clap_adapter/src/api/extensions/gui.rs
@@ -1,15 +1,23 @@
 use crate::{GuiApi, GuiConfig, GuiResizeHints, GuiSize, HostWindow, PluginResult};
 
+/// Thread-safe query surface for CLAP GUI API support.
+///
+/// The AUv2 wrapper reaches CLAP `gui.is_api_supported` while answering
+/// `GetPropertyInfo(kAudioUnitProperty_CocoaUI)`. This query is expected to be a
+/// cheap capability check, so keep implementations independent of GUI runtime
+/// state: do not allocate, lock, or touch thread-affine UI objects here.
+pub trait PluginGuiApiSupportExtension: Send + Sync + 'static {
+    /// Called from CLAP `gui.is_api_supported`.
+    ///
+    /// `[thread-safe]`
+    fn is_api_supported(&self, api: GuiApi, is_floating: bool) -> bool;
+}
+
 /// CLAP GUI query surface.
 ///
 /// These methods must be safe to call from non-audio control threads. They must
 /// not touch thread-affine native UI objects directly.
 pub trait PluginGuiQueryExtension: Send + Sync + 'static {
-    /// Called from CLAP `gui.is_api_supported`.
-    ///
-    /// `[thread-safe & control-thread]`
-    fn is_api_supported(&self, api: GuiApi, is_floating: bool) -> bool;
-
     /// Called from CLAP `gui.get_preferred_api`.
     ///
     /// `[thread-safe & control-thread]`
@@ -83,6 +91,8 @@ pub trait PluginGuiMainThreadExtension: 'static {
 /// Query methods and main-thread lifecycle methods are split so product code can
 /// implement thread-safe host queries separately from native UI operations.
 pub trait PluginGuiExtension: Send + Sync + 'static {
+    fn api_support(&self) -> &(dyn PluginGuiApiSupportExtension + Send + Sync);
+
     fn query(&self) -> &(dyn PluginGuiQueryExtension + Send + Sync);
 
     fn main_thread(&self) -> &dyn PluginGuiMainThreadExtension;

--- a/crates/wrac_clap_adapter/src/api/extensions/note_ports.rs
+++ b/crates/wrac_clap_adapter/src/api/extensions/note_ports.rs
@@ -2,13 +2,13 @@ use crate::NotePortInfo;
 
 /// CLAP note-ports extension.
 ///
-/// Native CLAP marks this extension `[main-thread]`, but WRAC requires audio-thread
-/// compatibility because wrappers may query it from audio/render workers.
-/// Implementations must not block, allocate, or take contended locks.
+/// Count queries may be reached from wrapper code that must stay realtime-safe.
+/// Metadata queries are non-realtime host/control queries and may allocate owned
+/// strings before the ABI layer copies them into CLAP buffers.
 pub trait PluginNotePortsExtension: Send + Sync + 'static {
     /// Called from CLAP `note_ports.count`. `[thread-safe]`
     fn note_port_count(&self, is_input: bool) -> u32;
 
-    /// Called from CLAP `note_ports.get`. `[thread-safe]`
+    /// Called from CLAP `note_ports.get`. `[thread-safe & control-thread]`
     fn note_port_info(&self, index: u32, is_input: bool) -> Option<NotePortInfo>;
 }

--- a/crates/wrac_clap_adapter/src/api/params.rs
+++ b/crates/wrac_clap_adapter/src/api/params.rs
@@ -14,7 +14,7 @@ pub trait PluginParamsQuery: Send + Sync + 'static {
     /// Called from CLAP `params.count`. `[thread-safe]`
     fn count(&self) -> u32;
 
-    /// Called from CLAP `params.get_info`. `[thread-safe]`
+    /// Called from CLAP `params.get_info`. `[thread-safe & control-thread]`
     fn get_info(&self, index: u32) -> Option<ParamInfo>;
 
     /// Called from CLAP `params.get_value`. `[thread-safe]`

--- a/crates/wrac_clap_adapter/src/api/types.rs
+++ b/crates/wrac_clap_adapter/src/api/types.rs
@@ -5,10 +5,10 @@ use clap_sys::ext::note_ports::{
     CLAP_NOTE_DIALECT_MIDI2,
 };
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct AudioPortInfo {
     pub id: u32,
-    pub name: &'static str,
+    pub name: String,
     pub flags: AudioPortFlags,
     pub channel_count: u32,
     pub port_type: AudioPortType,
@@ -23,12 +23,12 @@ pub struct AudioPortConfigRequest {
     pub port_type: AudioPortType,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct NotePortInfo {
     pub id: u32,
     pub supported_dialects: NoteDialects,
     pub preferred_dialect: NoteDialects,
-    pub name: &'static str,
+    pub name: String,
 }
 
 /// Thin Rust representation of the CLAP note dialect bitset.
@@ -71,11 +71,11 @@ pub enum AudioPortType {
     Stereo,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct ParamInfo {
     pub id: u32,
-    pub name: &'static str,
-    pub module: &'static str,
+    pub name: String,
+    pub module: String,
     pub min_value: f64,
     pub max_value: f64,
     pub default_value: f64,

--- a/crates/wrac_clap_adapter/src/lib.rs
+++ b/crates/wrac_clap_adapter/src/lib.rs
@@ -28,10 +28,11 @@ pub use api::{
     HostLifecycle, HostNotePorts, HostParams, HostState, HostTail, HostVersion, HostWindow,
     InactiveProcessor, NoteDialects, NotePortInfo, ParamFlags, ParamFlushContext, ParamInfo,
     ParamValueEvent, PluginAudioPortsExtension, PluginConfigurableAudioPortsExtension, PluginError,
-    PluginFormat, PluginGuiExtension, PluginGuiMainThreadExtension, PluginGuiQueryExtension,
-    PluginInstance, PluginInstanceContext, PluginLatencyExtension, PluginNotePortsExtension,
-    PluginParamsQuery, PluginRenderExtension, PluginRenderMode, PluginResult, PluginStateExtension,
-    PluginTailExtension, ProcessContext, ProcessStatus, State, SystemContext,
+    PluginFormat, PluginGuiApiSupportExtension, PluginGuiExtension, PluginGuiMainThreadExtension,
+    PluginGuiQueryExtension, PluginInstance, PluginInstanceContext, PluginLatencyExtension,
+    PluginNotePortsExtension, PluginParamsQuery, PluginRenderExtension, PluginRenderMode,
+    PluginResult, PluginStateExtension, PluginTailExtension, ProcessContext, ProcessStatus, State,
+    SystemContext,
 };
 #[cfg(feature = "raw-clap-forwarding")]
 pub use api::{RawParamFlushContext, RawProcessContext};

--- a/crates/wrac_wxp_gui/src/controller.rs
+++ b/crates/wrac_wxp_gui/src/controller.rs
@@ -9,8 +9,9 @@ use crate::window::StoredParentWindow;
 use novonotes_run_loop::{RunLoop, RunLoopLocal};
 use parking_lot::Mutex;
 use wrac_clap_adapter::{
-    GuiApi, GuiConfig, GuiResizeHints, GuiSize, HostWindow, PluginError, PluginGuiExtension,
-    PluginGuiMainThreadExtension, PluginGuiQueryExtension, PluginResult,
+    GuiApi, GuiConfig, GuiResizeHints, GuiSize, HostWindow, PluginError,
+    PluginGuiApiSupportExtension, PluginGuiExtension, PluginGuiMainThreadExtension,
+    PluginGuiQueryExtension, PluginResult,
 };
 use wrac_host_context::{HostContext, HostFamily, PluginFormat};
 
@@ -657,11 +658,13 @@ fn corrected_scale_for_parent(_parent: Option<StoredParentWindow>) -> Option<f64
     None
 }
 
-impl PluginGuiQueryExtension for WxpGuiController {
+impl PluginGuiApiSupportExtension for WxpGuiController {
     fn is_api_supported(&self, api: GuiApi, is_floating: bool) -> bool {
         !is_floating && api == default_gui_api()
     }
+}
 
+impl PluginGuiQueryExtension for WxpGuiController {
     fn preferred_api(&self) -> Option<GuiConfig> {
         Some(default_gui_configuration())
     }
@@ -692,7 +695,7 @@ impl PluginGuiQueryExtension for WxpGuiController {
 impl PluginGuiMainThreadExtension for WxpGuiController {
     fn create(&self, configuration: GuiConfig) -> PluginResult<()> {
         log::debug!("wxp controller: create called: configuration={configuration:?}");
-        if !PluginGuiQueryExtension::is_api_supported(
+        if !PluginGuiApiSupportExtension::is_api_supported(
             self,
             configuration.api,
             configuration.is_floating,
@@ -930,6 +933,10 @@ impl PluginGuiMainThreadExtension for WxpGuiController {
 }
 
 impl PluginGuiExtension for WxpGuiController {
+    fn api_support(&self) -> &(dyn PluginGuiApiSupportExtension + Send + Sync) {
+        self
+    }
+
     fn query(&self) -> &(dyn PluginGuiQueryExtension + Send + Sync) {
         self
     }

--- a/crates/wrac_wxp_gui/src/controller.rs
+++ b/crates/wrac_wxp_gui/src/controller.rs
@@ -15,8 +15,10 @@ use wrac_clap_adapter::{
 };
 use wrac_host_context::{HostContext, HostFamily, PluginFormat};
 
+mod defaults;
 mod resize;
 
+use self::defaults::{default_gui_api, default_gui_configuration};
 use self::resize::HostGuiLayout;
 pub use self::resize::WxpGuiResizeHandle;
 
@@ -979,23 +981,6 @@ enum ShowAction {
     Create {
         generation: u64,
     },
-}
-
-fn default_gui_api() -> GuiApi {
-    if cfg!(target_os = "macos") {
-        GuiApi::Cocoa
-    } else if cfg!(target_os = "windows") {
-        GuiApi::Win32
-    } else {
-        GuiApi::X11
-    }
-}
-
-fn default_gui_configuration() -> GuiConfig {
-    GuiConfig {
-        api: default_gui_api(),
-        is_floating: false,
-    }
 }
 
 #[cfg(test)]

--- a/crates/wrac_wxp_gui/src/controller/defaults.rs
+++ b/crates/wrac_wxp_gui/src/controller/defaults.rs
@@ -1,0 +1,18 @@
+use wrac_clap_adapter::{GuiApi, GuiConfig};
+
+pub(super) fn default_gui_api() -> GuiApi {
+    if cfg!(target_os = "macos") {
+        GuiApi::Cocoa
+    } else if cfg!(target_os = "windows") {
+        GuiApi::Win32
+    } else {
+        GuiApi::X11
+    }
+}
+
+pub(super) fn default_gui_configuration() -> GuiConfig {
+    GuiConfig {
+        api: default_gui_api(),
+        is_floating: false,
+    }
+}

--- a/plugins/wrac-gain/src-plugin/src/plugin/audio_ports.rs
+++ b/plugins/wrac-gain/src-plugin/src/plugin/audio_ports.rs
@@ -54,7 +54,7 @@ impl PluginAudioPortsExtension for WracGainAudioPorts {
         (index == 0).then_some(if is_input {
             AudioPortInfo {
                 id: 1,
-                name: "Main In",
+                name: "Main In".to_string(),
                 flags: AudioPortFlags {
                     is_main: true,
                     ..AudioPortFlags::default()
@@ -66,7 +66,7 @@ impl PluginAudioPortsExtension for WracGainAudioPorts {
         } else {
             AudioPortInfo {
                 id: 2,
-                name: "Main Out",
+                name: "Main Out".to_string(),
                 flags: AudioPortFlags {
                     is_main: true,
                     ..AudioPortFlags::default()

--- a/plugins/wrac-gain/src-plugin/src/plugin/params.rs
+++ b/plugins/wrac-gain/src-plugin/src/plugin/params.rs
@@ -29,7 +29,13 @@ enum ParameterKind {
 #[derive(Debug, Clone, Copy)]
 struct ParameterSpec {
     kind: ParameterKind,
-    info: ParamInfo,
+    id: u32,
+    name: &'static str,
+    module: &'static str,
+    min_value: f64,
+    max_value: f64,
+    default_value: f64,
+    flags: ParamFlags,
     // CLAP exposes normalized host-domain values, while the DSP and GUI use plain
     // product-domain values. Keeping both domains in the spec prevents host metadata,
     // GUI mapping, defaults, and DSP ranges from drifting inside the Rust contract.
@@ -47,15 +53,13 @@ struct ParameterSpec {
 const PARAM_SPECS: &[ParameterSpec] = &[
     ParameterSpec {
         kind: ParameterKind::Bypass,
-        info: ParamInfo {
-            id: PARAM_BYPASS_ID,
-            name: "Bypass",
-            module: "",
-            min_value: 0.0,
-            max_value: 1.0,
-            default_value: 0.0,
-            flags: param_flags(true, true, true, true),
-        },
+        id: PARAM_BYPASS_ID,
+        name: "Bypass",
+        module: "",
+        min_value: 0.0,
+        max_value: 1.0,
+        default_value: 0.0,
+        flags: param_flags(true, true, true, true),
         plain_min: 0.0,
         plain_max: 1.0,
         plain_default: 0.0,
@@ -65,15 +69,13 @@ const PARAM_SPECS: &[ParameterSpec] = &[
     },
     ParameterSpec {
         kind: ParameterKind::Gain,
-        info: ParamInfo {
-            id: PARAM_GAIN_ID,
-            name: "Gain",
-            module: "",
-            min_value: 0.0,
-            max_value: 1.0,
-            default_value: DEFAULT_GAIN_HOST_VALUE,
-            flags: param_flags(true, false, false, false),
-        },
+        id: PARAM_GAIN_ID,
+        name: "Gain",
+        module: "",
+        min_value: 0.0,
+        max_value: 1.0,
+        default_value: DEFAULT_GAIN_HOST_VALUE,
+        flags: param_flags(true, false, false, false),
         plain_min: MIN_GAIN as f64,
         plain_max: MAX_GAIN as f64,
         plain_default: DEFAULT_GAIN as f64,
@@ -130,7 +132,7 @@ impl PluginParamsQuery for WracGainParamsExtension {
     }
 
     fn get_info(&self, index: u32) -> Option<ParamInfo> {
-        PARAM_SPECS.get(index as usize).map(|spec| spec.info)
+        PARAM_SPECS.get(index as usize).map(param_info)
     }
 
     /// Answers the host's query for the current value of a parameter.
@@ -287,7 +289,7 @@ fn param_spec(parameter_id: u32) -> PluginResult<&'static ParameterSpec> {
     // by id after discovery so inserting a new parameter does not silently reroute edits.
     PARAM_SPECS
         .iter()
-        .find(|spec| spec.info.id == parameter_id)
+        .find(|spec| spec.id == parameter_id)
         .ok_or(PluginError::InvalidParameter)
 }
 
@@ -298,7 +300,7 @@ pub(crate) fn clamp_gain(gain: f32) -> f32 {
 }
 
 pub(crate) fn parameter_infos() -> impl Iterator<Item = ParamInfo> {
-    PARAM_SPECS.iter().map(|spec| spec.info)
+    PARAM_SPECS.iter().map(param_info)
 }
 
 /// Converts a plain value to a display string. GUI payloads route through here too, so
@@ -329,8 +331,8 @@ pub(crate) fn notify_gui_parameters(shared: &SharedState, mut notify: impl FnMut
     // still maps the gain control explicitly in TypeScript, but Rust owns the list of
     // parameters worth pushing over the WebView channel.
     for spec in PARAM_SPECS.iter().filter(|spec| spec.gui_role.is_some()) {
-        if let Some(value) = shared.parameter_value(spec.info.id) {
-            notify(spec.info.id, value);
+        if let Some(value) = shared.parameter_value(spec.id) {
+            notify(spec.id, value);
         }
     }
 }
@@ -366,6 +368,18 @@ pub(crate) fn gain_db_text(gain: f64) -> String {
 fn gain_spec() -> &'static ParameterSpec {
     PARAM_SPECS
         .iter()
-        .find(|spec| spec.info.id == PARAM_GAIN_ID)
+        .find(|spec| spec.id == PARAM_GAIN_ID)
         .expect("PARAM_GAIN_ID must be present in PARAM_SPECS")
+}
+
+fn param_info(spec: &ParameterSpec) -> ParamInfo {
+    ParamInfo {
+        id: spec.id,
+        name: spec.name.to_string(),
+        module: spec.module.to_string(),
+        min_value: spec.min_value,
+        max_value: spec.max_value,
+        default_value: spec.default_value,
+        flags: spec.flags,
+    }
 }


### PR DESCRIPTION
## 概要
- `wrac_clap_adapter` の metadata 型を owned `String` に変更
- `params.get_info` / `audio_ports.get` / `note_ports.get` を non-RT metadata query として annotation 修正
- wrac-gain サンプルを owned metadata に追随

## 確認
- `cargo check -p wrac_clap_adapter -p wrac_gain_plugin --all-targets`

## 関連
- novonotes-products 側の CoreDevice schema / value mirror 整理 PR がこの submodule commit に依存します。
