### PR TITLE
Allow owned plugin error messages

### DIFF
--- a/crates/wrac_clap_adapter/src/api/error.rs
+++ b/crates/wrac_clap_adapter/src/api/error.rs
@@ -1,5 +1,8 @@
-use std::error::Error;
-use std::fmt::{Display, Formatter};
+use std::{
+    borrow::Cow,
+    error::Error,
+    fmt::{Display, Formatter},
+};
 
 use crate::process_buffer::AudioBufferError;
 
@@ -9,7 +12,7 @@ pub enum PluginError {
     InvalidState,
     UnsupportedHostGuiThreadingModel,
     RequiresInactive,
-    Message(&'static str),
+    Message(Cow<'static, str>),
 }
 
 impl Display for PluginError {

--- a/crates/wrac_clap_adapter/src/host_gui.rs
+++ b/crates/wrac_clap_adapter/src/host_gui.rs
@@ -55,7 +55,7 @@ impl HostGui for HostGuiProxy {
     fn request_resize(&self, size: GuiSize) -> PluginResult<()> {
         let Some(host_gui) = self.callbacks() else {
             return Err(PluginError::Message(
-                "host does not expose CLAP GUI extension",
+                "host does not expose CLAP GUI extension".into(),
             ));
         };
 
@@ -63,7 +63,9 @@ impl HostGui for HostGuiProxy {
         if accepted {
             Ok(())
         } else {
-            Err(PluginError::Message("host rejected GUI resize request"))
+            Err(PluginError::Message(
+                "host rejected GUI resize request".into(),
+            ))
         }
     }
 

--- a/crates/wrac_wxp_gui/src/controller.rs
+++ b/crates/wrac_wxp_gui/src/controller.rs
@@ -703,7 +703,7 @@ impl PluginGuiMainThreadExtension for WxpGuiController {
             configuration.is_floating,
         ) {
             log::debug!("wxp controller: create rejected unsupported configuration");
-            return Err(PluginError::Message("unsupported GUI configuration"));
+            return Err(PluginError::Message("unsupported GUI configuration".into()));
         }
         self.destroy_gui_session();
         let scale = *self.scale.lock();

--- a/crates/wrac_wxp_gui/src/controller/resize.rs
+++ b/crates/wrac_wxp_gui/src/controller/resize.rs
@@ -149,7 +149,7 @@ impl WxpGuiResizeHandle {
                 // can resize without extending the lifetime of a closing editor.
                 web_view
                     .post_set_bounds(dpi.create_webview_bounds(logical_size))
-                    .map_err(|_| PluginError::Message("failed to resize webview"))?;
+                    .map_err(|_| PluginError::Message("failed to resize webview".into()))?;
                 self.layout.store_accepted_size(gui_size);
                 Ok(logical_size)
             }

--- a/crates/wrac_wxp_gui/src/session.rs
+++ b/crates/wrac_wxp_gui/src/session.rs
@@ -79,7 +79,7 @@ impl WxpWebViewSession {
 
         let data_dir = webview_data_dir(config.plugin_id);
         std::fs::create_dir_all(&data_dir)
-            .map_err(|_| PluginError::Message("failed to create GUI data directory"))?;
+            .map_err(|_| PluginError::Message("failed to create GUI data directory".into()))?;
         log::debug!("using GUI data directory: {}", data_dir.display());
 
         let mut wxp_context = WebContext::new(data_dir);
@@ -133,14 +133,14 @@ impl WxpWebViewSession {
                     .with_visible(true)
                     .with_bounds(bounds)
                     .with_serve_zip(scheme, bytes)
-                    .map_err(|_| PluginError::Message("failed to serve GUI assets"))?
+                    .map_err(|_| PluginError::Message("failed to serve GUI assets".into()))?
                     .with_url(url)
             }
         };
 
         let web_view = builder
             .build_as_child(&config.parent)
-            .map_err(|_| PluginError::Message("failed to build webview"))?;
+            .map_err(|_| PluginError::Message("failed to build webview".into()))?;
 
         log::debug!("creating wxp WebView session completed");
         Ok(Self {
@@ -182,7 +182,7 @@ impl WxpWebViewSession {
             web_view
                 .dispatch()
                 .post_set_visible(true)
-                .map_err(|_| PluginError::Message("failed to show webview"))?;
+                .map_err(|_| PluginError::Message("failed to show webview".into()))?;
         }
         Ok(())
     }
@@ -193,7 +193,7 @@ impl WxpWebViewSession {
             web_view
                 .dispatch()
                 .post_set_visible(false)
-                .map_err(|_| PluginError::Message("failed to hide webview"))?;
+                .map_err(|_| PluginError::Message("failed to hide webview".into()))?;
         }
         Ok(())
     }
@@ -205,7 +205,7 @@ impl WxpWebViewSession {
             web_view
                 .dispatch()
                 .post_set_bounds(self.dpi_converter.create_webview_bounds(self.logical_size))
-                .map_err(|_| PluginError::Message("failed to resize webview"))?;
+                .map_err(|_| PluginError::Message("failed to resize webview".into()))?;
         }
         Ok(())
     }

--- a/plugins/wrac-gain/src-plugin/src/gui/runtime.rs
+++ b/plugins/wrac-gain/src-plugin/src/gui/runtime.rs
@@ -73,7 +73,7 @@ impl WracGainGuiRuntime {
         // Implement floating window support separately if needed.
         if configuration.is_floating {
             log::warn!("rejecting floating GUI configuration");
-            return Err(PluginError::Message("unsupported GUI configuration"));
+            return Err(PluginError::Message("unsupported GUI configuration".into()));
         }
         log::debug!(
             "creating GUI runtime: width={}, height={}, configuration={configuration:?}",


### PR DESCRIPTION
## Summary
- Change PluginError::Message to use Cow<'static, str>.
- Update existing static message call sites to the new type.

## Verification
- cargo xtask quality