### PR TITLE
Add async file logger lifecycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3126,8 +3126,6 @@ version = "0.1.0"
 dependencies = [
  "env_logger",
  "log",
- "novonotes_run_loop",
- "run_loop_timer",
  "time",
 ]
 

--- a/crates/wrac_clap_adapter/src/abi/entry_callbacks.rs
+++ b/crates/wrac_clap_adapter/src/abi/entry_callbacks.rs
@@ -53,7 +53,7 @@ pub(crate) unsafe extern "C" fn entry_init(
         }
 
         if let Some(config) = registration.entry.log_config() {
-            wrac_log::configure(config);
+            registration.configure_log_runtime(config);
         }
 
         let plugin_path = if plugin_path.is_null() {

--- a/crates/wrac_clap_adapter/src/abi/entry_callbacks.rs
+++ b/crates/wrac_clap_adapter/src/abi/entry_callbacks.rs
@@ -14,7 +14,7 @@ use super::{
 };
 use crate::entry::{
     EntryContext, EntryRegistration, decrement_entry_init_count, entry_init_count,
-    increment_entry_init_count, reset_entry_init_count,
+    increment_entry_init_count, reset_entry_init_count, retain_entry_instance,
 };
 use crate::factory::{
     AaxFactoryState, Auv2FactoryState, ClapPluginFactoryAsAax, ClapPluginFactoryAsAuv2,
@@ -52,6 +52,10 @@ pub(crate) unsafe extern "C" fn entry_init(
             return true;
         }
 
+        if let Some(config) = registration.entry.log_config() {
+            wrac_log::configure(config);
+        }
+
         let plugin_path = if plugin_path.is_null() {
             None
         } else {
@@ -59,14 +63,17 @@ pub(crate) unsafe extern "C" fn entry_init(
             match plugin_path.to_str() {
                 Ok(plugin_path) => Some(plugin_path),
                 Err(error) => {
-                    log::warn!("entry.init: invalid UTF-8 plugin_path: {error}");
+                    let _ = error;
                     reset_entry_init_count(registration);
                     return false;
                 }
             }
         };
-        if let Err(error) = registration.entry.init(EntryContext { plugin_path }) {
-            log::warn!("entry.init: product init failed: {error}");
+        if registration
+            .entry
+            .init(EntryContext { plugin_path })
+            .is_err()
+        {
             reset_entry_init_count(registration);
             return false;
         }
@@ -81,7 +88,6 @@ pub(crate) unsafe extern "C" fn entry_init(
 pub(crate) unsafe extern "C" fn entry_deinit(registration: &'static EntryRegistration) {
     ffi_unit(|| {
         if entry_init_count(registration) == 0 {
-            log::warn!("entry.deinit: called while entry is not initialized");
             return;
         }
         let count = decrement_entry_init_count(registration);
@@ -316,6 +322,7 @@ pub(crate) unsafe extern "C" fn factory_create_plugin(
         let instance_ptr = (&mut *instance) as *mut PluginInstanceState;
         instance.plugin.plugin_data = instance_ptr.cast();
         let plugin_ptr = &instance.plugin as *const clap_plugin;
+        retain_entry_instance(registration);
         let _ = Box::into_raw(instance);
         plugin_ptr
     })

--- a/crates/wrac_clap_adapter/src/abi/plugin_callbacks.rs
+++ b/crates/wrac_clap_adapter/src/abi/plugin_callbacks.rs
@@ -27,6 +27,7 @@ use super::{
     audio_ports, configurable_audio_ports, gui_extension, latency_extension, note_ports,
     params_extension, render_extension, state_extension, tail_extension, vst3_extension,
 };
+use crate::entry::release_entry_instance;
 use crate::{
     ActivateContext, PluginInstanceContext, ProcessContext, ProcessStatus, TransportEvent,
 };
@@ -63,8 +64,9 @@ pub(super) unsafe extern "C" fn plugin_init(plugin: *const clap_plugin) -> bool 
             log::warn!("plugin.init: product factory returned no plugin core");
             return false;
         };
-        // Product construction initializes logging. Emit immediately afterward so
-        // wrapper/host routing is visible before capability queries or GUI attachment.
+        // Instance creation starts plugin logging before CLAP init. Emit immediately
+        // after product construction so wrapper/host routing is visible before
+        // capability queries or GUI attachment.
         log::info!(
             "plugin.init: host_context host=\"{}\" process=\"{}\" format={} clap_host_name=\"{}\"",
             instance.host_context.host.display_name,
@@ -200,6 +202,7 @@ pub(super) unsafe extern "C" fn plugin_destroy(plugin: *const clap_plugin) {
         if detach_in_adapter {
             registration.entry.detach_main_thread();
         }
+        release_entry_instance(registration);
     });
 }
 

--- a/crates/wrac_clap_adapter/src/abi/tests.rs
+++ b/crates/wrac_clap_adapter/src/abi/tests.rs
@@ -21,7 +21,7 @@ use super::{
 use crate::entry::EntryRegistration;
 use crate::{
     ActivateContext, ActivateNotifications, ActivateResult, ActiveProcessor, EntryContext,
-    HostAudioPorts, HostLifecycle, HostNotePorts, InactiveProcessor, NoteDialects,
+    HostAudioPorts, HostLifecycle, HostNotePorts, InactiveProcessor, LogConfig, NoteDialects,
     ParamFlushContext, PluginDescriptor, PluginEntry, PluginFactory, PluginInstance,
     PluginInstanceContext, PluginLatencyExtension, PluginParamsQuery, PluginResult, ProcessContext,
     ProcessStatus,
@@ -527,6 +527,10 @@ struct TestEntry {
 }
 
 impl PluginEntry for TestEntry {
+    fn log_config(&'static self) -> Option<&'static LogConfig> {
+        None
+    }
+
     fn init(&self, _context: EntryContext<'_>) -> PluginResult<()> {
         Ok(())
     }

--- a/crates/wrac_clap_adapter/src/entry.rs
+++ b/crates/wrac_clap_adapter/src/entry.rs
@@ -2,16 +2,40 @@ use std::sync::{Mutex, OnceLock};
 
 use crate::factory::PluginRegistrationStorage;
 use crate::{PluginDescriptor, PluginInstance, PluginInstanceContext, PluginResult};
+pub use wrac_log::{LogConfig, LogOutput};
 
 pub struct EntryContext<'a> {
     pub plugin_path: Option<&'a str>,
 }
 
 pub trait PluginEntry: Send + Sync + 'static {
+    /// Provides process-wide logger configuration without opening files or writing to stderr.
+    ///
+    /// The adapter installs a lightweight logger during entry initialization. The
+    /// file destination is opened lazily on the first log write or the first plugin
+    /// instance, whichever comes first. Return a stable static configuration so
+    /// repeated entry initialization cannot change logger identity or destination.
+    ///
+    /// Plugins managed by this adapter must not call `wrac_log::configure` or the
+    /// async file-writer lifecycle APIs directly. Standalone apps and other binaries
+    /// that do not enter through this adapter are responsible for calling
+    /// `wrac_log::configure` themselves.
+    fn log_config(&'static self) -> Option<&'static LogConfig>;
+
+    /// Initializes entry-level state.
+    ///
+    /// This callback belongs to the DSO entry lifecycle and may run during plugin
+    /// scanning without any plugin instance. Implementations must not log, open
+    /// files, write to stderr, or start worker threads here.
     fn init(&self, _context: EntryContext<'_>) -> PluginResult<()> {
         Ok(())
     }
 
+    /// Releases entry-level state.
+    ///
+    /// This callback can run close to DSO unload. Implementations must not log,
+    /// perform file I/O, or join worker threads here; per-instance cleanup must
+    /// happen when the last plugin instance is destroyed.
     fn deinit(&self) {}
 
     fn attach_main_thread(&self) {}
@@ -36,11 +60,18 @@ pub struct EntryRegistration {
     pub(crate) entry: &'static dyn PluginEntry,
     storage: OnceLock<PluginRegistrationStorage>,
     init_state: Mutex<EntryInitState>,
+    instance_state: Mutex<EntryInstanceState>,
 }
 
 #[derive(Debug, Default)]
 struct EntryInitState {
     count: u32,
+}
+
+#[derive(Default)]
+struct EntryInstanceState {
+    count: u32,
+    async_file_logger_guard: Option<wrac_log::__adapter::AsyncFileLoggerGuard>,
 }
 
 // Safety: `entry` is immutable and all mutable state is synchronized. Factory queries
@@ -54,6 +85,10 @@ impl EntryRegistration {
             entry,
             storage: OnceLock::new(),
             init_state: Mutex::new(EntryInitState { count: 0 }),
+            instance_state: Mutex::new(EntryInstanceState {
+                count: 0,
+                async_file_logger_guard: None,
+            }),
         }
     }
 
@@ -95,4 +130,26 @@ pub(crate) fn reset_entry_init_count(registration: &'static EntryRegistration) {
         .lock()
         .expect("entry init state mutex poisoned");
     state.count = 0;
+}
+
+pub(crate) fn retain_entry_instance(registration: &'static EntryRegistration) {
+    let mut state = registration
+        .instance_state
+        .lock()
+        .expect("entry instance state mutex poisoned");
+    state.count = state.count.saturating_add(1);
+    if state.count == 1 {
+        state.async_file_logger_guard = wrac_log::__adapter::start_async_file_logger();
+    }
+}
+
+pub(crate) fn release_entry_instance(registration: &'static EntryRegistration) {
+    let mut state = registration
+        .instance_state
+        .lock()
+        .expect("entry instance state mutex poisoned");
+    state.count = state.count.saturating_sub(1);
+    if state.count == 0 {
+        state.async_file_logger_guard = None;
+    }
 }

--- a/crates/wrac_clap_adapter/src/entry.rs
+++ b/crates/wrac_clap_adapter/src/entry.rs
@@ -16,10 +16,10 @@ pub trait PluginEntry: Send + Sync + 'static {
     /// instance, whichever comes first. Return a stable static configuration so
     /// repeated entry initialization cannot change logger identity or destination.
     ///
-    /// Plugins managed by this adapter must not call `wrac_log::configure` or the
-    /// async file-writer lifecycle APIs directly. Standalone apps and other binaries
-    /// that do not enter through this adapter are responsible for calling
-    /// `wrac_log::configure` themselves.
+    /// Plugins managed by this adapter must not call `wrac_log` configure APIs
+    /// directly. Standalone apps and other binaries that do not enter through
+    /// this adapter are responsible for calling `wrac_log::configure_standalone`
+    /// and holding the returned runtime themselves.
     fn log_config(&'static self) -> Option<&'static LogConfig>;
 
     /// Initializes entry-level state.
@@ -59,6 +59,7 @@ pub trait PluginFactory: Send + Sync + 'static {
 pub struct EntryRegistration {
     pub(crate) entry: &'static dyn PluginEntry,
     storage: OnceLock<PluginRegistrationStorage>,
+    log_runtime: OnceLock<wrac_log::PluginLogRuntime>,
     init_state: Mutex<EntryInitState>,
     instance_state: Mutex<EntryInstanceState>,
 }
@@ -71,7 +72,7 @@ struct EntryInitState {
 #[derive(Default)]
 struct EntryInstanceState {
     count: u32,
-    async_file_logger_guard: Option<wrac_log::__adapter::AsyncFileLoggerGuard>,
+    async_file_logger_guard: Option<wrac_log::PluginLogInstanceGuard>,
 }
 
 // Safety: `entry` is immutable and all mutable state is synchronized. Factory queries
@@ -84,6 +85,7 @@ impl EntryRegistration {
         Self {
             entry,
             storage: OnceLock::new(),
+            log_runtime: OnceLock::new(),
             init_state: Mutex::new(EntryInitState { count: 0 }),
             instance_state: Mutex::new(EntryInstanceState {
                 count: 0,
@@ -95,6 +97,16 @@ impl EntryRegistration {
     pub(crate) fn storage(&'static self) -> &'static PluginRegistrationStorage {
         self.storage
             .get_or_init(|| PluginRegistrationStorage::new(self))
+    }
+
+    pub(crate) fn configure_log_runtime(&'static self, config: &'static LogConfig) {
+        let _ = self
+            .log_runtime
+            .get_or_init(|| wrac_log::configure_plugin(config));
+    }
+
+    fn log_runtime(&self) -> Option<&wrac_log::PluginLogRuntime> {
+        self.log_runtime.get()
     }
 }
 
@@ -139,7 +151,10 @@ pub(crate) fn retain_entry_instance(registration: &'static EntryRegistration) {
         .expect("entry instance state mutex poisoned");
     state.count = state.count.saturating_add(1);
     if state.count == 1 {
-        state.async_file_logger_guard = wrac_log::__adapter::start_async_file_logger();
+        let Some(log_runtime) = registration.log_runtime() else {
+            return;
+        };
+        state.async_file_logger_guard = Some(log_runtime.retain_instance());
     }
 }
 

--- a/crates/wrac_clap_adapter/src/lib.rs
+++ b/crates/wrac_clap_adapter/src/lib.rs
@@ -39,7 +39,7 @@ pub use api::{RawParamFlushContext, RawProcessContext};
 pub use descriptor::{
     AaxDescriptor, AaxStemConfig, Auv2Descriptor, PluginDescriptor, PluginFeature, Vst3Descriptor,
 };
-pub use entry::{EntryContext, PluginEntry, PluginFactory};
+pub use entry::{EntryContext, LogConfig, LogOutput, PluginEntry, PluginFactory};
 pub use events::{
     EventLists, InputEvent, InputEvents, Midi2Event, MidiEvent, MidiSysexEvent, NoteEvent,
     NoteExpressionEvent, OutputEvent, OutputEvents, ParamGestureEvent, ParamInputEvents,

--- a/crates/wrac_log/Cargo.toml
+++ b/crates/wrac_log/Cargo.toml
@@ -7,8 +7,6 @@ publish = false
 [dependencies]
 env_logger = "0.11"
 log = "0.4"
-novonotes_run_loop = { workspace = true }
-run_loop_timer = { workspace = true }
 time = { version = "0.3", features = ["formatting", "local-offset", "macros"] }
 
 [lints.rust]

--- a/crates/wrac_log/src/file_logger.rs
+++ b/crates/wrac_log/src/file_logger.rs
@@ -6,13 +6,26 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, Once, OnceLock, mpsc};
 use std::thread::JoinHandle;
+use std::time::Duration;
 use time::{OffsetDateTime, macros::format_description};
 
-const MAX_LOG_FILES: usize = 30;
-const DEFAULT_RECENT_LOG_MAX_FILES: usize = 30;
-const DEFAULT_RECENT_LOG_MAX_TOTAL_BYTES: u64 = 50 * 1024 * 1024;
-const MAX_UNIQUE_ARCHIVED_LOG_FILE_ATTEMPTS: u32 = 1000;
+mod dotenv;
+mod recent_logs;
+mod rt_drain;
+
+use dotenv::rust_log_from_debug_dotenv;
+#[cfg(test)]
+use dotenv::{debug_dotenv_path, parse_dotenv_rust_log};
+#[cfg(test)]
+use recent_logs::MAX_LOG_FILES;
+use recent_logs::{
+    DEFAULT_RECENT_LOG_MAX_FILES, DEFAULT_RECENT_LOG_MAX_TOTAL_BYTES, archive_existing_latest_log,
+    collect_recent_log_files_from_current, latest_log_file_path, log_file_stem, rotate_logs,
+};
+use rt_drain::drain_rt_records_to_destination;
+
 const ASYNC_LOG_QUEUE_CAPACITY: usize = 4096;
+const ASYNC_WORKER_RT_DRAIN_INTERVAL: Duration = Duration::from_millis(20);
 const ASYNC_MODE: u8 = 0;
 const BLOCKING_MODE: u8 = 1;
 
@@ -165,60 +178,6 @@ impl Drop for AsyncFileLoggerGuard {
     }
 }
 
-fn collect_recent_log_files_from_current(
-    current_log_file: &Path,
-    options: &RecentLogFilesOptions,
-) -> std::io::Result<Vec<PathBuf>> {
-    let Some(log_dir) = current_log_file.parent() else {
-        return Ok(Vec::new());
-    };
-    let Some(current_log_file_name) = current_log_file.file_name().and_then(|name| name.to_str())
-    else {
-        return Ok(Vec::new());
-    };
-    let Some(file_stem) = current_log_file_name.strip_suffix(" Latest.log") else {
-        return Ok(vec![current_log_file.to_path_buf()]);
-    };
-
-    let mut archived_logs = Vec::new();
-    for entry in std::fs::read_dir(log_dir)? {
-        let entry = entry?;
-        let path = entry.path();
-        if path == current_log_file {
-            continue;
-        }
-        let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
-            continue;
-        };
-        if !is_archived_log_file_name(file_name, file_stem) {
-            continue;
-        }
-        let modified = entry.metadata()?.modified()?;
-        archived_logs.push((modified, path));
-    }
-    archived_logs.sort_by_key(|(modified, _)| std::cmp::Reverse(*modified));
-
-    // After a host crash, the crashed session's previous Latest log becomes an archived
-    // log on the next launch. Include recent archives so diagnostic bundles can still
-    // capture the failure that happened before the current session.
-    let mut selected = vec![current_log_file.to_path_buf()];
-    selected.extend(archived_logs.into_iter().map(|(_, path)| path));
-    selected.truncate(options.max_files.max(1));
-
-    // The current session describes the user's current state and is always included.
-    // Older sessions are included newest first while respecting the total size limit.
-    let mut total_bytes = 0_u64;
-    let mut limited = Vec::new();
-    for path in selected {
-        let size = std::fs::metadata(&path)?.len();
-        if limited.is_empty() || total_bytes.saturating_add(size) <= options.max_total_bytes {
-            total_bytes = total_bytes.saturating_add(size);
-            limited.push(path);
-        }
-    }
-    Ok(limited)
-}
-
 /// Initializes logging for tests.
 ///
 /// In debug builds, `WRAC_LOG_DIR` creates a per-test timestamped log file. Without
@@ -235,196 +194,6 @@ pub fn init_test() {
             init_stderr(None);
         }
     });
-}
-
-fn rotate_logs(log_dir: &Path, file_stem: &str) {
-    let Ok(entries) = std::fs::read_dir(log_dir) else {
-        return;
-    };
-
-    let mut log_files = entries
-        .filter_map(|entry| entry.ok())
-        .filter(|entry| is_archived_log_file_name(&entry.file_name().to_string_lossy(), file_stem))
-        .collect::<Vec<_>>();
-    if log_files.len() <= MAX_LOG_FILES {
-        return;
-    }
-
-    // Rotate by modification time so the newest archived logs survive even if a
-    // timestamped filename was created by a system clock with low precision.
-    log_files.sort_by_key(|entry| {
-        entry
-            .metadata()
-            .and_then(|metadata| metadata.modified())
-            .ok()
-    });
-    let files_to_delete = log_files.len() - MAX_LOG_FILES;
-    for entry in log_files.into_iter().take(files_to_delete) {
-        let _ = std::fs::remove_file(entry.path());
-    }
-}
-
-fn latest_log_file_path(log_dir: &Path, file_stem: &str) -> PathBuf {
-    log_dir.join(format!("{file_stem} Latest.log"))
-}
-
-fn archive_existing_latest_log(latest_log_file: &Path, file_stem: &str) -> std::io::Result<()> {
-    if !latest_log_file.exists() {
-        return Ok(());
-    }
-
-    let Some(log_dir) = latest_log_file.parent() else {
-        return Ok(());
-    };
-    match std::fs::rename(
-        latest_log_file,
-        unique_archived_log_file_path(log_dir, file_stem)?,
-    ) {
-        Ok(()) => Ok(()),
-        // Validators and plugin scanners can create multiple short-lived plugin
-        // processes at once. Another process may archive the same Latest log after
-        // our exists check, which is already a successful outcome for this session.
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(error) => Err(error),
-    }
-}
-
-fn unique_archived_log_file_path(log_dir: &Path, file_stem: &str) -> std::io::Result<PathBuf> {
-    let timestamp = get_timestamp();
-    let first = log_dir.join(format!("{file_stem} {timestamp}.log"));
-    if !first.exists() {
-        return Ok(first);
-    }
-
-    // Fast restarts or coarse system clocks can collide on the same timestamp. Bound
-    // the suffix search so an abnormal directory state cannot turn archive creation
-    // into an infinite loop.
-    for index in 1..MAX_UNIQUE_ARCHIVED_LOG_FILE_ATTEMPTS {
-        let candidate = log_dir.join(format!("{file_stem} {timestamp}-{index}.log"));
-        if !candidate.exists() {
-            return Ok(candidate);
-        }
-    }
-
-    Err(std::io::Error::new(
-        std::io::ErrorKind::AlreadyExists,
-        format!(
-            "failed to find a unique archived log file name for '{file_stem}' after {MAX_UNIQUE_ARCHIVED_LOG_FILE_ATTEMPTS} attempts",
-        ),
-    ))
-}
-
-fn is_archived_log_file_name(file_name: &str, file_stem: &str) -> bool {
-    file_name.starts_with(&format!("{file_stem} "))
-        && file_name.ends_with(".log")
-        && file_name != format!("{file_stem} Latest.log")
-}
-
-fn log_file_stem(app_name: &str) -> String {
-    // The app name is also user-visible in the log filename. Replace only characters
-    // that are unsafe or awkward across the major target filesystems.
-    let sanitized = app_name
-        .chars()
-        .map(|ch| {
-            if ch.is_control() || matches!(ch, '<' | '>' | ':' | '"' | '/' | '\\' | '|' | '?' | '*')
-            {
-                '_'
-            } else {
-                ch
-            }
-        })
-        .collect::<String>()
-        .trim()
-        .to_string();
-
-    if sanitized.is_empty() {
-        "Application".to_string()
-    } else {
-        sanitized
-    }
-}
-
-#[cfg(debug_assertions)]
-fn rust_log_from_debug_dotenv(search_dir: Option<&Path>) -> Option<String> {
-    if std::env::var("RUST_LOG").is_ok() {
-        return None;
-    }
-
-    let dotenv_path = debug_dotenv_path(search_dir?)?;
-    let Ok(content) = std::fs::read_to_string(&dotenv_path) else {
-        return None;
-    };
-    parse_dotenv_rust_log(&content)
-}
-
-#[cfg(not(debug_assertions))]
-fn rust_log_from_debug_dotenv(search_dir: Option<&Path>) -> Option<String> {
-    let _ = search_dir;
-    None
-}
-
-#[cfg(debug_assertions)]
-fn debug_dotenv_path(search_dir: &Path) -> Option<PathBuf> {
-    let mut fallback = None;
-
-    for ancestor in search_dir.ancestors() {
-        let candidate = ancestor.join(".env");
-        if ancestor.join(".git").exists() {
-            if candidate.is_file() {
-                return Some(candidate);
-            }
-            break;
-        }
-        if fallback.is_none() && candidate.is_file() {
-            fallback = Some(candidate);
-        }
-    }
-    fallback
-}
-
-#[cfg(debug_assertions)]
-fn parse_dotenv_rust_log(content: &str) -> Option<String> {
-    let mut rust_log = None;
-
-    for line in content.lines() {
-        let line = line.trim();
-        if line.is_empty() || line.starts_with('#') {
-            continue;
-        }
-
-        let line = line.strip_prefix("export ").unwrap_or(line).trim_start();
-        let Some((key, value)) = line.split_once('=') else {
-            continue;
-        };
-        if key.trim() != "RUST_LOG" {
-            continue;
-        }
-
-        let value = parse_dotenv_value(value.trim());
-        if !value.is_empty() {
-            rust_log = Some(value);
-        }
-    }
-    rust_log
-}
-
-#[cfg(debug_assertions)]
-fn parse_dotenv_value(value: &str) -> String {
-    if let Some(stripped) = value.strip_prefix('"') {
-        if let Some(end) = stripped.find('"') {
-            return stripped[..end].to_string();
-        }
-    } else if let Some(stripped) = value.strip_prefix('\'')
-        && let Some(end) = stripped.find('\'')
-    {
-        return stripped[..end].to_string();
-    }
-
-    value
-        .split_once(" #")
-        .map(|(value, _)| value.trim_end())
-        .unwrap_or(value)
-        .to_string()
 }
 
 #[cfg(not(debug_assertions))]
@@ -803,6 +572,7 @@ impl LazyFileWriter {
             Ok(worker) => {
                 *self.shared.sender.lock().unwrap() = Some(sender);
                 *self.shared.worker.lock().unwrap() = Some(worker);
+                crate::rt::start_rt_log_drain();
                 self.shared.mode.store(ASYNC_MODE, Ordering::Release);
             }
             Err(error) => {
@@ -816,6 +586,7 @@ impl LazyFileWriter {
 
     fn shutdown(&self) {
         let _shutdown = self.shared.shutdown.lock().unwrap();
+        crate::rt::stop_rt_log_drain();
         self.shared.mode.store(BLOCKING_MODE, Ordering::Release);
         drop(self.shared.sender.lock().unwrap().take());
         if let Some(worker) = self.shared.worker.lock().unwrap().take() {
@@ -936,11 +707,22 @@ enum LogDestination {
 }
 
 fn async_file_writer_worker(shared: Arc<LazyFileWriterShared>, receiver: mpsc::Receiver<Vec<u8>>) {
-    while let Ok(buf) = receiver.recv() {
-        write_dropped_record_notice_if_needed(&shared);
-        let _ = write_log_bytes_blocking(&mut shared.destination.lock().unwrap(), &buf);
+    loop {
+        match receiver.recv_timeout(ASYNC_WORKER_RT_DRAIN_INTERVAL) {
+            Ok(buf) => {
+                write_dropped_record_notice_if_needed(&shared);
+                let _ = write_log_bytes_blocking(&mut shared.destination.lock().unwrap(), &buf);
+                drain_rt_records_to_destination(&shared);
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                write_dropped_record_notice_if_needed(&shared);
+                drain_rt_records_to_destination(&shared);
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => break,
+        }
     }
     write_dropped_record_notice_if_needed(&shared);
+    drain_rt_records_to_destination(&shared);
     let _ = flush_log_outputs(&mut shared.destination.lock().unwrap());
 }
 

--- a/crates/wrac_log/src/file_logger.rs
+++ b/crates/wrac_log/src/file_logger.rs
@@ -21,9 +21,9 @@ static CURRENT_LOG_DIR: OnceLock<Option<PathBuf>> = OnceLock::new();
 static CURRENT_LOG_FILE: OnceLock<Option<PathBuf>> = OnceLock::new();
 static RT_SAFE_LOGGER: OnceLock<&'static WracLogger> = OnceLock::new();
 static FILE_WRITER: OnceLock<LazyFileWriter> = OnceLock::new();
-static ACTIVE_PLUGIN_INSTANCES: AtomicU32 = AtomicU32::new(0);
+static ACTIVE_ASYNC_FILE_LOGGERS: AtomicU32 = AtomicU32::new(0);
 
-/// File logging configuration supplied by the plugin adapter.
+/// WRAC file logging configuration.
 #[derive(Clone, Copy, Debug)]
 pub struct LogConfig {
     pub app_name: &'static str,
@@ -31,11 +31,10 @@ pub struct LogConfig {
     debug_dotenv_search_dir: Option<&'static str>,
 }
 
-/// Destination policy for WRAC file logging.
+/// WRAC file logging destination policy.
 #[derive(Clone, Copy, Debug)]
 pub enum LogOutput {
-    /// Use `WRAC_LOG_DIR` when set, otherwise use the release user log directory.
-    /// Debug builds use `debug_log_dir` when provided.
+    /// Uses `WRAC_LOG_DIR`, then the debug directory in debug builds, otherwise the platform log directory.
     DefaultPluginLogDir {
         debug_log_dir: Option<&'static str>,
     },
@@ -46,9 +45,6 @@ pub enum LogOutput {
 
 impl LogConfig {
     /// Creates a standard WRAC file-log configuration.
-    ///
-    /// `debug_log_dir` is used only for debug builds. Release builds use the
-    /// platform user log directory unless `WRAC_LOG_DIR` overrides it.
     pub const fn new(app_name: &'static str, debug_log_dir: Option<&'static str>) -> Self {
         Self {
             app_name,
@@ -58,8 +54,26 @@ impl LogConfig {
     }
 }
 
-/// Installs the lightweight WRAC logger without touching the filesystem.
-pub fn configure(config: &'static LogConfig) {
+/// Configures logging for a plugin managed by a host adapter.
+///
+/// This installs the lightweight logger without touching the filesystem.
+pub fn configure_plugin(config: &'static LogConfig) -> PluginLogRuntime {
+    PluginLogRuntime {
+        writer: configure_logger(config),
+    }
+}
+
+/// Configures logging for a standalone app or service.
+///
+/// Hold the returned runtime while async file logging should remain active.
+pub fn configure_standalone(config: &'static LogConfig) -> StandaloneLogRuntime {
+    let writer = configure_logger(config);
+    StandaloneLogRuntime {
+        _guard: writer.map(start_async_file_logger),
+    }
+}
+
+fn configure_logger(config: &'static LogConfig) -> Option<LazyFileWriter> {
     INIT.call_once(|| {
         let writer = LazyFileWriter::new(*config);
         let writer_for_runtime = writer.clone();
@@ -68,19 +82,15 @@ pub fn configure(config: &'static LogConfig) {
         }
         crate::rt::init_rt_buffer();
     });
+    FILE_WRITER.get().cloned()
 }
 
 /// Returns the directory currently used for file logging.
-///
-/// Returns `None` before initialization or when logging fell back to `stderr`.
-/// Use [`current_log_file`] when the caller needs the exact current session log.
 pub fn current_log_dir() -> Option<PathBuf> {
     CURRENT_LOG_DIR.get().cloned().flatten()
 }
 
 /// Returns the current session log file.
-///
-/// Returns `None` before initialization or when logging fell back to `stderr`.
 pub fn current_log_file() -> Option<PathBuf> {
     CURRENT_LOG_FILE.get().cloned().flatten()
 }
@@ -104,39 +114,52 @@ impl Default for RecentLogFilesOptions {
 }
 
 /// Returns the current log and recent archived logs, newest first.
-///
-/// The current log is always included even if it exceeds `max_total_bytes`.
-/// Archived logs are then added newest first until the file or byte limit is reached.
 pub fn collect_recent_log_files(options: RecentLogFilesOptions) -> std::io::Result<Vec<PathBuf>> {
     let current_log_file = current_log_file()
         .ok_or_else(|| std::io::Error::other("wrac_log is not writing to a log file"))?;
     collect_recent_log_files_from_current(&current_log_file, &options)
 }
 
-/// Keeps the asynchronous file logger running while this guard is alive.
-///
-/// Dropping the last guard stops the worker thread and joins it. After that, the
-/// installed logger remains usable and writes to the same destinations synchronously.
-pub struct AsyncFileLoggerGuard {
+/// Plugin logger runtime returned by [`configure_plugin`].
+pub struct PluginLogRuntime {
+    writer: Option<LazyFileWriter>,
+}
+
+impl PluginLogRuntime {
+    /// Keeps async file logging active while the returned instance guard is alive.
+    pub fn retain_instance(&self) -> PluginLogInstanceGuard {
+        PluginLogInstanceGuard {
+            _guard: self.writer.clone().map(start_async_file_logger),
+        }
+    }
+}
+
+/// Keeps plugin async file logging active for one plugin instance.
+pub struct PluginLogInstanceGuard {
+    _guard: Option<AsyncFileLoggerGuard>,
+}
+
+/// Keeps standalone async file logging active.
+pub struct StandaloneLogRuntime {
+    _guard: Option<AsyncFileLoggerGuard>,
+}
+
+/// Keeps the asynchronous file writer running while this guard is alive.
+struct AsyncFileLoggerGuard {
     writer: LazyFileWriter,
 }
 
-/// Starts the asynchronous file logger and returns its lifetime guard.
-///
-/// This function returns `None` when no WRAC logger was installed, for example when
-/// another logger implementation already owns the global `log` facade.
-pub fn start_async_file_logger() -> Option<AsyncFileLoggerGuard> {
-    let writer = FILE_WRITER.get()?.clone();
-    if ACTIVE_PLUGIN_INSTANCES.fetch_add(1, Ordering::AcqRel) == 0 {
+fn start_async_file_logger(writer: LazyFileWriter) -> AsyncFileLoggerGuard {
+    if ACTIVE_ASYNC_FILE_LOGGERS.fetch_add(1, Ordering::AcqRel) == 0 {
         writer.ensure_initialized();
         writer.start();
     }
-    Some(AsyncFileLoggerGuard { writer })
+    AsyncFileLoggerGuard { writer }
 }
 
 impl Drop for AsyncFileLoggerGuard {
     fn drop(&mut self) {
-        if ACTIVE_PLUGIN_INSTANCES.fetch_sub(1, Ordering::AcqRel) == 1 {
+        if ACTIVE_ASYNC_FILE_LOGGERS.fetch_sub(1, Ordering::AcqRel) == 1 {
             self.writer.shutdown();
         }
     }
@@ -737,13 +760,13 @@ impl LazyFileWriter {
     }
 
     fn config_for_logger(&self) -> LogConfig {
-        self.shared
+        *self
+            .shared
             .config
             .lock()
             .unwrap()
             .as_ref()
             .expect("lazy file logger config must exist before initialization")
-            .clone()
     }
 
     fn ensure_initialized(&self) {
@@ -832,8 +855,7 @@ impl WracLogger {
                 config,
                 writer,
             } => {
-                let logger =
-                    logger.get_or_init(|| build_file_logger(config.clone(), writer.clone()));
+                let logger = logger.get_or_init(|| build_file_logger(*config, writer.clone()));
                 let max_level = logger.filter();
                 crate::rt::set_rt_fallback_max_level(max_level);
                 log::set_max_level(max_level);
@@ -870,7 +892,7 @@ impl Log for WracLogger {
 impl Write for LazyFileWriter {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         self.ensure_initialized();
-        if ACTIVE_PLUGIN_INSTANCES.load(Ordering::Acquire) > 0 {
+        if ACTIVE_ASYNC_FILE_LOGGERS.load(Ordering::Acquire) > 0 {
             self.start();
         }
 

--- a/crates/wrac_log/src/file_logger.rs
+++ b/crates/wrac_log/src/file_logger.rs
@@ -3,57 +3,70 @@ use log::{Level, LevelFilter, Log, Metadata, Record};
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex, Once, OnceLock};
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU32, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, Once, OnceLock, mpsc};
+use std::thread::JoinHandle;
 use time::{OffsetDateTime, macros::format_description};
 
 const MAX_LOG_FILES: usize = 30;
 const DEFAULT_RECENT_LOG_MAX_FILES: usize = 30;
 const DEFAULT_RECENT_LOG_MAX_TOTAL_BYTES: u64 = 50 * 1024 * 1024;
 const MAX_UNIQUE_ARCHIVED_LOG_FILE_ATTEMPTS: u32 = 1000;
+const ASYNC_LOG_QUEUE_CAPACITY: usize = 4096;
+const ASYNC_MODE: u8 = 0;
+const BLOCKING_MODE: u8 = 1;
 
 static INIT: Once = Once::new();
 static CURRENT_LOG_DIR: OnceLock<Option<PathBuf>> = OnceLock::new();
 static CURRENT_LOG_FILE: OnceLock<Option<PathBuf>> = OnceLock::new();
 static RT_SAFE_LOGGER: OnceLock<&'static WracLogger> = OnceLock::new();
+static FILE_WRITER: OnceLock<LazyFileWriter> = OnceLock::new();
+static ACTIVE_PLUGIN_INSTANCES: AtomicU32 = AtomicU32::new(0);
 
-/// Implementation for [`crate::init!`].
-///
-/// Prefer calling the macro so `manifest_dir` is captured from the plugin crate,
-/// not from `wrac_log`.
-pub fn init_impl(manifest_dir: Option<&'static str>, app_name: &str) {
+/// File logging configuration supplied by the plugin adapter.
+#[derive(Clone, Copy, Debug)]
+pub struct LogConfig {
+    pub app_name: &'static str,
+    pub output: LogOutput,
+    debug_dotenv_search_dir: Option<&'static str>,
+}
+
+/// Destination policy for WRAC file logging.
+#[derive(Clone, Copy, Debug)]
+pub enum LogOutput {
+    /// Use `WRAC_LOG_DIR` when set, otherwise use the release user log directory.
+    /// Debug builds use `debug_log_dir` when provided.
+    DefaultPluginLogDir {
+        debug_log_dir: Option<&'static str>,
+    },
+    Directory(&'static str),
+    File(&'static str),
+    Stderr,
+}
+
+impl LogConfig {
+    /// Creates a standard WRAC file-log configuration.
+    ///
+    /// `debug_log_dir` is used only for debug builds. Release builds use the
+    /// platform user log directory unless `WRAC_LOG_DIR` overrides it.
+    pub const fn new(app_name: &'static str, debug_log_dir: Option<&'static str>) -> Self {
+        Self {
+            app_name,
+            output: LogOutput::DefaultPluginLogDir { debug_log_dir },
+            debug_dotenv_search_dir: debug_log_dir,
+        }
+    }
+}
+
+/// Installs the lightweight WRAC logger without touching the filesystem.
+pub fn configure(config: &'static LogConfig) {
     INIT.call_once(|| {
-        let dotenv_rust_log = rust_log_from_debug_dotenv(manifest_dir);
-
-        // Explicit environment configuration is useful for host-driven debugging and CI.
-        if let Ok(log_dir) = std::env::var("WRAC_LOG_DIR") {
-            init_with_dir(&log_dir, app_name, dotenv_rust_log.as_deref());
-            return;
+        let writer = LazyFileWriter::new(*config);
+        let writer_for_runtime = writer.clone();
+        if let Some(writer) = install_lazy_logger(writer, writer_for_runtime) {
+            let _ = FILE_WRITER.set(writer);
         }
-
-        // Debug builds should make local development logs easy to find in the repository.
-        #[cfg(debug_assertions)]
-        if let Some(manifest_dir) = manifest_dir {
-            let log_dir = Path::new(manifest_dir).join("../.log");
-            if let Some(log_dir_str) = log_dir.to_str() {
-                init_with_dir(log_dir_str, app_name, dotenv_rust_log.as_deref());
-                return;
-            }
-        }
-
-        // Release builds use a user log directory so installed plugins can keep logs
-        // without depending on the build tree.
-        #[cfg(not(debug_assertions))]
-        {
-            let _ = manifest_dir;
-            if let Some(log_dir) = resolve_release_log_dir(app_name) {
-                init_with_dir(log_dir.to_string_lossy().as_ref(), app_name, None);
-                return;
-            }
-        }
-
-        #[cfg(debug_assertions)]
-        let _ = app_name;
-        init_stderr(dotenv_rust_log.as_deref());
+        crate::rt::init_rt_buffer();
     });
 }
 
@@ -98,6 +111,35 @@ pub fn collect_recent_log_files(options: RecentLogFilesOptions) -> std::io::Resu
     let current_log_file = current_log_file()
         .ok_or_else(|| std::io::Error::other("wrac_log is not writing to a log file"))?;
     collect_recent_log_files_from_current(&current_log_file, &options)
+}
+
+/// Keeps the asynchronous file logger running while this guard is alive.
+///
+/// Dropping the last guard stops the worker thread and joins it. After that, the
+/// installed logger remains usable and writes to the same destinations synchronously.
+pub struct AsyncFileLoggerGuard {
+    writer: LazyFileWriter,
+}
+
+/// Starts the asynchronous file logger and returns its lifetime guard.
+///
+/// This function returns `None` when no WRAC logger was installed, for example when
+/// another logger implementation already owns the global `log` facade.
+pub fn start_async_file_logger() -> Option<AsyncFileLoggerGuard> {
+    let writer = FILE_WRITER.get()?.clone();
+    if ACTIVE_PLUGIN_INSTANCES.fetch_add(1, Ordering::AcqRel) == 0 {
+        writer.ensure_initialized();
+        writer.start();
+    }
+    Some(AsyncFileLoggerGuard { writer })
+}
+
+impl Drop for AsyncFileLoggerGuard {
+    fn drop(&mut self) {
+        if ACTIVE_PLUGIN_INSTANCES.fetch_sub(1, Ordering::AcqRel) == 1 {
+            self.writer.shutdown();
+        }
+    }
 }
 
 fn collect_recent_log_files_from_current(
@@ -170,30 +212,6 @@ pub fn init_test() {
             init_stderr(None);
         }
     });
-}
-
-fn init_with_dir(log_dir: &str, app_name: &str, dotenv_rust_log: Option<&str>) {
-    let log_dir_path = Path::new(log_dir);
-    if !log_dir_path.exists()
-        && let Err(error) = std::fs::create_dir_all(log_dir_path)
-    {
-        eprintln!("Failed to create log directory '{log_dir}': {error}");
-        init_stderr(dotenv_rust_log);
-        return;
-    }
-
-    let file_stem = log_file_stem(app_name);
-    let latest_log_file = latest_log_file_path(log_dir_path, &file_stem);
-    // Keep a stable Latest filename for users while preserving the previous session
-    // before the new logger appends current-session output.
-    if let Err(error) = archive_existing_latest_log(&latest_log_file, &file_stem) {
-        eprintln!(
-            "Failed to archive latest log file '{}': {error}",
-            latest_log_file.display(),
-        );
-    }
-    rotate_logs(log_dir_path, &file_stem);
-    init_with_file(&latest_log_file, dotenv_rust_log);
 }
 
 fn rotate_logs(log_dir: &Path, file_stem: &str) {
@@ -304,12 +322,12 @@ fn log_file_stem(app_name: &str) -> String {
 }
 
 #[cfg(debug_assertions)]
-fn rust_log_from_debug_dotenv(manifest_dir: Option<&str>) -> Option<String> {
+fn rust_log_from_debug_dotenv(search_dir: Option<&Path>) -> Option<String> {
     if std::env::var("RUST_LOG").is_ok() {
         return None;
     }
 
-    let dotenv_path = debug_dotenv_path(manifest_dir?)?;
+    let dotenv_path = debug_dotenv_path(search_dir?)?;
     let Ok(content) = std::fs::read_to_string(&dotenv_path) else {
         return None;
     };
@@ -317,17 +335,16 @@ fn rust_log_from_debug_dotenv(manifest_dir: Option<&str>) -> Option<String> {
 }
 
 #[cfg(not(debug_assertions))]
-fn rust_log_from_debug_dotenv(manifest_dir: Option<&str>) -> Option<String> {
-    let _ = manifest_dir;
+fn rust_log_from_debug_dotenv(search_dir: Option<&Path>) -> Option<String> {
+    let _ = search_dir;
     None
 }
 
 #[cfg(debug_assertions)]
-fn debug_dotenv_path(manifest_dir: &str) -> Option<PathBuf> {
-    let start = Path::new(manifest_dir);
+fn debug_dotenv_path(search_dir: &Path) -> Option<PathBuf> {
     let mut fallback = None;
 
-    for ancestor in start.ancestors() {
+    for ancestor in search_dir.ancestors() {
         let candidate = ancestor.join(".env");
         if ancestor.join(".git").exists() {
             if candidate.is_file() {
@@ -436,7 +453,7 @@ fn init_stderr(dotenv_rust_log: Option<&str>) {
     let mut builder = Builder::from_default_env();
     apply_default_filter(&mut builder, dotenv_rust_log);
     builder.target(Target::Stderr);
-    install_logger(builder);
+    install_logger(builder, None);
     crate::rt::init_rt_buffer();
 }
 
@@ -456,13 +473,113 @@ fn init_with_file(log_file: impl AsRef<Path>, dotenv_rust_log: Option<&str>) {
             record_current_log_paths(Some(canonical_log_file));
             let mut builder = Builder::from_default_env();
             apply_default_filter(&mut builder, dotenv_rust_log);
-            builder.target(Target::Pipe(Box::new(FileAndStderr::new(file))));
-            install_logger(builder);
+            let writer = LazyFileWriter::from_open_file(file);
+            let writer_for_shutdown = writer.clone();
+            builder.target(Target::Pipe(Box::new(writer)));
+            if let Some(writer) = install_logger(builder, Some(writer_for_shutdown)) {
+                let _ = FILE_WRITER.set(writer);
+            }
             crate::rt::init_rt_buffer();
         }
         Err(error) => {
             eprintln!("Failed to open log file '{}': {error}", log_file.display());
             init_stderr(dotenv_rust_log);
+        }
+    }
+}
+
+fn initialize_log_destination(config: LogConfig) -> LogDestination {
+    match resolve_log_file_path(&config) {
+        Some(log_file) => {
+            let Some(file_stem) = log_file
+                .file_name()
+                .and_then(|name| name.to_str())
+                .and_then(|name| name.strip_suffix(" Latest.log"))
+                .map(str::to_string)
+            else {
+                return open_log_file_destination(&log_file);
+            };
+            if let Some(log_dir) = log_file.parent() {
+                if !log_dir.exists()
+                    && let Err(error) = std::fs::create_dir_all(log_dir)
+                {
+                    let _ = writeln!(
+                        std::io::stderr(),
+                        "Failed to create log directory '{}': {error}",
+                        log_dir.display()
+                    );
+                    record_current_log_paths(None);
+                    return LogDestination::Stderr;
+                }
+                if let Err(error) = archive_existing_latest_log(&log_file, &file_stem) {
+                    let _ = writeln!(
+                        std::io::stderr(),
+                        "Failed to archive latest log file '{}': {error}",
+                        log_file.display()
+                    );
+                }
+                rotate_logs(log_dir, &file_stem);
+            }
+            open_log_file_destination(&log_file)
+        }
+        None => {
+            record_current_log_paths(None);
+            LogDestination::Stderr
+        }
+    }
+}
+
+fn resolve_log_file_path(config: &LogConfig) -> Option<PathBuf> {
+    match &config.output {
+        LogOutput::Stderr => None,
+        LogOutput::File(path) => Some(PathBuf::from(path)),
+        LogOutput::Directory(path) => Some(latest_log_file_path(
+            Path::new(path),
+            &log_file_stem(config.app_name),
+        )),
+        LogOutput::DefaultPluginLogDir { debug_log_dir } => {
+            if let Ok(log_dir) = std::env::var("WRAC_LOG_DIR") {
+                return Some(latest_log_file_path(
+                    Path::new(&log_dir),
+                    &log_file_stem(config.app_name),
+                ));
+            }
+            #[cfg(debug_assertions)]
+            {
+                debug_log_dir.map(|log_dir| {
+                    latest_log_file_path(Path::new(log_dir), &log_file_stem(config.app_name))
+                })
+            }
+            #[cfg(not(debug_assertions))]
+            {
+                let _ = debug_log_dir;
+                resolve_release_log_dir(config.app_name)
+                    .map(|log_dir| latest_log_file_path(&log_dir, &log_file_stem(config.app_name)))
+            }
+        }
+    }
+}
+
+fn open_log_file_destination(log_file: &Path) -> LogDestination {
+    if let Some(parent) = log_file.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    match OpenOptions::new().create(true).append(true).open(log_file) {
+        Ok(file) => {
+            let canonical_log_file = log_file
+                .canonicalize()
+                .unwrap_or_else(|_| log_file.to_path_buf());
+            record_current_log_paths(Some(canonical_log_file));
+            LogDestination::File(Arc::new(Mutex::new(file)))
+        }
+        Err(error) => {
+            let _ = writeln!(
+                std::io::stderr(),
+                "Failed to open log file '{}': {error}",
+                log_file.display()
+            );
+            record_current_log_paths(None);
+            LogDestination::Stderr
         }
     }
 }
@@ -491,13 +608,50 @@ fn apply_default_filter(builder: &mut Builder, dotenv_rust_log: Option<&str>) {
     }
 }
 
-fn install_logger(mut builder: Builder) {
-    let logger = WracLogger {
-        inner: builder.build(),
-    };
-    let max_level = logger.inner.filter();
-    crate::rt::set_rt_fallback_max_level(max_level);
+fn build_file_logger(config: LogConfig, writer: LazyFileWriter) -> Logger {
+    let dotenv_rust_log = rust_log_from_debug_dotenv(config.debug_dotenv_search_dir.map(Path::new));
+    let mut builder = Builder::from_default_env();
+    apply_default_filter(&mut builder, dotenv_rust_log.as_deref());
+    builder.target(Target::Pipe(Box::new(writer)));
+    builder.build()
+}
 
+fn install_lazy_logger(
+    writer: LazyFileWriter,
+    file_writer: LazyFileWriter,
+) -> Option<LazyFileWriter> {
+    let config = writer.config_for_logger();
+    let logger = WracLogger {
+        inner: LoggerInner::Lazy {
+            logger: OnceLock::new(),
+            config,
+            writer,
+        },
+        fallback_max_level: default_level_filter(),
+    };
+    crate::rt::set_rt_fallback_max_level(logger.fallback_max_level);
+    install_wrac_logger(logger, Some(file_writer), LevelFilter::Trace)
+}
+
+fn install_logger(
+    mut builder: Builder,
+    file_writer: Option<LazyFileWriter>,
+) -> Option<LazyFileWriter> {
+    let inner = builder.build();
+    let max_level = inner.filter();
+    let logger = WracLogger {
+        inner: LoggerInner::Immediate(inner),
+        fallback_max_level: max_level,
+    };
+    crate::rt::set_rt_fallback_max_level(max_level);
+    install_wrac_logger(logger, file_writer, max_level)
+}
+
+fn install_wrac_logger(
+    logger: WracLogger,
+    file_writer: Option<LazyFileWriter>,
+    max_level: LevelFilter,
+) -> Option<LazyFileWriter> {
     let logger = Box::new(logger);
     let logger_ptr = Box::into_raw(logger);
     // `log` stores a `'static` logger reference. On failure, another logger is already
@@ -508,9 +662,14 @@ fn install_logger(mut builder: Builder) {
             let logger = unsafe { &*logger_ptr };
             let _ = RT_SAFE_LOGGER.set(logger);
             log::set_max_level(max_level);
+            file_writer
         }
         Err(_) => {
             drop(unsafe { Box::from_raw(logger_ptr) });
+            if let Some(writer) = file_writer {
+                writer.shutdown();
+            }
+            None
         }
     }
 }
@@ -518,7 +677,7 @@ fn install_logger(mut builder: Builder) {
 pub(crate) fn rt_logger_enabled(level: Level, target: &'static str) -> Option<bool> {
     let logger = RT_SAFE_LOGGER.get()?;
     let metadata = Metadata::builder().level(level).target(target).build();
-    Some(logger.enabled(&metadata))
+    Some(logger.rt_enabled(&metadata))
 }
 
 fn default_level_filter() -> LevelFilter {
@@ -532,48 +691,267 @@ fn default_level_filter() -> LevelFilter {
     }
 }
 
-struct FileAndStderr {
-    file: Arc<Mutex<std::fs::File>>,
+#[derive(Clone)]
+struct LazyFileWriter {
+    shared: Arc<LazyFileWriterShared>,
 }
 
-impl FileAndStderr {
-    fn new(file: std::fs::File) -> Self {
-        Self {
-            file: Arc::new(Mutex::new(file)),
+struct LazyFileWriterShared {
+    config: Mutex<Option<LogConfig>>,
+    destination: Mutex<LogDestination>,
+    sender: Mutex<Option<mpsc::SyncSender<Vec<u8>>>>,
+    worker: Mutex<Option<JoinHandle<()>>>,
+    shutdown: Mutex<()>,
+    mode: AtomicU8,
+    dropped_records: AtomicU64,
+    initialized: AtomicBool,
+}
+
+impl LazyFileWriter {
+    fn new(config: LogConfig) -> Self {
+        let shared = Arc::new(LazyFileWriterShared {
+            config: Mutex::new(Some(config)),
+            destination: Mutex::new(LogDestination::Uninitialized),
+            sender: Mutex::new(None),
+            worker: Mutex::new(None),
+            shutdown: Mutex::new(()),
+            mode: AtomicU8::new(BLOCKING_MODE),
+            dropped_records: AtomicU64::new(0),
+            initialized: AtomicBool::new(false),
+        });
+        Self { shared }
+    }
+
+    fn from_open_file(file: std::fs::File) -> Self {
+        let shared = Arc::new(LazyFileWriterShared {
+            config: Mutex::new(None),
+            destination: Mutex::new(LogDestination::File(Arc::new(Mutex::new(file)))),
+            sender: Mutex::new(None),
+            worker: Mutex::new(None),
+            shutdown: Mutex::new(()),
+            mode: AtomicU8::new(BLOCKING_MODE),
+            dropped_records: AtomicU64::new(0),
+            initialized: AtomicBool::new(true),
+        });
+        Self { shared }
+    }
+
+    fn config_for_logger(&self) -> LogConfig {
+        self.shared
+            .config
+            .lock()
+            .unwrap()
+            .as_ref()
+            .expect("lazy file logger config must exist before initialization")
+            .clone()
+    }
+
+    fn ensure_initialized(&self) {
+        if self.shared.initialized.load(Ordering::Acquire) {
+            return;
+        }
+
+        let _shutdown = self.shared.shutdown.lock().unwrap();
+        if self.shared.initialized.load(Ordering::Acquire) {
+            return;
+        }
+
+        let config = self.shared.config.lock().unwrap().take();
+        let destination = config
+            .map(initialize_log_destination)
+            .unwrap_or(LogDestination::Stderr);
+        *self.shared.destination.lock().unwrap() = destination;
+        self.shared.initialized.store(true, Ordering::Release);
+    }
+
+    fn start(&self) {
+        self.ensure_initialized();
+        let _shutdown = self.shared.shutdown.lock().unwrap();
+        if self.shared.worker.lock().unwrap().is_some() {
+            return;
+        }
+
+        let (sender, receiver) = mpsc::sync_channel(ASYNC_LOG_QUEUE_CAPACITY);
+        let worker_shared = self.shared.clone();
+        match std::thread::Builder::new()
+            .name("wrac-log-writer".to_string())
+            .spawn(move || async_file_writer_worker(worker_shared, receiver))
+        {
+            Ok(worker) => {
+                *self.shared.sender.lock().unwrap() = Some(sender);
+                *self.shared.worker.lock().unwrap() = Some(worker);
+                self.shared.mode.store(ASYNC_MODE, Ordering::Release);
+            }
+            Err(error) => {
+                let message =
+                    format!("[wrac_log] failed to start async file log worker: {error}\n");
+                let _ = self.write_blocking(message.as_bytes());
+                self.shared.mode.store(BLOCKING_MODE, Ordering::Release);
+            }
+        }
+    }
+
+    fn shutdown(&self) {
+        let _shutdown = self.shared.shutdown.lock().unwrap();
+        self.shared.mode.store(BLOCKING_MODE, Ordering::Release);
+        drop(self.shared.sender.lock().unwrap().take());
+        if let Some(worker) = self.shared.worker.lock().unwrap().take() {
+            let _ = worker.join();
+        }
+    }
+
+    fn write_blocking(&self, buf: &[u8]) -> std::io::Result<()> {
+        write_log_bytes_blocking(&mut self.shared.destination.lock().unwrap(), buf)
+    }
+
+    fn flush_blocking(&self) -> std::io::Result<()> {
+        flush_log_outputs(&mut self.shared.destination.lock().unwrap())
+    }
+}
+
+enum LoggerInner {
+    Immediate(Logger),
+    Lazy {
+        logger: OnceLock<Logger>,
+        config: LogConfig,
+        writer: LazyFileWriter,
+    },
+}
+
+struct WracLogger {
+    inner: LoggerInner,
+    fallback_max_level: LevelFilter,
+}
+
+impl WracLogger {
+    fn logger(&self) -> &Logger {
+        match &self.inner {
+            LoggerInner::Immediate(logger) => logger,
+            LoggerInner::Lazy {
+                logger,
+                config,
+                writer,
+            } => {
+                let logger =
+                    logger.get_or_init(|| build_file_logger(config.clone(), writer.clone()));
+                let max_level = logger.filter();
+                crate::rt::set_rt_fallback_max_level(max_level);
+                log::set_max_level(max_level);
+                logger
+            }
+        }
+    }
+
+    fn rt_enabled(&self, metadata: &Metadata<'_>) -> bool {
+        match &self.inner {
+            LoggerInner::Immediate(logger) => logger.enabled(metadata),
+            LoggerInner::Lazy { logger, .. } => logger
+                .get()
+                .map(|logger| logger.enabled(metadata))
+                .unwrap_or_else(|| metadata.level() <= self.fallback_max_level),
         }
     }
 }
 
-struct WracLogger {
-    inner: Logger,
-}
-
 impl Log for WracLogger {
     fn enabled(&self, metadata: &Metadata<'_>) -> bool {
-        self.inner.enabled(metadata)
+        self.logger().enabled(metadata)
     }
 
     fn log(&self, record: &Record<'_>) {
-        self.inner.log(record);
+        self.logger().log(record);
     }
 
     fn flush(&self) {
-        self.inner.flush();
+        self.logger().flush();
     }
 }
 
-impl Write for FileAndStderr {
+impl Write for LazyFileWriter {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        std::io::stderr().write_all(buf)?;
-        let mut file = self.file.lock().unwrap();
-        file.write_all(buf)?;
+        self.ensure_initialized();
+        if ACTIVE_PLUGIN_INSTANCES.load(Ordering::Acquire) > 0 {
+            self.start();
+        }
+
+        if self.shared.mode.load(Ordering::Acquire) == ASYNC_MODE {
+            let send_result = self
+                .shared
+                .sender
+                .lock()
+                .unwrap()
+                .as_ref()
+                .map(|sender| sender.try_send(buf.to_vec()));
+            match send_result {
+                Some(Ok(())) => return Ok(buf.len()),
+                Some(Err(mpsc::TrySendError::Full(_))) => {
+                    self.shared.dropped_records.fetch_add(1, Ordering::Relaxed);
+                    return Ok(buf.len());
+                }
+                Some(Err(mpsc::TrySendError::Disconnected(_))) | None => {
+                    self.shared.mode.store(BLOCKING_MODE, Ordering::Release);
+                }
+            }
+        }
+
+        let _shutdown = self.shared.shutdown.lock().unwrap();
+        self.write_blocking(buf)?;
         Ok(buf.len())
     }
 
     fn flush(&mut self) -> std::io::Result<()> {
-        std::io::stderr().flush()?;
-        let mut file = self.file.lock().unwrap();
-        file.flush()
+        if self.shared.mode.load(Ordering::Acquire) == ASYNC_MODE {
+            return Ok(());
+        }
+        self.flush_blocking()
+    }
+}
+
+enum LogDestination {
+    Uninitialized,
+    File(Arc<Mutex<std::fs::File>>),
+    Stderr,
+}
+
+fn async_file_writer_worker(shared: Arc<LazyFileWriterShared>, receiver: mpsc::Receiver<Vec<u8>>) {
+    while let Ok(buf) = receiver.recv() {
+        write_dropped_record_notice_if_needed(&shared);
+        let _ = write_log_bytes_blocking(&mut shared.destination.lock().unwrap(), &buf);
+    }
+    write_dropped_record_notice_if_needed(&shared);
+    let _ = flush_log_outputs(&mut shared.destination.lock().unwrap());
+}
+
+fn write_dropped_record_notice_if_needed(shared: &LazyFileWriterShared) {
+    let dropped = shared.dropped_records.swap(0, Ordering::AcqRel);
+    if dropped == 0 {
+        return;
+    }
+    let message = format!("[wrac_log] dropped {dropped} async file log records\n");
+    let _ = write_log_bytes_blocking(&mut shared.destination.lock().unwrap(), message.as_bytes());
+}
+
+fn write_log_bytes_blocking(destination: &mut LogDestination, buf: &[u8]) -> std::io::Result<()> {
+    match destination {
+        LogDestination::Uninitialized => Ok(()),
+        LogDestination::Stderr => std::io::stderr().write_all(buf),
+        LogDestination::File(file) => {
+            std::io::stderr().write_all(buf)?;
+            let mut file = file.lock().unwrap();
+            file.write_all(buf)
+        }
+    }
+}
+
+fn flush_log_outputs(destination: &mut LogDestination) -> std::io::Result<()> {
+    match destination {
+        LogDestination::Uninitialized => Ok(()),
+        LogDestination::Stderr => std::io::stderr().flush(),
+        LogDestination::File(file) => {
+            std::io::stderr().flush()?;
+            let mut file = file.lock().unwrap();
+            file.flush()
+        }
     }
 }
 
@@ -595,226 +973,4 @@ fn get_timestamp() -> String {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use std::path::{Path, PathBuf};
-    use std::time::{SystemTime, UNIX_EPOCH};
-
-    #[test]
-    fn init_test_is_idempotent() {
-        init_test();
-        init_test();
-    }
-
-    #[test]
-    fn test_name_and_timestamp_are_available() {
-        assert!(get_test_name().contains("test"));
-
-        let timestamp = get_timestamp();
-        assert_eq!(timestamp.len(), 19);
-        assert_eq!(timestamp.chars().nth(8).unwrap(), '_');
-        assert_eq!(timestamp.chars().nth(15).unwrap(), '_');
-    }
-
-    #[test]
-    fn logging_is_thread_safe_after_initialization() {
-        use std::sync::Arc;
-        use std::sync::atomic::{AtomicUsize, Ordering};
-        use std::thread;
-
-        let counter = Arc::new(AtomicUsize::new(0));
-        let handles = (0..10)
-            .map(|i| {
-                let counter = counter.clone();
-                thread::spawn(move || {
-                    for j in 0..100 {
-                        log::info!("Thread {i} - Message {j}");
-                        counter.fetch_add(1, Ordering::SeqCst);
-                    }
-                })
-            })
-            .collect::<Vec<_>>();
-
-        for handle in handles {
-            handle.join().unwrap();
-        }
-        assert_eq!(counter.load(Ordering::SeqCst), 1000);
-    }
-
-    #[test]
-    fn log_file_stem_replaces_path_unsafe_characters() {
-        assert_eq!(log_file_stem("TestApp"), "TestApp");
-        assert_eq!(log_file_stem("Bad/Name:Plugin"), "Bad_Name_Plugin");
-        assert_eq!(log_file_stem("   "), "Application");
-    }
-
-    #[test]
-    fn archive_existing_latest_log_moves_latest_to_timestamped_log() {
-        let temp_dir = TempDir::new("wrac_log_archive_latest");
-        let latest = temp_dir.path().join("TestApp Latest.log");
-        std::fs::write(&latest, "previous session").unwrap();
-
-        archive_existing_latest_log(&latest, "TestApp").unwrap();
-
-        assert!(!latest.exists());
-        let archived = log_files(temp_dir.path());
-        assert_eq!(archived.len(), 1);
-        let archived_name = archived[0].file_name().unwrap().to_string_lossy();
-        assert!(archived_name.starts_with("TestApp "));
-        assert!(archived_name.ends_with(".log"));
-        assert_ne!(archived_name, "TestApp Latest.log");
-        assert_eq!(
-            std::fs::read_to_string(&archived[0]).unwrap(),
-            "previous session",
-        );
-    }
-
-    #[test]
-    fn collect_recent_log_files_includes_latest_first_and_respects_limit() {
-        let temp_dir = TempDir::new("wrac_log_collect_recent");
-        let latest = temp_dir.path().join("TestApp Latest.log");
-        let archived1 = temp_dir.path().join("TestApp 20260101_000000_000.log");
-        let archived2 = temp_dir.path().join("TestApp 20260102_000000_000.log");
-        let other = temp_dir.path().join("Other 20260103_000000_000.log");
-        std::fs::write(&latest, "latest").unwrap();
-        std::fs::write(&archived1, "archived1").unwrap();
-        std::fs::write(&archived2, "archived2").unwrap();
-        std::fs::write(&other, "other").unwrap();
-
-        let files = collect_recent_log_files_from_current(
-            &latest,
-            &RecentLogFilesOptions {
-                max_files: 2,
-                max_total_bytes: 1024,
-            },
-        )
-        .unwrap();
-
-        assert_eq!(files.len(), 2);
-        assert_eq!(files[0], latest);
-        assert!(files[1] == archived1 || files[1] == archived2);
-        assert!(!files.contains(&other));
-    }
-
-    #[test]
-    fn rotate_logs_keeps_max_archived_logs() {
-        let temp_dir = TempDir::new("wrac_log_rotate");
-        for index in 0..(MAX_LOG_FILES + 2) {
-            let file = temp_dir
-                .path()
-                .join(format!("TestApp 20260101_000000_{index:03}.log"));
-            std::fs::write(file, format!("log {index}")).unwrap();
-        }
-        std::fs::write(temp_dir.path().join("TestApp Latest.log"), "latest").unwrap();
-
-        rotate_logs(temp_dir.path(), "TestApp");
-
-        let archived = log_files(temp_dir.path())
-            .into_iter()
-            .filter(|path| path.file_name().unwrap().to_string_lossy() != "TestApp Latest.log")
-            .collect::<Vec<_>>();
-        assert_eq!(archived.len(), MAX_LOG_FILES);
-        assert!(temp_dir.path().join("TestApp Latest.log").exists());
-    }
-
-    #[test]
-    fn parse_dotenv_rust_log_reads_last_non_empty_rust_log() {
-        let content = r#"
-            # wrac_log reads this only in development builds
-            OTHER=value
-            export RUST_LOG="wrac_gain_plugin=debug,wrac_log=trace"
-            RUST_LOG=wrac_gain_plugin=info # the last definition wins
-        "#;
-
-        assert_eq!(
-            parse_dotenv_rust_log(content).as_deref(),
-            Some("wrac_gain_plugin=info"),
-        );
-    }
-
-    #[test]
-    fn parse_dotenv_rust_log_ignores_empty_rust_log() {
-        assert_eq!(parse_dotenv_rust_log("RUST_LOG=\n"), None);
-    }
-
-    #[test]
-    fn debug_dotenv_path_prefers_repository_root() {
-        let temp_dir = TempDir::new("wrac_log_dotenv_root");
-        std::fs::create_dir(temp_dir.path().join(".git")).unwrap();
-        std::fs::write(temp_dir.path().join(".env"), "RUST_LOG=info").unwrap();
-
-        let crate_dir = temp_dir.path().join("plugins").join("gain");
-        std::fs::create_dir_all(&crate_dir).unwrap();
-        std::fs::write(crate_dir.join(".env"), "RUST_LOG=trace").unwrap();
-
-        let expected = temp_dir.path().join(".env");
-        assert_eq!(
-            debug_dotenv_path(crate_dir.to_str().unwrap()).as_deref(),
-            Some(expected.as_path()),
-        );
-    }
-
-    #[test]
-    fn debug_dotenv_path_falls_back_to_nearest_dotenv_when_repository_root_has_none() {
-        let temp_dir = TempDir::new("wrac_log_dotenv_fallback");
-        std::fs::create_dir(temp_dir.path().join(".git")).unwrap();
-
-        let crate_dir = temp_dir.path().join("plugins").join("gain");
-        std::fs::create_dir_all(&crate_dir).unwrap();
-        std::fs::write(crate_dir.join(".env"), "RUST_LOG=trace").unwrap();
-
-        let expected = crate_dir.join(".env");
-        assert_eq!(
-            debug_dotenv_path(crate_dir.to_str().unwrap()).as_deref(),
-            Some(expected.as_path()),
-        );
-    }
-
-    #[test]
-    fn parse_dotenv_rust_log_strips_comment_after_quoted_value() {
-        assert_eq!(
-            parse_dotenv_rust_log(r#"RUST_LOG="debug" # comment"#).as_deref(),
-            Some("debug"),
-        );
-        assert_eq!(
-            parse_dotenv_rust_log("RUST_LOG='wrac_gain_plugin=trace' # comment").as_deref(),
-            Some("wrac_gain_plugin=trace"),
-        );
-    }
-
-    struct TempDir {
-        path: PathBuf,
-    }
-
-    impl TempDir {
-        fn new(prefix: &str) -> Self {
-            let nanos = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap()
-                .as_nanos();
-            let path = std::env::temp_dir().join(format!("{prefix}_{nanos}"));
-            std::fs::create_dir_all(&path).unwrap();
-            Self { path }
-        }
-
-        fn path(&self) -> &Path {
-            &self.path
-        }
-    }
-
-    impl Drop for TempDir {
-        fn drop(&mut self) {
-            let _ = std::fs::remove_dir_all(&self.path);
-        }
-    }
-
-    fn log_files(dir: &Path) -> Vec<PathBuf> {
-        let mut files = std::fs::read_dir(dir)
-            .unwrap()
-            .map(|entry| entry.unwrap().path())
-            .filter(|path| path.extension().is_some_and(|extension| extension == "log"))
-            .collect::<Vec<_>>();
-        files.sort();
-        files
-    }
-}
+mod tests;

--- a/crates/wrac_log/src/file_logger/dotenv.rs
+++ b/crates/wrac_log/src/file_logger/dotenv.rs
@@ -1,0 +1,84 @@
+use std::path::{Path, PathBuf};
+
+#[cfg(debug_assertions)]
+pub(super) fn rust_log_from_debug_dotenv(search_dir: Option<&Path>) -> Option<String> {
+    if std::env::var("RUST_LOG").is_ok() {
+        return None;
+    }
+
+    let dotenv_path = debug_dotenv_path(search_dir?)?;
+    let Ok(content) = std::fs::read_to_string(&dotenv_path) else {
+        return None;
+    };
+    parse_dotenv_rust_log(&content)
+}
+
+#[cfg(not(debug_assertions))]
+pub(super) fn rust_log_from_debug_dotenv(search_dir: Option<&Path>) -> Option<String> {
+    let _ = search_dir;
+    None
+}
+
+#[cfg(debug_assertions)]
+pub(super) fn debug_dotenv_path(search_dir: &Path) -> Option<PathBuf> {
+    let mut fallback = None;
+
+    for ancestor in search_dir.ancestors() {
+        let candidate = ancestor.join(".env");
+        if ancestor.join(".git").exists() {
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+            break;
+        }
+        if fallback.is_none() && candidate.is_file() {
+            fallback = Some(candidate);
+        }
+    }
+    fallback
+}
+
+#[cfg(debug_assertions)]
+pub(super) fn parse_dotenv_rust_log(content: &str) -> Option<String> {
+    let mut rust_log = None;
+
+    for line in content.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+
+        let line = line.strip_prefix("export ").unwrap_or(line).trim_start();
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        if key.trim() != "RUST_LOG" {
+            continue;
+        }
+
+        let value = parse_dotenv_value(value.trim());
+        if !value.is_empty() {
+            rust_log = Some(value);
+        }
+    }
+    rust_log
+}
+
+#[cfg(debug_assertions)]
+fn parse_dotenv_value(value: &str) -> String {
+    if let Some(stripped) = value.strip_prefix('"') {
+        if let Some(end) = stripped.find('"') {
+            return stripped[..end].to_string();
+        }
+    } else if let Some(stripped) = value.strip_prefix('\'')
+        && let Some(end) = stripped.find('\'')
+    {
+        return stripped[..end].to_string();
+    }
+
+    value
+        .split_once(" #")
+        .map(|(value, _)| value.trim_end())
+        .unwrap_or(value)
+        .to_string()
+}

--- a/crates/wrac_log/src/file_logger/recent_logs.rs
+++ b/crates/wrac_log/src/file_logger/recent_logs.rs
@@ -1,0 +1,172 @@
+use std::path::{Path, PathBuf};
+
+pub(super) const MAX_LOG_FILES: usize = 30;
+pub(super) const DEFAULT_RECENT_LOG_MAX_FILES: usize = 30;
+pub(super) const DEFAULT_RECENT_LOG_MAX_TOTAL_BYTES: u64 = 50 * 1024 * 1024;
+const MAX_UNIQUE_ARCHIVED_LOG_FILE_ATTEMPTS: u32 = 1000;
+
+use super::get_timestamp;
+
+pub(super) fn collect_recent_log_files_from_current(
+    current_log_file: &Path,
+    options: &super::RecentLogFilesOptions,
+) -> std::io::Result<Vec<PathBuf>> {
+    let Some(log_dir) = current_log_file.parent() else {
+        return Ok(Vec::new());
+    };
+    let Some(current_log_file_name) = current_log_file.file_name().and_then(|name| name.to_str())
+    else {
+        return Ok(Vec::new());
+    };
+    let Some(file_stem) = current_log_file_name.strip_suffix(" Latest.log") else {
+        return Ok(vec![current_log_file.to_path_buf()]);
+    };
+
+    let mut archived_logs = Vec::new();
+    for entry in std::fs::read_dir(log_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path == current_log_file {
+            continue;
+        }
+        let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
+            continue;
+        };
+        if !is_archived_log_file_name(file_name, file_stem) {
+            continue;
+        }
+        let modified = entry.metadata()?.modified()?;
+        archived_logs.push((modified, path));
+    }
+    archived_logs.sort_by_key(|(modified, _)| std::cmp::Reverse(*modified));
+
+    // After a host crash, the crashed session's previous Latest log becomes an archived
+    // log on the next launch. Include recent archives so diagnostic bundles can still
+    // capture the failure that happened before the current session.
+    let mut selected = vec![current_log_file.to_path_buf()];
+    selected.extend(archived_logs.into_iter().map(|(_, path)| path));
+    selected.truncate(options.max_files.max(1));
+
+    // The current session describes the user's current state and is always included.
+    // Older sessions are included newest first while respecting the total size limit.
+    let mut total_bytes = 0_u64;
+    let mut limited = Vec::new();
+    for path in selected {
+        let size = std::fs::metadata(&path)?.len();
+        if limited.is_empty() || total_bytes.saturating_add(size) <= options.max_total_bytes {
+            total_bytes = total_bytes.saturating_add(size);
+            limited.push(path);
+        }
+    }
+    Ok(limited)
+}
+
+pub(super) fn rotate_logs(log_dir: &Path, file_stem: &str) {
+    let Ok(entries) = std::fs::read_dir(log_dir) else {
+        return;
+    };
+
+    let mut log_files = entries
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| is_archived_log_file_name(&entry.file_name().to_string_lossy(), file_stem))
+        .collect::<Vec<_>>();
+    if log_files.len() <= MAX_LOG_FILES {
+        return;
+    }
+
+    // Rotate by modification time so the newest archived logs survive even if a
+    // timestamped filename was created by a system clock with low precision.
+    log_files.sort_by_key(|entry| {
+        entry
+            .metadata()
+            .and_then(|metadata| metadata.modified())
+            .ok()
+    });
+    let files_to_delete = log_files.len() - MAX_LOG_FILES;
+    for entry in log_files.into_iter().take(files_to_delete) {
+        let _ = std::fs::remove_file(entry.path());
+    }
+}
+
+pub(super) fn latest_log_file_path(log_dir: &Path, file_stem: &str) -> PathBuf {
+    log_dir.join(format!("{file_stem} Latest.log"))
+}
+
+pub(super) fn archive_existing_latest_log(
+    latest_log_file: &Path,
+    file_stem: &str,
+) -> std::io::Result<()> {
+    if !latest_log_file.exists() {
+        return Ok(());
+    }
+
+    let Some(log_dir) = latest_log_file.parent() else {
+        return Ok(());
+    };
+    match std::fs::rename(
+        latest_log_file,
+        unique_archived_log_file_path(log_dir, file_stem)?,
+    ) {
+        Ok(()) => Ok(()),
+        // Validators and plugin scanners can create multiple short-lived plugin
+        // processes at once. Another process may archive the same Latest log after
+        // our exists check, which is already a successful outcome for this session.
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+fn unique_archived_log_file_path(log_dir: &Path, file_stem: &str) -> std::io::Result<PathBuf> {
+    let timestamp = get_timestamp();
+    let first = log_dir.join(format!("{file_stem} {timestamp}.log"));
+    if !first.exists() {
+        return Ok(first);
+    }
+
+    // Fast restarts or coarse system clocks can collide on the same timestamp. Bound
+    // the suffix search so an abnormal directory state cannot turn archive creation
+    // into an infinite loop.
+    for index in 1..MAX_UNIQUE_ARCHIVED_LOG_FILE_ATTEMPTS {
+        let candidate = log_dir.join(format!("{file_stem} {timestamp}-{index}.log"));
+        if !candidate.exists() {
+            return Ok(candidate);
+        }
+    }
+
+    Err(std::io::Error::new(
+        std::io::ErrorKind::AlreadyExists,
+        format!(
+            "failed to find a unique archived log file name for '{file_stem}' after {MAX_UNIQUE_ARCHIVED_LOG_FILE_ATTEMPTS} attempts",
+        ),
+    ))
+}
+
+pub(super) fn is_archived_log_file_name(file_name: &str, file_stem: &str) -> bool {
+    file_name.starts_with(&format!("{file_stem} "))
+        && file_name.ends_with(".log")
+        && file_name != format!("{file_stem} Latest.log")
+}
+
+pub(super) fn log_file_stem(app_name: &str) -> String {
+    // The app name is also user-visible in the log filename. Replace only characters
+    // that are unsafe or awkward across the major target filesystems.
+    let sanitized = app_name
+        .chars()
+        .map(|ch| {
+            if ch.is_control() || matches!(ch, '<' | '>' | ':' | '"' | '/' | '\\' | '|' | '?' | '*')
+            {
+                '_'
+            } else {
+                ch
+            }
+        })
+        .collect::<String>()
+        .trim()
+        .to_string();
+
+    if sanitized.is_empty() {
+        "Application".to_string()
+    } else {
+        sanitized
+    }
+}

--- a/crates/wrac_log/src/file_logger/rt_drain.rs
+++ b/crates/wrac_log/src/file_logger/rt_drain.rs
@@ -1,0 +1,17 @@
+use std::io::Write as _;
+
+pub(super) fn drain_rt_records_to_destination(shared: &super::LazyFileWriterShared) {
+    crate::rt::drain_rt_logs_to(|record| {
+        let mut line = Vec::new();
+        let _ = writeln!(
+            line,
+            "[{} {} {}] [rt] seq={} {}",
+            super::get_timestamp(),
+            record.level(),
+            record.target(),
+            record.sequence(),
+            record.message(),
+        );
+        let _ = super::write_log_bytes_blocking(&mut shared.destination.lock().unwrap(), &line);
+    });
+}

--- a/crates/wrac_log/src/file_logger/tests.rs
+++ b/crates/wrac_log/src/file_logger/tests.rs
@@ -1,0 +1,221 @@
+use super::*;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[test]
+fn init_test_is_idempotent() {
+    init_test();
+    init_test();
+}
+
+#[test]
+fn test_name_and_timestamp_are_available() {
+    assert!(get_test_name().contains("test"));
+
+    let timestamp = get_timestamp();
+    assert_eq!(timestamp.len(), 19);
+    assert_eq!(timestamp.chars().nth(8).unwrap(), '_');
+    assert_eq!(timestamp.chars().nth(15).unwrap(), '_');
+}
+
+#[test]
+fn logging_is_thread_safe_after_initialization() {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::thread;
+
+    let counter = Arc::new(AtomicUsize::new(0));
+    let handles = (0..10)
+        .map(|i| {
+            let counter = counter.clone();
+            thread::spawn(move || {
+                for j in 0..100 {
+                    log::info!("Thread {i} - Message {j}");
+                    counter.fetch_add(1, Ordering::SeqCst);
+                }
+            })
+        })
+        .collect::<Vec<_>>();
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+    assert_eq!(counter.load(Ordering::SeqCst), 1000);
+}
+
+#[test]
+fn log_file_stem_replaces_path_unsafe_characters() {
+    assert_eq!(log_file_stem("TestApp"), "TestApp");
+    assert_eq!(log_file_stem("Bad/Name:Plugin"), "Bad_Name_Plugin");
+    assert_eq!(log_file_stem("   "), "Application");
+}
+
+#[test]
+fn archive_existing_latest_log_moves_latest_to_timestamped_log() {
+    let temp_dir = TempDir::new("wrac_log_archive_latest");
+    let latest = temp_dir.path().join("TestApp Latest.log");
+    std::fs::write(&latest, "previous session").unwrap();
+
+    archive_existing_latest_log(&latest, "TestApp").unwrap();
+
+    assert!(!latest.exists());
+    let archived = log_files(temp_dir.path());
+    assert_eq!(archived.len(), 1);
+    let archived_name = archived[0].file_name().unwrap().to_string_lossy();
+    assert!(archived_name.starts_with("TestApp "));
+    assert!(archived_name.ends_with(".log"));
+    assert_ne!(archived_name, "TestApp Latest.log");
+    assert_eq!(
+        std::fs::read_to_string(&archived[0]).unwrap(),
+        "previous session",
+    );
+}
+
+#[test]
+fn collect_recent_log_files_includes_latest_first_and_respects_limit() {
+    let temp_dir = TempDir::new("wrac_log_collect_recent");
+    let latest = temp_dir.path().join("TestApp Latest.log");
+    let archived1 = temp_dir.path().join("TestApp 20260101_000000_000.log");
+    let archived2 = temp_dir.path().join("TestApp 20260102_000000_000.log");
+    let other = temp_dir.path().join("Other 20260103_000000_000.log");
+    std::fs::write(&latest, "latest").unwrap();
+    std::fs::write(&archived1, "archived1").unwrap();
+    std::fs::write(&archived2, "archived2").unwrap();
+    std::fs::write(&other, "other").unwrap();
+
+    let files = collect_recent_log_files_from_current(
+        &latest,
+        &RecentLogFilesOptions {
+            max_files: 2,
+            max_total_bytes: 1024,
+        },
+    )
+    .unwrap();
+
+    assert_eq!(files.len(), 2);
+    assert_eq!(files[0], latest);
+    assert!(files[1] == archived1 || files[1] == archived2);
+    assert!(!files.contains(&other));
+}
+
+#[test]
+fn rotate_logs_keeps_max_archived_logs() {
+    let temp_dir = TempDir::new("wrac_log_rotate");
+    for index in 0..(MAX_LOG_FILES + 2) {
+        let file = temp_dir
+            .path()
+            .join(format!("TestApp 20260101_000000_{index:03}.log"));
+        std::fs::write(file, format!("log {index}")).unwrap();
+    }
+    std::fs::write(temp_dir.path().join("TestApp Latest.log"), "latest").unwrap();
+
+    rotate_logs(temp_dir.path(), "TestApp");
+
+    let archived = log_files(temp_dir.path())
+        .into_iter()
+        .filter(|path| path.file_name().unwrap().to_string_lossy() != "TestApp Latest.log")
+        .collect::<Vec<_>>();
+    assert_eq!(archived.len(), MAX_LOG_FILES);
+    assert!(temp_dir.path().join("TestApp Latest.log").exists());
+}
+
+#[test]
+fn parse_dotenv_rust_log_reads_last_non_empty_rust_log() {
+    let content = r#"
+            # wrac_log reads this only in development builds
+            OTHER=value
+            export RUST_LOG="wrac_gain_plugin=debug,wrac_log=trace"
+            RUST_LOG=wrac_gain_plugin=info # the last definition wins
+        "#;
+
+    assert_eq!(
+        parse_dotenv_rust_log(content).as_deref(),
+        Some("wrac_gain_plugin=info"),
+    );
+}
+
+#[test]
+fn parse_dotenv_rust_log_ignores_empty_rust_log() {
+    assert_eq!(parse_dotenv_rust_log("RUST_LOG=\n"), None);
+}
+
+#[test]
+fn debug_dotenv_path_prefers_repository_root() {
+    let temp_dir = TempDir::new("wrac_log_dotenv_root");
+    std::fs::create_dir(temp_dir.path().join(".git")).unwrap();
+    std::fs::write(temp_dir.path().join(".env"), "RUST_LOG=info").unwrap();
+
+    let crate_dir = temp_dir.path().join("plugins").join("gain");
+    std::fs::create_dir_all(&crate_dir).unwrap();
+    std::fs::write(crate_dir.join(".env"), "RUST_LOG=trace").unwrap();
+
+    let expected = temp_dir.path().join(".env");
+    assert_eq!(
+        debug_dotenv_path(&crate_dir).as_deref(),
+        Some(expected.as_path()),
+    );
+}
+
+#[test]
+fn debug_dotenv_path_falls_back_to_nearest_dotenv_when_repository_root_has_none() {
+    let temp_dir = TempDir::new("wrac_log_dotenv_fallback");
+    std::fs::create_dir(temp_dir.path().join(".git")).unwrap();
+
+    let crate_dir = temp_dir.path().join("plugins").join("gain");
+    std::fs::create_dir_all(&crate_dir).unwrap();
+    std::fs::write(crate_dir.join(".env"), "RUST_LOG=trace").unwrap();
+
+    let expected = crate_dir.join(".env");
+    assert_eq!(
+        debug_dotenv_path(&crate_dir).as_deref(),
+        Some(expected.as_path()),
+    );
+}
+
+#[test]
+fn parse_dotenv_rust_log_strips_comment_after_quoted_value() {
+    assert_eq!(
+        parse_dotenv_rust_log(r#"RUST_LOG="debug" # comment"#).as_deref(),
+        Some("debug"),
+    );
+    assert_eq!(
+        parse_dotenv_rust_log("RUST_LOG='wrac_gain_plugin=trace' # comment").as_deref(),
+        Some("wrac_gain_plugin=trace"),
+    );
+}
+
+struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    fn new(prefix: &str) -> Self {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("{prefix}_{nanos}"));
+        std::fs::create_dir_all(&path).unwrap();
+        Self { path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+fn log_files(dir: &Path) -> Vec<PathBuf> {
+    let mut files = std::fs::read_dir(dir)
+        .unwrap()
+        .map(|entry| entry.unwrap().path())
+        .filter(|path| path.extension().is_some_and(|extension| extension == "log"))
+        .collect::<Vec<_>>();
+    files.sort();
+    files
+}

--- a/crates/wrac_log/src/lib.rs
+++ b/crates/wrac_log/src/lib.rs
@@ -8,9 +8,14 @@ mod file_logger;
 mod rt;
 
 pub use file_logger::{
-    RecentLogFilesOptions, collect_recent_log_files, current_log_dir, current_log_file, init_impl,
-    init_test,
+    LogConfig, LogOutput, RecentLogFilesOptions, collect_recent_log_files, configure,
+    current_log_dir, current_log_file, init_test,
 };
+
+#[doc(hidden)]
+pub mod __adapter {
+    pub use crate::file_logger::{AsyncFileLoggerGuard, start_async_file_logger};
+}
 /// Macro support function used by the realtime log macros to check filtering.
 ///
 /// This remains public because exported macros refer to it through `$crate`.
@@ -24,31 +29,6 @@ pub use rt::rt_log_enabled as __rt_log_enabled;
 /// logging macros instead.
 pub use rt::write_rt_log as __write_rt_log;
 pub use rt::{RtDrainingRunLoopGuard, attach_rt_drain, drain_rt_logs_once};
-
-/// Initializes logging for a WRAC plugin.
-///
-/// This macro must be called from the plugin crate so `CARGO_MANIFEST_DIR` points at
-/// the caller. In debug builds, the default log directory is resolved as
-/// `{plugin_crate}/../.log`; calling the implementation function directly from this
-/// crate would resolve that path relative to `wrac_log` instead.
-///
-/// Initialization is process-wide and idempotent. The first call wins.
-///
-/// Output destination priority:
-/// 1. `WRAC_LOG_DIR`
-/// 2. Debug builds: `{plugin_crate}/../.log`
-/// 3. Release builds: the platform user log directory under `NovoNotes/{app_name}`
-/// 4. `stderr` when no file destination can be resolved
-///
-/// When writing to a file, the current session is written to
-/// `{app_name} Latest.log`; any previous latest log is archived with a timestamp and
-/// old archives are rotated.
-#[macro_export]
-macro_rules! init {
-    ($app_name:expr) => {
-        $crate::init_impl(option_env!("CARGO_MANIFEST_DIR"), $app_name)
-    };
-}
 
 #[macro_export]
 macro_rules! rttrace {

--- a/crates/wrac_log/src/lib.rs
+++ b/crates/wrac_log/src/lib.rs
@@ -8,14 +8,10 @@ mod file_logger;
 mod rt;
 
 pub use file_logger::{
-    LogConfig, LogOutput, RecentLogFilesOptions, collect_recent_log_files, configure,
+    LogConfig, LogOutput, PluginLogInstanceGuard, PluginLogRuntime, RecentLogFilesOptions,
+    StandaloneLogRuntime, collect_recent_log_files, configure_plugin, configure_standalone,
     current_log_dir, current_log_file, init_test,
 };
-
-#[doc(hidden)]
-pub mod __adapter {
-    pub use crate::file_logger::{AsyncFileLoggerGuard, start_async_file_logger};
-}
 /// Macro support function used by the realtime log macros to check filtering.
 ///
 /// This remains public because exported macros refer to it through `$crate`.

--- a/crates/wrac_log/src/lib.rs
+++ b/crates/wrac_log/src/lib.rs
@@ -1,8 +1,12 @@
 //! Logging utilities for WRAC plugins.
 //!
 //! Regular logs are written through the `log` facade. Realtime audio threads must use
-//! the `rt*` macros, which write into a fixed-size global buffer drained later from a
-//! non-realtime run loop timer.
+//! the `rt*` macros, which write into a fixed-size global buffer drained later by the
+//! asynchronous file logger worker.
+//!
+//! Realtime logs preserve their own sequence order, and regular logs preserve their
+//! queue order. Relative ordering between realtime and regular logs is intentionally
+//! not guaranteed because they use separate non-blocking paths.
 
 mod file_logger;
 mod rt;
@@ -24,7 +28,6 @@ pub use rt::rt_log_enabled as __rt_log_enabled;
 /// Plugin code should not call or rely on this symbol directly; use the `rt*`
 /// logging macros instead.
 pub use rt::write_rt_log as __write_rt_log;
-pub use rt::{RtDrainingRunLoopGuard, attach_rt_drain, drain_rt_logs_once};
 
 #[macro_export]
 macro_rules! rttrace {

--- a/crates/wrac_log/src/rt.rs
+++ b/crates/wrac_log/src/rt.rs
@@ -1,95 +1,16 @@
 use log::{Level, LevelFilter};
 use std::array;
-use std::cell::RefCell;
 use std::fmt::{self, Write as _};
-use std::rc::{Rc, Weak};
 use std::sync::OnceLock;
-use std::sync::atomic::{AtomicU8, AtomicU64, AtomicUsize, Ordering};
-use std::time::Duration;
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, AtomicUsize, Ordering};
 
 const RT_LOG_CAPACITY: usize = 4096;
 const RT_MESSAGE_CAPACITY: usize = 256;
 const RT_TARGET_CAPACITY: usize = 96;
-const RT_DRAIN_INTERVAL: Duration = Duration::from_millis(100);
 
 static RT_LOG: OnceLock<RtLogInner> = OnceLock::new();
 static RT_FALLBACK_MAX_LEVEL: AtomicU8 = AtomicU8::new(level_filter_to_u8(LevelFilter::Off));
-
-thread_local! {
-    static RT_DRAIN_TIMER: RefCell<Weak<RtDrainInner>> = const { RefCell::new(Weak::new()) };
-}
-
-/// Keeps realtime log draining attached to a [`novonotes_run_loop::RunLoopGuard`].
-///
-/// Dropping this guard stops the drain timer before releasing the wrapped run loop
-/// guard, then drains any remaining realtime log records once on the current thread.
-#[must_use = "keep RtDrainingRunLoopGuard alive while its RunLoop is alive"]
-pub struct RtDrainingRunLoopGuard {
-    _rt_drain: RtDrain,
-    guard: novonotes_run_loop::RunLoopGuard,
-}
-
-impl RtDrainingRunLoopGuard {
-    /// Returns the run-loop-thread-local capability for the wrapped guard.
-    pub fn local(&self) -> &novonotes_run_loop::RunLoopLocal {
-        self.guard.local()
-    }
-}
-
-struct RtDrain {
-    _inner: Rc<RtDrainInner>,
-}
-
-struct RtDrainInner {
-    timer: run_loop_timer::Timer,
-}
-
-impl Drop for RtDrainInner {
-    fn drop(&mut self) {
-        self.timer.stop();
-        drain_existing_rt_logs_once();
-    }
-}
-
-/// Attaches realtime log draining to the given run loop guard.
-///
-/// Multiple calls on the same run-loop thread share one timer. The timer keeps
-/// running until the last returned guard is dropped.
-pub fn attach_rt_drain(guard: novonotes_run_loop::RunLoopGuard) -> RtDrainingRunLoopGuard {
-    let rt_drain = attach_rt_drain_to_local(guard.local());
-    RtDrainingRunLoopGuard {
-        _rt_drain: rt_drain,
-        guard,
-    }
-}
-
-fn attach_rt_drain_to_local(run_loop: &novonotes_run_loop::RunLoopLocal) -> RtDrain {
-    let _ = rt_log();
-    let inner = RT_DRAIN_TIMER.with(|slot| {
-        if let Some(inner) = slot.borrow().upgrade() {
-            return inner;
-        }
-
-        let timer = run_loop_timer::Timer::new(RT_DRAIN_INTERVAL, drain_existing_rt_logs_once);
-        timer.start(run_loop);
-        let inner = Rc::new(RtDrainInner { timer });
-        *slot.borrow_mut() = Rc::downgrade(&inner);
-        inner
-    });
-    drain_existing_rt_logs_once();
-    RtDrain { _inner: inner }
-}
-
-/// Drains the global realtime log once on the current thread.
-pub fn drain_rt_logs_once() {
-    rt_log().drain_to_log();
-}
-
-fn drain_existing_rt_logs_once() {
-    if let Some(rt_log) = RT_LOG.get() {
-        rt_log.drain_to_log();
-    }
-}
+static RT_LOG_ACCEPTING: AtomicBool = AtomicBool::new(false);
 
 pub(crate) fn init_rt_buffer() {
     // Initialize from the non-realtime setup path so the first RT log write only
@@ -101,11 +22,32 @@ pub(crate) fn set_rt_fallback_max_level(level: LevelFilter) {
     RT_FALLBACK_MAX_LEVEL.store(level_filter_to_u8(level), Ordering::Relaxed);
 }
 
+pub(crate) fn start_rt_log_drain() {
+    let rt_log = rt_log();
+    rt_log.discard_retained_records();
+    RT_LOG_ACCEPTING.store(true, Ordering::Release);
+}
+
+pub(crate) fn stop_rt_log_drain() {
+    RT_LOG_ACCEPTING.store(false, Ordering::Release);
+}
+
+pub(crate) fn drain_rt_logs_to(mut sink: impl FnMut(&RtLogRecord)) {
+    let Some(rt_log) = RT_LOG.get() else {
+        return;
+    };
+    rt_log.drain_to(&mut sink);
+}
+
 /// Returns whether a realtime log record should be written.
 ///
 /// Exported macros call this before constructing `fmt::Arguments`, so disabled RT logs
 /// do not evaluate formatting arguments on the realtime thread.
 pub fn rt_log_enabled(level: Level, target: &'static str) -> bool {
+    if !RT_LOG_ACCEPTING.load(Ordering::Acquire) {
+        return false;
+    }
+
     if level > log::STATIC_MAX_LEVEL {
         return false;
     }
@@ -123,6 +65,10 @@ pub fn rt_log_enabled(level: Level, target: &'static str) -> bool {
 /// `$crate`. Plugin code should not call or rely on this function directly; use
 /// the `rt*` logging macros instead.
 pub fn write_rt_log(level: Level, target: &'static str, args: fmt::Arguments<'_>) {
+    if !RT_LOG_ACCEPTING.load(Ordering::Acquire) {
+        return;
+    }
+
     rt_log().write_fmt(level, target, args);
 }
 
@@ -158,7 +104,13 @@ impl RtLogInner {
         self.slots[sequence as usize % RT_LOG_CAPACITY].write(sequence, level, target, args);
     }
 
-    fn drain_to_log(&self) {
+    fn discard_retained_records(&self) {
+        let total = self.next_sequence.load(Ordering::Acquire);
+        self.drain_sequence.store(total, Ordering::Release);
+        self.dropped.store(0, Ordering::Release);
+    }
+
+    fn drain_to(&self, sink: &mut impl FnMut(&RtLogRecord)) {
         let total = self.next_sequence.load(Ordering::Acquire);
         let retained_start = total.saturating_sub(RT_LOG_CAPACITY as u64);
         let start = self
@@ -169,24 +121,23 @@ impl RtLogInner {
         let previous_drain_sequence = self.drain_sequence.load(Ordering::Acquire);
         let dropped = self.dropped.swap(0, Ordering::AcqRel);
         if dropped > 0 || start > previous_drain_sequence {
-            log::warn!(
-                target: "wrac_log::rt",
-                "[rt] dropped={} skipped={}",
-                dropped,
-                start.saturating_sub(previous_drain_sequence),
-            );
+            let record = RtLogRecord {
+                sequence: start,
+                level: Level::Warn,
+                target: FixedString::from_str("wrac_log::rt"),
+                message: FixedString::from_string(format!(
+                    "dropped={} skipped={}",
+                    dropped,
+                    start.saturating_sub(previous_drain_sequence),
+                )),
+            };
+            sink(&record);
         }
 
         let mut drained_until = start;
         for sequence in start..total {
             if let Some(record) = self.slots[sequence as usize % RT_LOG_CAPACITY].read(sequence) {
-                log::log!(
-                    target: record.target.as_str(),
-                    record.level,
-                    "[rt] seq={} {}",
-                    record.sequence,
-                    record.message.as_str(),
-                );
+                sink(&record);
                 drained_until = sequence + 1;
             } else {
                 // The writer reserves the sequence before publishing the slot. Stop at the first
@@ -250,11 +201,29 @@ impl RtLogSlot {
     }
 }
 
-struct RtLogRecord {
+pub(crate) struct RtLogRecord {
     sequence: u64,
     level: Level,
     target: FixedString<RT_TARGET_CAPACITY>,
     message: FixedString<RT_MESSAGE_CAPACITY>,
+}
+
+impl RtLogRecord {
+    pub(crate) fn sequence(&self) -> u64 {
+        self.sequence
+    }
+
+    pub(crate) fn level(&self) -> Level {
+        self.level
+    }
+
+    pub(crate) fn target(&self) -> &str {
+        self.target.as_str()
+    }
+
+    pub(crate) fn message(&self) -> &str {
+        self.message.as_str()
+    }
 }
 
 struct FixedMessage {
@@ -302,6 +271,17 @@ struct FixedString<const N: usize> {
 }
 
 impl<const N: usize> FixedString<N> {
+    fn from_str(value: &str) -> Self {
+        let mut bytes = [0; N];
+        let len = utf8_boundary_len(value, N);
+        bytes[..len].copy_from_slice(&value.as_bytes()[..len]);
+        Self { bytes, len }
+    }
+
+    fn from_string(value: String) -> Self {
+        Self::from_str(&value)
+    }
+
     fn as_str(&self) -> &str {
         std::str::from_utf8(&self.bytes[..self.len]).unwrap_or("<invalid utf8>")
     }
@@ -375,12 +355,14 @@ mod tests {
         let log = RtLogInner::new();
         log.next_sequence.store(1, Ordering::Release);
 
-        log.drain_to_log();
+        let mut records = Vec::new();
+        log.drain_to(&mut |record| records.push(record.sequence()));
         assert_eq!(log.drain_sequence.load(Ordering::Acquire), 0);
 
         log.slots[0].write(0, Level::Debug, "test", format_args!("published"));
-        log.drain_to_log();
+        log.drain_to(&mut |record| records.push(record.sequence()));
         assert_eq!(log.drain_sequence.load(Ordering::Acquire), 1);
+        assert_eq!(records, vec![0]);
     }
 
     #[test]
@@ -398,23 +380,19 @@ mod tests {
     }
 
     #[test]
-    fn rt_drain_guards_share_one_run_loop_timer() {
-        let first_run_loop_guard = novonotes_run_loop::RunLoop::init().expect("init test RunLoop");
-        let second_run_loop_guard =
-            novonotes_run_loop::RunLoop::init().expect("share test RunLoop");
+    fn rt_logs_are_dropped_while_drain_is_stopped() {
+        RT_LOG_ACCEPTING.store(false, Ordering::Release);
 
-        let first_drain = attach_rt_drain(first_run_loop_guard);
-        let second_drain = attach_rt_drain(second_run_loop_guard);
+        write_rt_log(Level::Warn, "test", format_args!("stopped"));
 
-        assert!(Rc::ptr_eq(
-            &first_drain._rt_drain._inner,
-            &second_drain._rt_drain._inner
-        ));
-        assert_eq!(Rc::strong_count(&first_drain._rt_drain._inner), 2);
+        let log = rt_log();
+        let before_start = log.next_sequence.load(Ordering::Acquire);
+        start_rt_log_drain();
+        write_rt_log(Level::Warn, "test", format_args!("started"));
+        stop_rt_log_drain();
 
-        drop(first_drain);
-        assert_eq!(Rc::strong_count(&second_drain._rt_drain._inner), 1);
-
-        drop(second_drain);
+        let mut records = Vec::new();
+        drain_rt_logs_to(|record| records.push(record.sequence()));
+        assert_eq!(records, vec![before_start]);
     }
 }

--- a/crates/wrac_wxp_gui/src/runtime.rs
+++ b/crates/wrac_wxp_gui/src/runtime.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::thread::ThreadId;
 
-use novonotes_run_loop::{RunLoop, RunLoopLocal};
+use novonotes_run_loop::{RunLoop, RunLoopGuard, RunLoopLocal};
 use parking_lot::Mutex;
 use wrac_clap_adapter::{GuiConfig, GuiSize, PluginError, PluginResult};
 
@@ -15,7 +15,7 @@ thread_local! {
     static GUI_RUNTIMES: RefCell<HashMap<u64, GuiRuntimeEntry>> = RefCell::new(HashMap::new());
     // Keep the `!Send` run-loop guard on the GUI thread. `GuiThreadLease` is only a
     // cross-thread token; it releases this guard by dispatching back to the owner thread.
-    static GUI_RUN_LOOP_GUARD: RefCell<Option<wrac_log::RtDrainingRunLoopGuard>> = const {
+    static GUI_RUN_LOOP_GUARD: RefCell<Option<RunLoopGuard>> = const {
         RefCell::new(None)
     };
 }
@@ -272,7 +272,6 @@ impl GuiThreadLease {
                 log::debug!("wxp GUI thread lease: RunLoop::init failed");
                 PluginError::UnsupportedHostGuiThreadingModel
             })?;
-            let guard = wrac_log::attach_rt_drain(guard);
             GUI_RUN_LOOP_GUARD.with(|stored_guard| {
                 debug_assert!(stored_guard.borrow().is_none());
                 *stored_guard.borrow_mut() = Some(guard);

--- a/docs/setup-ja.md
+++ b/docs/setup-ja.md
@@ -149,3 +149,14 @@ package が複数の plugin product を公開している場合は `--plugin-id`
 
 デバッグビルドのログは `.log/<plugin_name> Latest.log` に出ます。
 追いかける場合は macOS / Linux では `tail -f ".log/<plugin_name> Latest.log"`、Windows PowerShell では `Get-Content ".log\<plugin_name> Latest.log" -Wait` などを使います。
+ログレベルを上書きする場合は `RUST_LOG` 環境変数を使ってください。
+Debug build では、process 環境変数に `RUST_LOG` が無い場合、repository root の `.env` に書いた `RUST_LOG` も参照します。
+`PluginEntry::init` / `PluginEntry::deinit` からログを書かないでください。これらの callback は plugin scan や DSO unload の近くで呼ばれ得るため、File IO、stderr 書き込み、worker 起動、worker join も避けてください。
+
+### Plugin logging の責務
+
+`wrac_clap_adapter` を使う plugin は、`PluginEntry::log_config` からログ設定を返してください。
+Plugin 製品コードから `wrac_log::configure` や async file writer lifecycle API を直接呼ばないでください。logger の install と async file writer の lifecycle は adapter が管理します。
+Realtime 経路以外では通常の `log::*` macro を使い、realtime 経路では必要な場合だけ `wrac_log::rtdebug!` / `wrac_log::rtwarn!` を使ってください。
+
+Standalone app、service、test binary は `wrac_clap_adapter` を通らないため、`wrac_log::configure` または `wrac_log::init_test` で明示的に logger を初期化してください。

--- a/docs/setup-ja.md
+++ b/docs/setup-ja.md
@@ -156,7 +156,7 @@ Debug build では、process 環境変数に `RUST_LOG` が無い場合、reposi
 ### Plugin logging の責務
 
 `wrac_clap_adapter` を使う plugin は、`PluginEntry::log_config` からログ設定を返してください。
-Plugin 製品コードから `wrac_log::configure` や async file writer lifecycle API を直接呼ばないでください。logger の install と async file writer の lifecycle は adapter が管理します。
+Plugin 製品コードから `wrac_log` の configure API を直接呼ばないでください。logger の install と async file writer の lifecycle は adapter が管理します。
 Realtime 経路以外では通常の `log::*` macro を使い、realtime 経路では必要な場合だけ `wrac_log::rtdebug!` / `wrac_log::rtwarn!` を使ってください。
 
-Standalone app、service、test binary は `wrac_clap_adapter` を通らないため、`wrac_log::configure` または `wrac_log::init_test` で明示的に logger を初期化してください。
+Standalone app / service は `wrac_clap_adapter` を通らないため、`wrac_log::configure_standalone` で明示的に logger を初期化し、async file logging を有効にしたい期間は返り値の runtime を保持してください。test binary は `wrac_log::init_test` を使ってください。

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -158,7 +158,7 @@ Do not log from `PluginEntry::init` or `PluginEntry::deinit`; those callbacks ma
 ### Plugin Logging Responsibilities
 
 Plugins using `wrac_clap_adapter` must provide logging configuration from `PluginEntry::log_config`.
-Do not call `wrac_log::configure` or the async file-writer lifecycle APIs from plugin product code; the adapter owns logger installation and the async file-writer lifecycle.
+Do not call `wrac_log` configure APIs from plugin product code; the adapter owns logger installation and the async file-writer lifecycle.
 Use regular `log::*` macros outside realtime paths, and use `wrac_log::rtdebug!` / `wrac_log::rtwarn!` only from realtime paths.
 
-Standalone apps, services, and test binaries do not enter through `wrac_clap_adapter`, so they must initialize logging explicitly with `wrac_log::configure` or `wrac_log::init_test`.
+Standalone apps and services do not enter through `wrac_clap_adapter`, so they must initialize logging explicitly with `wrac_log::configure_standalone` and hold the returned runtime while async file logging should remain active. Test binaries should use `wrac_log::init_test`.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -151,3 +151,14 @@ If the package exposes multiple plugin products, pass `--plugin-id`; invalid plu
 
 Debug build logs are written to `.log/<plugin_name> Latest.log`.
 To follow the log, use `tail -f ".log/<plugin_name> Latest.log"` on macOS/Linux, or `Get-Content ".log\<plugin_name> Latest.log" -Wait` in Windows PowerShell.
+Use the `RUST_LOG` environment variable to override the default log level.
+In debug builds, WRAC also reads `RUST_LOG` from the repository root `.env` when the process environment does not provide it.
+Do not log from `PluginEntry::init` or `PluginEntry::deinit`; those callbacks may run during plugin scanning or DSO unload. Keep them free of file I/O, stderr writes, worker startup, and worker joins.
+
+### Plugin Logging Responsibilities
+
+Plugins using `wrac_clap_adapter` must provide logging configuration from `PluginEntry::log_config`.
+Do not call `wrac_log::configure` or the async file-writer lifecycle APIs from plugin product code; the adapter owns logger installation and the async file-writer lifecycle.
+Use regular `log::*` macros outside realtime paths, and use `wrac_log::rtdebug!` / `wrac_log::rtwarn!` only from realtime paths.
+
+Standalone apps, services, and test binaries do not enter through `wrac_clap_adapter`, so they must initialize logging explicitly with `wrac_log::configure` or `wrac_log::init_test`.

--- a/plugins/wrac-gain/src-plugin/src/plugin.rs
+++ b/plugins/wrac-gain/src-plugin/src/plugin.rs
@@ -28,7 +28,7 @@ use params::WracGainParamsExtension;
 use state::WracGainStateExtension;
 use wrac_clap_adapter::{
     AaxDescriptor, AaxStemConfig, ActivateContext, ActivateResult, ActiveProcessor, Auv2Descriptor,
-    InactiveProcessor, PluginAudioPortsExtension, PluginConfigurableAudioPortsExtension,
+    InactiveProcessor, LogConfig, PluginAudioPortsExtension, PluginConfigurableAudioPortsExtension,
     PluginDescriptor, PluginEntry, PluginFactory, PluginFeature, PluginGuiExtension,
     PluginInstance, PluginInstanceContext, PluginParamsQuery, PluginResult, PluginStateExtension,
     Vst3Descriptor,
@@ -45,10 +45,18 @@ use crate::state::{ProjectStateStore, SharedState};
 include!(concat!(env!("OUT_DIR"), "/wrac_plugin_products.rs"));
 
 pub(crate) static PLUGIN_ENTRY: WracGainEntry = WracGainEntry;
+static LOG_CONFIG: LogConfig = LogConfig::new(
+    PLUGIN_DESCRIPTORS[0].name,
+    Some(concat!(env!("CARGO_MANIFEST_DIR"), "/../.log")),
+);
 
 pub(crate) struct WracGainEntry;
 
 impl PluginEntry for WracGainEntry {
+    fn log_config(&'static self) -> Option<&'static LogConfig> {
+        Some(&LOG_CONFIG)
+    }
+
     fn plugin_factory(&self) -> Option<&dyn PluginFactory> {
         Some(&WRAC_GAIN_FACTORY)
     }
@@ -155,8 +163,6 @@ pub(crate) fn create_plugin_core(
     context: PluginInstanceContext,
     descriptor: PluginDescriptor,
 ) -> Box<dyn PluginInstance> {
-    wrac_log::init!(descriptor.name);
-
     log::debug!(
         "creating plugin core: id={}, name={}",
         descriptor.id,


### PR DESCRIPTION
## Summary
- Add lazy WRAC file logger initialization and an adapter-owned async file writer guard.
- Move async writer stop/join into plugin instance lifetime instead of DSO entry deinit.
- Document plugin logging responsibilities and keep direct logger lifecycle calls out of plugin product code.

## Validation
- cargo check --manifest-path deps/wrac-plugin-template/Cargo.toml --workspace --all-targets
- cargo xtask quality in deps/wrac-plugin-template
- cargo xtask quality in novonotes-products root
