### PR TITLE
Stage plugin resources before packaging

### DIFF
--- a/clap_wrapper_builder/CMakeLists.txt
+++ b/clap_wrapper_builder/CMakeLists.txt
@@ -28,6 +28,9 @@ project(clap_wrapper_builder)
 #     CLAP_WRAPPER_BUILDER_STAGE_DIR        If set, finished artifacts are
 #                                           copied here under fixed names.
 #                                           Leave empty to skip staging.
+#     CLAP_WRAPPER_BUILDER_RESOURCE_DIRECTORY
+#                                           Directory copied into plugin bundle
+#                                           resources for supported formats.
 #
 #   Products
 #     CLAP_WRAPPER_BUILDER_PRODUCT_COUNT    Number of plugin products exposed by
@@ -81,6 +84,7 @@ set(CLAP_WRAPPER_BUILDER_TARGET_NAME "" CACHE STRING "Internal CMake target name
 set(CLAP_WRAPPER_BUILDER_OUTPUT_NAME "" CACHE STRING "Output plugin display/bundle name")
 set(CLAP_WRAPPER_BUILDER_STAGE_DIR "" CACHE PATH "Directory where built artifacts are staged")
 set(CLAP_WRAPPER_BUILDER_BUNDLE_VERSION "1.0.0" CACHE STRING "Version written into wrapped plugin bundles")
+set(CLAP_WRAPPER_BUILDER_RESOURCE_DIRECTORY "" CACHE PATH "Directory copied into plugin bundle resources")
 set(CLAP_WRAPPER_BUILDER_PRODUCT_COUNT "1" CACHE STRING "Number of plugin products exposed by the wrapped library")
 option(CLAP_WRAPPER_BUILDER_BUILD_STANDALONE "Build standalone app target in clap_wrapper_builder" OFF)
 option(CLAP_WRAPPER_BUILDER_BUILD_VST3 "Build VST3 target in clap_wrapper_builder" ON)
@@ -121,12 +125,31 @@ message(STATUS "  Target Library: ${CLAP_WRAPPER_BUILDER_TARGET_LIB}")
 message(STATUS "  Plugin Name: ${PLUGIN_NAME}")
 message(STATUS "  Safe Plugin Name: ${PLUGIN_NAME_SAFE}")
 message(STATUS "  Stage Dir: ${CLAP_WRAPPER_BUILDER_STAGE_DIR}")
+message(STATUS "  Resource Dir: ${CLAP_WRAPPER_BUILDER_RESOURCE_DIRECTORY}")
 message(STATUS "  Build AAX: ${CLAP_WRAPPER_BUILDER_BUILD_AAX}")
 message(STATUS "  Product Count: ${CLAP_WRAPPER_BUILDER_PRODUCT_COUNT}")
 if(CLAP_WRAPPER_BUILDER_PRODUCT_COUNT LESS 1)
     message(FATAL_ERROR "CLAP_WRAPPER_BUILDER_PRODUCT_COUNT must be at least 1")
 endif()
 math(EXPR PRODUCT_LAST_INDEX "${CLAP_WRAPPER_BUILDER_PRODUCT_COUNT} - 1")
+
+if(CLAP_WRAPPER_BUILDER_RESOURCE_DIRECTORY)
+    if(NOT EXISTS "${CLAP_WRAPPER_BUILDER_RESOURCE_DIRECTORY}")
+        message(FATAL_ERROR "CLAP_WRAPPER_BUILDER_RESOURCE_DIRECTORY does not exist: ${CLAP_WRAPPER_BUILDER_RESOURCE_DIRECTORY}")
+    endif()
+    if(CLAP_WRAPPER_BUILDER_BUILD_AUV2)
+        message(FATAL_ERROR "CLAP_WRAPPER_BUILDER_RESOURCE_DIRECTORY is not supported for AUv2 builds yet")
+    endif()
+    if(CLAP_WRAPPER_BUILDER_BUILD_AAX)
+        message(FATAL_ERROR "CLAP_WRAPPER_BUILDER_RESOURCE_DIRECTORY is not supported for AAX builds yet")
+    endif()
+    if(CLAP_WRAPPER_BUILDER_BUILD_STANDALONE)
+        message(FATAL_ERROR "CLAP_WRAPPER_BUILDER_RESOURCE_DIRECTORY is not supported for standalone builds yet")
+    endif()
+    if(CLAP_WRAPPER_BUILDER_BUILD_VST3 AND NOT APPLE)
+        message(FATAL_ERROR "CLAP_WRAPPER_BUILDER_RESOURCE_DIRECTORY is only supported for macOS VST3 builds")
+    endif()
+endif()
 
 # Add the clap-wrapper subproject
 add_subdirectory(clap-wrapper)
@@ -243,6 +266,7 @@ set(CLAPFIRST_COMMON_ARGS
     # We stage artifacts ourselves into STAGE_DIR below, so suppress
     # clap-wrapper's own install-to-system-folders step.
     COPY_AFTER_BUILD FALSE
+    RESOURCE_DIRECTORY "${CLAP_WRAPPER_BUILDER_RESOURCE_DIRECTORY}"
     WINDOWS_FOLDER_VST3 TRUE
 )
 

--- a/clap_wrapper_builder/CMakeLists.txt
+++ b/clap_wrapper_builder/CMakeLists.txt
@@ -28,9 +28,6 @@ project(clap_wrapper_builder)
 #     CLAP_WRAPPER_BUILDER_STAGE_DIR        If set, finished artifacts are
 #                                           copied here under fixed names.
 #                                           Leave empty to skip staging.
-#     CLAP_WRAPPER_BUILDER_RESOURCE_DIRECTORY
-#                                           Directory copied into plugin bundle
-#                                           resources for supported formats.
 #
 #   Products
 #     CLAP_WRAPPER_BUILDER_PRODUCT_COUNT    Number of plugin products exposed by
@@ -84,7 +81,6 @@ set(CLAP_WRAPPER_BUILDER_TARGET_NAME "" CACHE STRING "Internal CMake target name
 set(CLAP_WRAPPER_BUILDER_OUTPUT_NAME "" CACHE STRING "Output plugin display/bundle name")
 set(CLAP_WRAPPER_BUILDER_STAGE_DIR "" CACHE PATH "Directory where built artifacts are staged")
 set(CLAP_WRAPPER_BUILDER_BUNDLE_VERSION "1.0.0" CACHE STRING "Version written into wrapped plugin bundles")
-set(CLAP_WRAPPER_BUILDER_RESOURCE_DIRECTORY "" CACHE PATH "Directory copied into plugin bundle resources")
 set(CLAP_WRAPPER_BUILDER_PRODUCT_COUNT "1" CACHE STRING "Number of plugin products exposed by the wrapped library")
 option(CLAP_WRAPPER_BUILDER_BUILD_STANDALONE "Build standalone app target in clap_wrapper_builder" OFF)
 option(CLAP_WRAPPER_BUILDER_BUILD_VST3 "Build VST3 target in clap_wrapper_builder" ON)
@@ -125,31 +121,12 @@ message(STATUS "  Target Library: ${CLAP_WRAPPER_BUILDER_TARGET_LIB}")
 message(STATUS "  Plugin Name: ${PLUGIN_NAME}")
 message(STATUS "  Safe Plugin Name: ${PLUGIN_NAME_SAFE}")
 message(STATUS "  Stage Dir: ${CLAP_WRAPPER_BUILDER_STAGE_DIR}")
-message(STATUS "  Resource Dir: ${CLAP_WRAPPER_BUILDER_RESOURCE_DIRECTORY}")
 message(STATUS "  Build AAX: ${CLAP_WRAPPER_BUILDER_BUILD_AAX}")
 message(STATUS "  Product Count: ${CLAP_WRAPPER_BUILDER_PRODUCT_COUNT}")
 if(CLAP_WRAPPER_BUILDER_PRODUCT_COUNT LESS 1)
     message(FATAL_ERROR "CLAP_WRAPPER_BUILDER_PRODUCT_COUNT must be at least 1")
 endif()
 math(EXPR PRODUCT_LAST_INDEX "${CLAP_WRAPPER_BUILDER_PRODUCT_COUNT} - 1")
-
-if(CLAP_WRAPPER_BUILDER_RESOURCE_DIRECTORY)
-    if(NOT EXISTS "${CLAP_WRAPPER_BUILDER_RESOURCE_DIRECTORY}")
-        message(FATAL_ERROR "CLAP_WRAPPER_BUILDER_RESOURCE_DIRECTORY does not exist: ${CLAP_WRAPPER_BUILDER_RESOURCE_DIRECTORY}")
-    endif()
-    if(CLAP_WRAPPER_BUILDER_BUILD_AUV2)
-        message(FATAL_ERROR "CLAP_WRAPPER_BUILDER_RESOURCE_DIRECTORY is not supported for AUv2 builds yet")
-    endif()
-    if(CLAP_WRAPPER_BUILDER_BUILD_AAX)
-        message(FATAL_ERROR "CLAP_WRAPPER_BUILDER_RESOURCE_DIRECTORY is not supported for AAX builds yet")
-    endif()
-    if(CLAP_WRAPPER_BUILDER_BUILD_STANDALONE)
-        message(FATAL_ERROR "CLAP_WRAPPER_BUILDER_RESOURCE_DIRECTORY is not supported for standalone builds yet")
-    endif()
-    if(CLAP_WRAPPER_BUILDER_BUILD_VST3 AND NOT APPLE)
-        message(FATAL_ERROR "CLAP_WRAPPER_BUILDER_RESOURCE_DIRECTORY is only supported for macOS VST3 builds")
-    endif()
-endif()
 
 # Add the clap-wrapper subproject
 add_subdirectory(clap-wrapper)
@@ -266,7 +243,6 @@ set(CLAPFIRST_COMMON_ARGS
     # We stage artifacts ourselves into STAGE_DIR below, so suppress
     # clap-wrapper's own install-to-system-folders step.
     COPY_AFTER_BUILD FALSE
-    RESOURCE_DIRECTORY "${CLAP_WRAPPER_BUILDER_RESOURCE_DIRECTORY}"
     WINDOWS_FOLDER_VST3 TRUE
 )
 

--- a/crates/wrac_xtask/src/commands.rs
+++ b/crates/wrac_xtask/src/commands.rs
@@ -15,6 +15,7 @@ use crate::util::{
 use crate::{BuildProfile, InstallScope, UninstallScope};
 
 mod build;
+mod plugin_resources;
 mod validation;
 
 pub(crate) use self::build::{

--- a/crates/wrac_xtask/src/commands/build.rs
+++ b/crates/wrac_xtask/src/commands/build.rs
@@ -244,6 +244,7 @@ pub(crate) fn package_clap(ctx: &Context, profile: BuildProfile) -> Result<()> {
     let bundle = ctx.clap_bundle(profile);
     remove_if_exists(&bundle)?;
     fs::create_dir_all(ctx.plugins_dir(profile))?;
+    let resource_dir = prepare_plugin_resource_dir(ctx)?;
 
     match ctx.platform {
         Platform::Macos => {
@@ -262,6 +263,9 @@ pub(crate) fn package_clap(ctx: &Context, profile: BuildProfile) -> Result<()> {
                 ctx.dynamic_library(profile),
                 macos.join(&ctx.metadata.bundle_name),
             )?;
+            if let Some(resource_dir) = &resource_dir {
+                copy_resource_directory(resource_dir, &contents.join("Resources"))?;
+            }
             run_with_language(
                 Command::new("install_name_tool")
                     .arg("-id")
@@ -276,10 +280,116 @@ pub(crate) fn package_clap(ctx: &Context, profile: BuildProfile) -> Result<()> {
             // On Windows/Linux the CLAP artifact is a dynamic library with the .clap extension.
             // Skipping the bundle structure keeps it compatible with each OS's existing host scan conventions.
             fs::copy(ctx.dynamic_library(profile), &bundle)?;
+            if let (Some(resource_dir), Some(parent)) = (&resource_dir, bundle.parent()) {
+                copy_resource_directory(resource_dir, parent)?;
+            }
         }
     }
 
     ensure_exists(&bundle, "CLAP artifact")?;
+    Ok(())
+}
+
+fn prepare_plugin_resource_dir(ctx: &Context) -> Result<Option<PathBuf>> {
+    let source_dirs = plugin_resource_dirs(ctx);
+    let stage_dir = staged_plugin_resource_dir(ctx);
+    remove_if_exists(&stage_dir)?;
+    if source_dirs.is_empty() {
+        return Ok(None);
+    }
+
+    fs::create_dir_all(&stage_dir)?;
+    for source_dir in source_dirs {
+        copy_resource_directory(&source_dir, &stage_dir)?;
+    }
+    Ok(Some(stage_dir))
+}
+
+fn plugin_resource_dirs(ctx: &Context) -> Vec<PathBuf> {
+    [
+        // Source resources are hand-authored plugin assets. They are copied first so generated
+        // resources can intentionally replace them when both trees contain the same relative path.
+        ctx.plugin_root.join("resources"),
+        // Generated resources belong under the build output so large artifacts can be rebuilt and
+        // omitted from source control while still flowing through the same packaging contract.
+        ctx.wrac_dir().join("resources"),
+    ]
+    .into_iter()
+    .filter(|resource_dir| resource_dir.exists())
+    .collect()
+}
+
+fn staged_plugin_resource_dir(ctx: &Context) -> PathBuf {
+    ctx.wrac_dir().join("staged-resources")
+}
+
+fn copy_resource_directory(source: &Path, destination: &Path) -> Result<()> {
+    fs::create_dir_all(destination)?;
+    copy_resource_directory_inner(source, destination)
+}
+
+fn copy_resource_directory_inner(source: &Path, destination: &Path) -> Result<()> {
+    for entry in fs::read_dir(source)? {
+        let entry = entry?;
+        let source_path = entry.path();
+        let destination_path = destination.join(entry.file_name());
+        let file_type = entry.file_type()?;
+        if file_type.is_symlink() {
+            copy_symlink(&source_path, &destination_path)?;
+        } else if file_type.is_dir() {
+            if destination_path.is_symlink()
+                || (destination_path.exists() && !destination_path.is_dir())
+            {
+                remove_resource_destination(&destination_path)?;
+            }
+            fs::create_dir_all(&destination_path)?;
+            copy_resource_directory_inner(&source_path, &destination_path)?;
+        } else if file_type.is_file() {
+            if destination_path.exists() || destination_path.is_symlink() {
+                remove_resource_destination(&destination_path)?;
+            }
+            fs::copy(&source_path, &destination_path)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn copy_symlink(source: &Path, destination: &Path) -> Result<()> {
+    let target = fs::read_link(source)?;
+    if destination.exists() || destination.is_symlink() {
+        remove_resource_destination(destination)?;
+    }
+    std::os::unix::fs::symlink(target, destination)?;
+    Ok(())
+}
+
+#[cfg(windows)]
+fn copy_symlink(source: &Path, destination: &Path) -> Result<()> {
+    let target = fs::read_link(source)?;
+    if destination.exists() || destination.is_symlink() {
+        remove_resource_destination(destination)?;
+    }
+    // Preserve symlinks produced by external packagers instead of flattening them, because their
+    // relative loader paths can be part of the runtime's file-system contract.
+    if source.is_dir() {
+        std::os::windows::fs::symlink_dir(target, destination)?;
+    } else {
+        std::os::windows::fs::symlink_file(target, destination)?;
+    }
+    Ok(())
+}
+
+fn remove_resource_destination(path: &Path) -> Result<()> {
+    // Resource staging intentionally allows generated resources to replace source resources with
+    // the same relative path. Use symlink_metadata so replacement never follows a symlink into the
+    // source tree or a tool-generated runtime directory.
+    let metadata = fs::symlink_metadata(path)?;
+    if metadata.file_type().is_symlink() || metadata.is_file() {
+        fs::remove_file(path)?;
+    } else if metadata.is_dir() {
+        fs::remove_dir_all(path)?;
+    }
     Ok(())
 }
 
@@ -353,6 +463,8 @@ pub(crate) fn configure_wrapper(
         WrapperBuild::Standalone => ctx.standalone_dir(profile),
     };
     fs::create_dir_all(&stage_dir)?;
+    let resource_dir = prepare_plugin_resource_dir(ctx)?;
+    ensure_wrapper_resources_supported(ctx, build, resource_dir.as_deref())?;
 
     let mut args = Vec::<OsString>::new();
     push_cmake_arg(&mut args, "-S");
@@ -395,6 +507,15 @@ pub(crate) fn configure_wrapper(
             ctx.metadata.version
         ),
     );
+    if let Some(resource_dir) = &resource_dir {
+        push_cmake_arg(
+            &mut args,
+            format!(
+                "-DCLAP_WRAPPER_BUILDER_RESOURCE_DIRECTORY={}",
+                resource_dir.display()
+            ),
+        );
+    }
     push_cmake_arg(
         &mut args,
         format!("-DCMAKE_BUILD_TYPE={}", profile.cmake_config()),
@@ -625,6 +746,38 @@ pub(crate) fn standalone_products<'a>(
             .ok_or_else(|| format!("plugin ID not found in WRAC metadata: {plugin_id}").into());
     }
     Ok(ctx.metadata.plugins.iter().enumerate().collect())
+}
+
+fn ensure_wrapper_resources_supported(
+    ctx: &Context,
+    build: WrapperBuild,
+    resource_dir: Option<&Path>,
+) -> Result<()> {
+    if resource_dir.is_none() {
+        return Ok(());
+    }
+
+    match build {
+        WrapperBuild::Plugins { vst3: true, au: false } if ctx.platform == Platform::Macos => {
+            Ok(())
+        }
+        WrapperBuild::Plugins { au: true, .. } => Err(
+            "plugin resources are not supported for AUv2 wrapper builds yet; build CLAP or macOS VST3 only, or remove plugin resources".into(),
+        ),
+        WrapperBuild::Plugins { vst3: true, .. } => Err(
+            "plugin resources are only supported for macOS VST3 wrapper builds; build CLAP or remove plugin resources".into(),
+        ),
+        WrapperBuild::Plugins {
+            vst3: false,
+            au: false,
+        } => Ok(()),
+        WrapperBuild::Aax => Err(
+            "plugin resources are not supported for AAX wrapper builds yet; build CLAP or remove plugin resources".into(),
+        ),
+        WrapperBuild::Standalone => Err(
+            "plugin resources are not supported for standalone app builds yet; build CLAP or remove plugin resources".into(),
+        ),
+    }
 }
 
 fn push_cmake_arg(args: &mut Vec<OsString>, arg: impl Into<OsString>) {

--- a/crates/wrac_xtask/src/commands/build.rs
+++ b/crates/wrac_xtask/src/commands/build.rs
@@ -280,12 +280,17 @@ pub(crate) fn package_clap(ctx: &Context, profile: BuildProfile) -> Result<()> {
             codesign(&bundle, ctx.output_language)?;
         }
         Platform::Windows | Platform::Linux => {
+            if resource_dir.is_some() {
+                // Non-macOS CLAP artifacts are bare dynamic libraries. Until resources have a
+                // namespaced artifact layout and matching install/uninstall behavior there, fail
+                // instead of leaving required files beside an artifact that install will not move.
+                return Err(
+                    "plugin resources are only supported for macOS CLAP bundles; Windows/Linux CLAP resources need an explicit artifact and install layout before they can be enabled".into(),
+                );
+            }
             // On Windows/Linux the CLAP artifact is a dynamic library with the .clap extension.
             // Skipping the bundle structure keeps it compatible with each OS's existing host scan conventions.
             fs::copy(ctx.dynamic_library(profile), &bundle)?;
-            if let (Some(resource_dir), Some(parent)) = (&resource_dir, bundle.parent()) {
-                copy_resource_directory(resource_dir, parent)?;
-            }
         }
     }
 
@@ -364,7 +369,7 @@ pub(crate) fn configure_wrapper(
     };
     fs::create_dir_all(&stage_dir)?;
     let resource_dir = prepare_plugin_resource_dir(ctx)?;
-    ensure_wrapper_resources_supported(ctx, build, resource_dir.as_deref())?;
+    ensure_wrapper_resources_supported(build, resource_dir.as_deref())?;
 
     let mut args = Vec::<OsString>::new();
     push_cmake_arg(&mut args, "-S");
@@ -407,15 +412,6 @@ pub(crate) fn configure_wrapper(
             ctx.metadata.version
         ),
     );
-    if let Some(resource_dir) = &resource_dir {
-        push_cmake_arg(
-            &mut args,
-            format!(
-                "-DCLAP_WRAPPER_BUILDER_RESOURCE_DIRECTORY={}",
-                resource_dir.display()
-            ),
-        );
-    }
     push_cmake_arg(
         &mut args,
         format!("-DCMAKE_BUILD_TYPE={}", profile.cmake_config()),

--- a/crates/wrac_xtask/src/commands/build.rs
+++ b/crates/wrac_xtask/src/commands/build.rs
@@ -16,6 +16,9 @@ use crate::util::{
 };
 use crate::{Result, XtaskOutputLanguage};
 
+use super::plugin_resources::{
+    copy_resource_directory, ensure_wrapper_resources_supported, prepare_plugin_resource_dir,
+};
 use super::{
     aax_sdk_root, codesign, codesign_nested_macos_bundle, ensure_aax_sdk_input,
     ensure_au_sdk_input, ensure_common_wrapper_inputs, ensure_vst3_sdk_input,
@@ -287,109 +290,6 @@ pub(crate) fn package_clap(ctx: &Context, profile: BuildProfile) -> Result<()> {
     }
 
     ensure_exists(&bundle, "CLAP artifact")?;
-    Ok(())
-}
-
-fn prepare_plugin_resource_dir(ctx: &Context) -> Result<Option<PathBuf>> {
-    let source_dirs = plugin_resource_dirs(ctx);
-    let stage_dir = staged_plugin_resource_dir(ctx);
-    remove_if_exists(&stage_dir)?;
-    if source_dirs.is_empty() {
-        return Ok(None);
-    }
-
-    fs::create_dir_all(&stage_dir)?;
-    for source_dir in source_dirs {
-        copy_resource_directory(&source_dir, &stage_dir)?;
-    }
-    Ok(Some(stage_dir))
-}
-
-fn plugin_resource_dirs(ctx: &Context) -> Vec<PathBuf> {
-    [
-        // Source resources are hand-authored plugin assets. They are copied first so generated
-        // resources can intentionally replace them when both trees contain the same relative path.
-        ctx.plugin_root.join("resources"),
-        // Generated resources belong under the build output so large artifacts can be rebuilt and
-        // omitted from source control while still flowing through the same packaging contract.
-        ctx.wrac_dir().join("resources"),
-    ]
-    .into_iter()
-    .filter(|resource_dir| resource_dir.exists())
-    .collect()
-}
-
-fn staged_plugin_resource_dir(ctx: &Context) -> PathBuf {
-    ctx.wrac_dir().join("staged-resources")
-}
-
-fn copy_resource_directory(source: &Path, destination: &Path) -> Result<()> {
-    fs::create_dir_all(destination)?;
-    copy_resource_directory_inner(source, destination)
-}
-
-fn copy_resource_directory_inner(source: &Path, destination: &Path) -> Result<()> {
-    for entry in fs::read_dir(source)? {
-        let entry = entry?;
-        let source_path = entry.path();
-        let destination_path = destination.join(entry.file_name());
-        let file_type = entry.file_type()?;
-        if file_type.is_symlink() {
-            copy_symlink(&source_path, &destination_path)?;
-        } else if file_type.is_dir() {
-            if destination_path.is_symlink()
-                || (destination_path.exists() && !destination_path.is_dir())
-            {
-                remove_resource_destination(&destination_path)?;
-            }
-            fs::create_dir_all(&destination_path)?;
-            copy_resource_directory_inner(&source_path, &destination_path)?;
-        } else if file_type.is_file() {
-            if destination_path.exists() || destination_path.is_symlink() {
-                remove_resource_destination(&destination_path)?;
-            }
-            fs::copy(&source_path, &destination_path)?;
-        }
-    }
-    Ok(())
-}
-
-#[cfg(unix)]
-fn copy_symlink(source: &Path, destination: &Path) -> Result<()> {
-    let target = fs::read_link(source)?;
-    if destination.exists() || destination.is_symlink() {
-        remove_resource_destination(destination)?;
-    }
-    std::os::unix::fs::symlink(target, destination)?;
-    Ok(())
-}
-
-#[cfg(windows)]
-fn copy_symlink(source: &Path, destination: &Path) -> Result<()> {
-    let target = fs::read_link(source)?;
-    if destination.exists() || destination.is_symlink() {
-        remove_resource_destination(destination)?;
-    }
-    // Preserve symlinks produced by external packagers instead of flattening them, because their
-    // relative loader paths can be part of the runtime's file-system contract.
-    if source.is_dir() {
-        std::os::windows::fs::symlink_dir(target, destination)?;
-    } else {
-        std::os::windows::fs::symlink_file(target, destination)?;
-    }
-    Ok(())
-}
-
-fn remove_resource_destination(path: &Path) -> Result<()> {
-    // Resource staging intentionally allows generated resources to replace source resources with
-    // the same relative path. Use symlink_metadata so replacement never follows a symlink into the
-    // source tree or a tool-generated runtime directory.
-    let metadata = fs::symlink_metadata(path)?;
-    if metadata.file_type().is_symlink() || metadata.is_file() {
-        fs::remove_file(path)?;
-    } else if metadata.is_dir() {
-        fs::remove_dir_all(path)?;
-    }
     Ok(())
 }
 
@@ -746,38 +646,6 @@ pub(crate) fn standalone_products<'a>(
             .ok_or_else(|| format!("plugin ID not found in WRAC metadata: {plugin_id}").into());
     }
     Ok(ctx.metadata.plugins.iter().enumerate().collect())
-}
-
-fn ensure_wrapper_resources_supported(
-    ctx: &Context,
-    build: WrapperBuild,
-    resource_dir: Option<&Path>,
-) -> Result<()> {
-    if resource_dir.is_none() {
-        return Ok(());
-    }
-
-    match build {
-        WrapperBuild::Plugins { vst3: true, au: false } if ctx.platform == Platform::Macos => {
-            Ok(())
-        }
-        WrapperBuild::Plugins { au: true, .. } => Err(
-            "plugin resources are not supported for AUv2 wrapper builds yet; build CLAP or macOS VST3 only, or remove plugin resources".into(),
-        ),
-        WrapperBuild::Plugins { vst3: true, .. } => Err(
-            "plugin resources are only supported for macOS VST3 wrapper builds; build CLAP or remove plugin resources".into(),
-        ),
-        WrapperBuild::Plugins {
-            vst3: false,
-            au: false,
-        } => Ok(()),
-        WrapperBuild::Aax => Err(
-            "plugin resources are not supported for AAX wrapper builds yet; build CLAP or remove plugin resources".into(),
-        ),
-        WrapperBuild::Standalone => Err(
-            "plugin resources are not supported for standalone app builds yet; build CLAP or remove plugin resources".into(),
-        ),
-    }
 }
 
 fn push_cmake_arg(args: &mut Vec<OsString>, arg: impl Into<OsString>) {

--- a/crates/wrac_xtask/src/commands/plugin_resources.rs
+++ b/crates/wrac_xtask/src/commands/plugin_resources.rs
@@ -1,0 +1,145 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::Result;
+use crate::context::Context;
+use crate::targets::Platform;
+use crate::util::remove_if_exists;
+
+use super::build::WrapperBuild;
+
+pub(super) fn prepare_plugin_resource_dir(ctx: &Context) -> Result<Option<PathBuf>> {
+    let source_dirs = plugin_resource_dirs(ctx);
+    let stage_dir = staged_plugin_resource_dir(ctx);
+    remove_if_exists(&stage_dir)?;
+    if source_dirs.is_empty() {
+        return Ok(None);
+    }
+
+    fs::create_dir_all(&stage_dir)?;
+    for source_dir in source_dirs {
+        copy_resource_directory(&source_dir, &stage_dir)?;
+    }
+    Ok(Some(stage_dir))
+}
+
+fn plugin_resource_dirs(ctx: &Context) -> Vec<PathBuf> {
+    [
+        // Source resources are hand-authored plugin assets. They are copied first so generated
+        // resources can intentionally replace them when both trees contain the same relative path.
+        ctx.plugin_root.join("resources"),
+        // Generated resources belong under the build output so large artifacts can be rebuilt and
+        // omitted from source control while still flowing through the same packaging contract.
+        ctx.wrac_dir().join("resources"),
+    ]
+    .into_iter()
+    .filter(|resource_dir| resource_dir.exists())
+    .collect()
+}
+
+fn staged_plugin_resource_dir(ctx: &Context) -> PathBuf {
+    ctx.wrac_dir().join("staged-resources")
+}
+
+pub(super) fn copy_resource_directory(source: &Path, destination: &Path) -> Result<()> {
+    fs::create_dir_all(destination)?;
+    copy_resource_directory_inner(source, destination)
+}
+
+fn copy_resource_directory_inner(source: &Path, destination: &Path) -> Result<()> {
+    for entry in fs::read_dir(source)? {
+        let entry = entry?;
+        let source_path = entry.path();
+        let destination_path = destination.join(entry.file_name());
+        let file_type = entry.file_type()?;
+        if file_type.is_symlink() {
+            copy_symlink(&source_path, &destination_path)?;
+        } else if file_type.is_dir() {
+            if destination_path.is_symlink()
+                || (destination_path.exists() && !destination_path.is_dir())
+            {
+                remove_resource_destination(&destination_path)?;
+            }
+            fs::create_dir_all(&destination_path)?;
+            copy_resource_directory_inner(&source_path, &destination_path)?;
+        } else if file_type.is_file() {
+            if destination_path.exists() || destination_path.is_symlink() {
+                remove_resource_destination(&destination_path)?;
+            }
+            fs::copy(&source_path, &destination_path)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn copy_symlink(source: &Path, destination: &Path) -> Result<()> {
+    let target = fs::read_link(source)?;
+    if destination.exists() || destination.is_symlink() {
+        remove_resource_destination(destination)?;
+    }
+    std::os::unix::fs::symlink(target, destination)?;
+    Ok(())
+}
+
+#[cfg(windows)]
+fn copy_symlink(source: &Path, destination: &Path) -> Result<()> {
+    let target = fs::read_link(source)?;
+    if destination.exists() || destination.is_symlink() {
+        remove_resource_destination(destination)?;
+    }
+    // Preserve symlinks produced by external packagers instead of flattening them, because their
+    // relative loader paths can be part of the runtime's file-system contract.
+    if source.is_dir() {
+        std::os::windows::fs::symlink_dir(target, destination)?;
+    } else {
+        std::os::windows::fs::symlink_file(target, destination)?;
+    }
+    Ok(())
+}
+
+fn remove_resource_destination(path: &Path) -> Result<()> {
+    // Resource staging intentionally allows generated resources to replace source resources with
+    // the same relative path. Use symlink_metadata so replacement never follows a symlink into the
+    // source tree or a tool-generated runtime directory.
+    let metadata = fs::symlink_metadata(path)?;
+    if metadata.file_type().is_symlink() || metadata.is_file() {
+        fs::remove_file(path)?;
+    } else if metadata.is_dir() {
+        fs::remove_dir_all(path)?;
+    }
+    Ok(())
+}
+
+pub(super) fn ensure_wrapper_resources_supported(
+    ctx: &Context,
+    build: WrapperBuild,
+    resource_dir: Option<&Path>,
+) -> Result<()> {
+    if resource_dir.is_none() {
+        return Ok(());
+    }
+
+    match build {
+        WrapperBuild::Plugins {
+            vst3: true,
+            au: false,
+        } if ctx.platform == Platform::Macos => Ok(()),
+        WrapperBuild::Plugins { au: true, .. } => Err(
+            "plugin resources are not supported for AUv2 wrapper builds yet; build CLAP or macOS VST3 only, or remove plugin resources".into(),
+        ),
+        WrapperBuild::Plugins { vst3: true, .. } => Err(
+            "plugin resources are only supported for macOS VST3 wrapper builds; build CLAP or remove plugin resources".into(),
+        ),
+        WrapperBuild::Plugins {
+            vst3: false,
+            au: false,
+        } => Ok(()),
+        WrapperBuild::Aax => Err(
+            "plugin resources are not supported for AAX wrapper builds yet; build CLAP or remove plugin resources".into(),
+        ),
+        WrapperBuild::Standalone => Err(
+            "plugin resources are not supported for standalone app builds yet; build CLAP or remove plugin resources".into(),
+        ),
+    }
+}

--- a/crates/wrac_xtask/src/commands/plugin_resources.rs
+++ b/crates/wrac_xtask/src/commands/plugin_resources.rs
@@ -3,7 +3,6 @@ use std::path::{Path, PathBuf};
 
 use crate::Result;
 use crate::context::Context;
-use crate::targets::Platform;
 use crate::util::remove_if_exists;
 
 use super::build::WrapperBuild;
@@ -112,7 +111,6 @@ fn remove_resource_destination(path: &Path) -> Result<()> {
 }
 
 pub(super) fn ensure_wrapper_resources_supported(
-    ctx: &Context,
     build: WrapperBuild,
     resource_dir: Option<&Path>,
 ) -> Result<()> {
@@ -120,26 +118,18 @@ pub(super) fn ensure_wrapper_resources_supported(
         return Ok(());
     }
 
+    // Wrapper resource packaging needs format-specific artifact/install semantics and rebuild
+    // dependencies. Failing here avoids producing bundles that pass build steps while silently
+    // omitting or staling required runtime files.
     match build {
-        WrapperBuild::Plugins {
-            vst3: true,
-            au: false,
-        } if ctx.platform == Platform::Macos => Ok(()),
-        WrapperBuild::Plugins { au: true, .. } => Err(
-            "plugin resources are not supported for AUv2 wrapper builds yet; build CLAP or macOS VST3 only, or remove plugin resources".into(),
+        WrapperBuild::Plugins { .. } => Err(
+            "plugin resources are not supported for wrapper plugin builds yet; build macOS CLAP or remove plugin resources".into(),
         ),
-        WrapperBuild::Plugins { vst3: true, .. } => Err(
-            "plugin resources are only supported for macOS VST3 wrapper builds; build CLAP or remove plugin resources".into(),
-        ),
-        WrapperBuild::Plugins {
-            vst3: false,
-            au: false,
-        } => Ok(()),
         WrapperBuild::Aax => Err(
-            "plugin resources are not supported for AAX wrapper builds yet; build CLAP or remove plugin resources".into(),
+            "plugin resources are not supported for AAX wrapper builds yet; build macOS CLAP or remove plugin resources".into(),
         ),
         WrapperBuild::Standalone => Err(
-            "plugin resources are not supported for standalone app builds yet; build CLAP or remove plugin resources".into(),
+            "plugin resources are not supported for standalone app builds yet; build macOS CLAP or remove plugin resources".into(),
         ),
     }
 }

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -102,19 +102,22 @@ target/wrac-plugins/<plugin>/wrac/resources/ # generated resources
 `xtask` merges these directories into a clean staging directory before packaging.
 Source-managed resources are copied first, then generated resources are copied on
 top of them. This lets generated files intentionally replace source-managed files
-with the same relative path while keeping the final packaged resources identical
-across the supported formats.
+with the same relative path.
 
 Resource packaging is currently supported for:
 
-- CLAP on macOS, Windows, and Linux
-- VST3 on macOS
+- CLAP on macOS
 
-If plugin resources are present and an unsupported wrapper format is requested,
-`xtask` fails during wrapper configure instead of producing an artifact that is
-missing required files. AUv2, AAX, standalone, Windows VST3, and Linux VST3
-resource packaging should be implemented in the wrapper layer before enabling
-those combinations.
+macOS CLAP is enabled first because its `.clap` bundle has a dedicated
+`Contents/Resources` namespace and the bundle is the same unit that build,
+install, and uninstall commands move around. Windows/Linux CLAP artifacts are
+single `.clap` dynamic libraries, so resource packaging needs an explicit
+artifact layout and install/uninstall contract before it can be enabled there.
+
+If plugin resources are present and an unsupported target is requested, `xtask`
+fails instead of producing an artifact that is missing required files. Wrapper
+formats such as VST3, AUv2, AAX, and standalone also need format-specific
+resource copy and rebuild semantics before resource packaging can be enabled.
 
 ### 5. Verify
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -89,6 +89,33 @@ cargo xtask install
 `cargo xtask install` builds and installs the selected plugin formats.
 For detailed usage of each xtask command, see `cargo xtask --help`.
 
+### Plugin Resources
+
+Plugins can package additional runtime resources by placing files in one of the
+resource directories below.
+
+```text
+plugins/<plugin>/resources/                 # source-managed resources
+target/wrac-plugins/<plugin>/wrac/resources/ # generated resources
+```
+
+`xtask` merges these directories into a clean staging directory before packaging.
+Source-managed resources are copied first, then generated resources are copied on
+top of them. This lets generated files intentionally replace source-managed files
+with the same relative path while keeping the final packaged resources identical
+across the supported formats.
+
+Resource packaging is currently supported for:
+
+- CLAP on macOS, Windows, and Linux
+- VST3 on macOS
+
+If plugin resources are present and an unsupported wrapper format is requested,
+`xtask` fails during wrapper configure instead of producing an artifact that is
+missing required files. AUv2, AAX, standalone, Windows VST3, and Linux VST3
+resource packaging should be implemented in the wrapper layer before enabling
+those combinations.
+
 ### 5. Verify
 
 Debug builds fetch GUI resources from the Vite dev server (`localhost:5173`).


### PR DESCRIPTION
## Summary

- Merge plugin resource directories into a clean staging directory before macOS CLAP packaging.
- Copy staged resources into the macOS `.clap` bundle `Contents/Resources` directory.
- Fail fast when plugin resources are present for targets whose resource artifact/install semantics are not defined yet.
- Document the resource directory convention, merge order, supported format, and why other targets are intentionally disabled.

## Notes

- Source-managed resources are copied before generated resources, so generated files can intentionally replace files with the same relative path.
- Resource packaging is currently enabled only for macOS CLAP because the bundle provides a dedicated resource namespace and is the install/uninstall unit.
- Windows/Linux CLAP and wrapper formats now fail before producing artifacts when plugin resources are present.

## Validation

- `cargo fmt --all -- --check`
- `cargo xtask quality`
- `git diff --check`
- `cargo check -p wrac_xtask`
- `cargo test -p wrac_xtask`
- `cargo clippy -p wrac_xtask --all-targets -- -D warnings`
- `cargo xtask build --target=clap`
- Temporary generated-resource smoke check confirmed the macOS CLAP bundle receives the staged resource file.
- Temporary VST3 resource smoke check confirmed wrapper builds fail during configure.

## Known existing issue

- `cargo xtask validate --target=clap` currently fails in the template example plugin because plugin initialization panics when the latency extension is missing. This appears unrelated to resource packaging.
