### PR TITLE
Improve xtask task result output

### DIFF
--- a/crates/wrac_build_ops/README.md
+++ b/crates/wrac_build_ops/README.md
@@ -12,6 +12,10 @@ artifact node selection, and task execution dispatch. That boundary keeps
 product-specific tasks, such as attaching generated assets after a standard
 package step, outside the WRAC operation layer.
 
+Operations that can intentionally avoid work, such as a GUI build without a
+frontend package or an up-to-date CMake configure, return `TaskOutcome` so the
+repository workflow can print one task result with the concrete skip reason.
+
 The standard `wrac-plugin.toml` schema is documented in
 [`wrac_manifest`](../wrac_manifest/README.md).
 

--- a/crates/wrac_build_ops/src/commands.rs
+++ b/crates/wrac_build_ops/src/commands.rs
@@ -9,8 +9,8 @@ use crate::context::Context;
 use crate::metadata::PluginMetadata;
 use crate::targets::{Platform, PluginFormat, PluginTarget, Target};
 use crate::util::{
-    common_program_files, copy_path, ensure_exists, home_dir, local_app_data, print_section,
-    print_success, remove_if_exists, run_with_language,
+    common_program_files, copy_path, ensure_exists, home_dir, local_app_data, print_detail,
+    print_section, remove_if_exists, run_with_language,
 };
 use crate::{BuildProfile, InstallScope, UninstallScope};
 
@@ -40,8 +40,7 @@ pub fn launch(ctx: &Context, profile: BuildProfile, plugin_id: Option<&str>) -> 
         .into());
     }
 
-    print_section(ctx.output_language, "Launch standalone", "standalone 起動");
-    print_success(
+    print_detail(
         ctx.output_language,
         &format!("Launching standalone artifact: {}", artifact.display()),
         &format!("standalone artifact: {}", artifact.display()),
@@ -275,7 +274,7 @@ fn install_artifact(
     // Remove the destination first, then copy the whole artifact so the installed result matches the build output exactly.
     remove_if_exists(&destination)?;
     copy_path(artifact, &destination)?;
-    print_success(
+    print_detail(
         language,
         &format!("Installed: {}", destination.display()),
         &format!("インストール: {}", destination.display()),

--- a/crates/wrac_build_ops/src/commands/build.rs
+++ b/crates/wrac_build_ops/src/commands/build.rs
@@ -5,14 +5,15 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use serde_json::Value;
+use xtask_workflow::TaskOutcome;
 
 use crate::context::Context;
 use crate::metadata::PluginProductMetadata;
 use crate::profile::BuildProfile;
 use crate::targets::Platform;
 use crate::util::{
-    ensure_exists, env_value_or, on_off, print_section, print_skip, remove_if_exists,
-    run_output_with_language, run_with_language, run_with_optional_xcbeautify_language,
+    ensure_exists, env_value_or, on_off, remove_if_exists, run_output_with_language,
+    run_with_language, run_with_optional_xcbeautify_language,
 };
 use crate::{Result, XtaskOutputLanguage};
 
@@ -22,30 +23,26 @@ use super::{
     macos_clap_info_plist,
 };
 
-pub fn build_gui(ctx: &Context) -> Result<()> {
-    print_section(ctx.output_language, "Build GUI", "GUI ビルド");
+pub fn build_gui(ctx: &Context) -> Result<TaskOutcome> {
     let package_json = ctx.gui_dir().join("package.json");
     if !package_json.exists() {
-        print_skip(
-            ctx.output_language,
-            "No src-gui/package.json found; skipping GUI build.",
-            "src-gui/package.json がないため GUI ビルドをスキップ",
-        );
-        return Ok(());
+        return Ok(TaskOutcome::skipped(match ctx.output_language {
+            XtaskOutputLanguage::English => "src-gui/package.json was not found",
+            XtaskOutputLanguage::Japanese => "src-gui/package.json が存在しないため",
+        }));
     }
     if !has_package_script(&package_json, "build")? {
-        print_skip(
-            ctx.output_language,
-            &format!(
-                "No build script found in {}; skipping GUI build.",
-                package_json.display()
-            ),
-            &format!(
-                "{} に build script がないため GUI ビルドをスキップ",
-                package_json.display()
-            ),
-        );
-        return Ok(());
+        return Ok(TaskOutcome::skipped(match ctx.output_language {
+            XtaskOutputLanguage::English => {
+                format!("no build script was found in {}", package_json.display())
+            }
+            XtaskOutputLanguage::Japanese => {
+                format!(
+                    "{} に build script が存在しないため",
+                    package_json.display()
+                )
+            }
+        }));
     }
     let package = read_package_json(&package_json)?;
     if !is_pnpm_workspace(ctx) {
@@ -63,7 +60,7 @@ pub fn build_gui(ctx: &Context) -> Result<()> {
                 .current_dir(ctx.gui_dir()),
             ctx.output_language,
         )?;
-        return Ok(());
+        return Ok(TaskOutcome::Completed);
     }
 
     let package_name = package_name(&package, &package_json)?;
@@ -90,7 +87,7 @@ pub fn build_gui(ctx: &Context) -> Result<()> {
             .current_dir(&ctx.root),
         ctx.output_language,
     )?;
-    Ok(())
+    Ok(TaskOutcome::Completed)
 }
 
 fn is_pnpm_workspace(ctx: &Context) -> bool {
@@ -203,11 +200,6 @@ pub fn build_rust_plugin(
     profile: BuildProfile,
     build: RustPluginBuild,
 ) -> Result<()> {
-    print_section(
-        ctx.output_language,
-        &format!("Build Rust plugin ({})", build.label()),
-        &format!("Rust plugin ビルド ({})", build.label()),
-    );
     let mut command = Command::new("cargo");
     command
         .arg("build")
@@ -240,7 +232,6 @@ pub fn build_rust_plugin(
 }
 
 pub fn package_clap(ctx: &Context, profile: BuildProfile) -> Result<()> {
-    print_section(ctx.output_language, "Package CLAP", "CLAP packaging");
     let bundle = ctx.clap_bundle(profile);
     remove_if_exists(&bundle)?;
     fs::create_dir_all(ctx.plugins_dir(profile))?;
@@ -320,7 +311,11 @@ impl WrapperBuild {
     }
 }
 
-pub fn configure_wrapper(ctx: &Context, profile: BuildProfile, build: WrapperBuild) -> Result<()> {
+pub fn configure_wrapper(
+    ctx: &Context,
+    profile: BuildProfile,
+    build: WrapperBuild,
+) -> Result<TaskOutcome> {
     // Keep SDK/submodule diagnostics close to the configure task even when the
     // DAG was created by install, validate, or launch. Checking before the CMake
     // stamp shortcut avoids silently relying on a stale cache after an SDK
@@ -474,20 +469,18 @@ pub fn configure_wrapper(ctx: &Context, profile: BuildProfile, build: WrapperBui
     }
 
     if cmake_configure_is_current(&build_dir, &args, &ctx.wrapper_dir)? {
-        print_skip(
-            ctx.output_language,
-            &format!(
+        return Ok(TaskOutcome::skipped(match ctx.output_language {
+            XtaskOutputLanguage::English => format!(
                 "CMake configure is up to date for {} ({})",
                 build.purpose(),
                 profile.cmake_config()
             ),
-            &format!(
+            XtaskOutputLanguage::Japanese => format!(
                 "CMake configure は最新です: {} ({})",
                 build.purpose(),
                 profile.cmake_config()
             ),
-        );
-        return Ok(());
+        }));
     }
 
     let mut configure = Command::new("cmake");
@@ -500,7 +493,7 @@ pub fn configure_wrapper(ctx: &Context, profile: BuildProfile, build: WrapperBui
     }
     run_with_language(configure.current_dir(&ctx.root), ctx.output_language)?;
     write_cmake_configure_stamp(&build_dir, &args, &ctx.wrapper_dir)?;
-    Ok(())
+    Ok(TaskOutcome::Completed)
 }
 
 pub fn build_wrapper_target(

--- a/crates/wrac_build_ops/src/commands/validation.rs
+++ b/crates/wrac_build_ops/src/commands/validation.rs
@@ -12,7 +12,7 @@ use crate::context::Context;
 use crate::profile::BuildProfile;
 use crate::targets::{Platform, ValidateTarget};
 use crate::util::{
-    copy_path, ensure_exists, print_section, print_skip, print_success, remove_if_exists,
+    copy_path, ensure_exists, print_detail, print_section, remove_if_exists,
     run_output_with_language, run_with_language, run_with_optional_xcbeautify_language,
 };
 use crate::validation::validate_wrac_rules;
@@ -90,7 +90,7 @@ pub fn validate_plugin_target(
                     .skip_reason
                     .as_deref()
                     .unwrap_or("no reason provided");
-                print_skip(
+                print_detail(
                     ctx.output_language,
                     &format!("CLAP validator skip filter: {filter} ({reason})"),
                     &format!("CLAP validator skip filter: {filter} ({reason})"),
@@ -183,7 +183,7 @@ fn validate_vst3_component_ids(
         .into());
     }
 
-    print_success(
+    print_detail(
         ctx.output_language,
         "VST3 component IDs match plugins.vst3_component_id",
         "VST3 component ID は plugins.vst3_component_id と一致",
@@ -233,7 +233,7 @@ fn run_aax_validator(ctx: &Context, aax: &Path) -> Result<()> {
         AAX_VALIDATOR_REQUIRED_TESTS.len()
     );
     for (test_id, reason) in AAX_VALIDATOR_SKIPPED_TESTS {
-        print_skip(
+        print_detail(
             ctx.output_language,
             &format!("Skipping {test_id}: {reason}."),
             &format!("{test_id}: {reason}"),
@@ -250,8 +250,7 @@ fn run_aax_validator_dtt(ctx: &Context, aax: &Path, results_dir: &Path) -> Resul
     let aax_search_dir = aax
         .parent()
         .ok_or_else(|| format!("AAX bundle path has no parent directory: {}", aax.display()))?;
-    print_section(ctx.output_language, "Running command", "コマンド実行");
-    println!("$ {}", dtt.display());
+    println!("  $ {}", dtt.display());
 
     for (index, test_id) in AAX_VALIDATOR_REQUIRED_TESTS.iter().enumerate() {
         let test_dir =
@@ -367,7 +366,7 @@ fn assert_aax_validator_results(ctx: &Context, results_dir: &Path) -> Result<()>
         // and artifacts can be audited against.
         let status = aax_validator_result_status(&result_path)?;
         if status == "E_COMPLETED_PASS" {
-            print_success(
+            print_detail(
                 ctx.output_language,
                 &format!("AAX validator PASS: {test_id}"),
                 &format!("AAX validator 成功: {test_id}"),

--- a/crates/wrac_build_ops/src/util.rs
+++ b/crates/wrac_build_ops/src/util.rs
@@ -47,8 +47,7 @@ pub(crate) fn run_with_language(
 ) -> Result<()> {
     // xtask is a build orchestrator, so seeing the exact external command on failure is important.
     // Run directly via Command without a shell, but print in a form that humans can re-run easily.
-    print_section(language, "Running command", "コマンド実行");
-    println!("$ {}", format_command(command));
+    println!("  $ {}", format_command(command));
     let status = command.status()?;
     if !status.success() {
         return Err(command_failed_message(language, status, &format_command(command)).into());
@@ -64,8 +63,7 @@ pub(crate) fn run_with_optional_xcbeautify_language(
         return run_with_language(command, language);
     }
 
-    print_section(language, "Running command", "コマンド実行");
-    println!("$ {} 2>&1 | xcbeautify", format_command(command));
+    println!("  $ {} 2>&1 | xcbeautify", format_command(command));
 
     let mut child = command
         .stdout(Stdio::piped())
@@ -152,8 +150,7 @@ pub(crate) fn run_output_with_language(
     command: &mut Command,
     language: XtaskOutputLanguage,
 ) -> Result<Output> {
-    print_section(language, "Running command", "コマンド実行");
-    println!("$ {}", format_command(command));
+    println!("  $ {}", format_command(command));
     let output = command.output()?;
     if !output.status.success() {
         return Err(
@@ -175,19 +172,11 @@ pub(crate) fn print_section(language: XtaskOutputLanguage, english: &str, japane
     println!();
 }
 
-pub(crate) fn print_success(language: XtaskOutputLanguage, english: &str, japanese: &str) {
+// The workflow owns task outcome icons; operation-level messages stay as
+// details so one task cannot appear to have multiple final results.
+pub(crate) fn print_detail(language: XtaskOutputLanguage, english: &str, japanese: &str) {
     println!(
-        "  ✅ {}",
-        match language {
-            XtaskOutputLanguage::English => english,
-            XtaskOutputLanguage::Japanese => japanese,
-        }
-    );
-}
-
-pub(crate) fn print_skip(language: XtaskOutputLanguage, english: &str, japanese: &str) {
-    println!(
-        "  ⏭️ {}",
+        "  {}",
         match language {
             XtaskOutputLanguage::English => english,
             XtaskOutputLanguage::Japanese => japanese,

--- a/crates/xtask_workflow/README.md
+++ b/crates/xtask_workflow/README.md
@@ -7,8 +7,13 @@ It intentionally does not know about WRAC, audio plugins, plugin formats, or
 build commands. Product repositories define their own task enum, task labels,
 task executor, and dependency graph while reusing this crate for stable
 topological ordering, cycle detection, task IDs, task status, failure policy,
-dry-run output, dependency-skip behavior, and result summaries.
+dry-run output, dependency-blocking behavior, and result summaries.
 
 The executor accepts caller-provided label and run closures. Those closures are
 not stored in graph nodes, so task semantics remain visible in each repository's
 local task enum.
+
+Run closures return `TaskOutcome`. `Completed` records executed work, while
+`Skipped { reason }` records a successful decision that no work was necessary.
+Skipped tasks remain valid dependencies. Tasks that cannot run because a
+dependency failed are reported separately as `Blocked`.

--- a/crates/xtask_workflow/src/lib.rs
+++ b/crates/xtask_workflow/src/lib.rs
@@ -51,8 +51,10 @@ pub struct WorkflowMessages {
     pub ok: &'static str,
     pub failed: &'static str,
     pub skipped: &'static str,
+    pub blocked: &'static str,
     pub planned: &'static str,
-    pub dependency_skip_reason: &'static str,
+    pub reason: &'static str,
+    pub dependency_block_reason: &'static str,
 }
 
 impl WorkflowMessages {
@@ -66,8 +68,10 @@ impl WorkflowMessages {
         ok: "ok",
         failed: "failed",
         skipped: "skipped",
+        blocked: "blocked",
         planned: "planned",
-        dependency_skip_reason: "Reason: dependency failed or was skipped",
+        reason: "Reason",
+        dependency_block_reason: "dependency failed or was blocked",
     };
 
     pub const JAPANESE: Self = Self {
@@ -80,16 +84,38 @@ impl WorkflowMessages {
         ok: "成功",
         failed: "失敗",
         skipped: "スキップ",
+        blocked: "依存失敗",
         planned: "未実行",
-        dependency_skip_reason: "理由: 依存タスクが失敗またはスキップされました",
+        reason: "理由",
+        dependency_block_reason: "依存タスクが失敗または依存失敗になったため",
     };
 
     fn status_label(&self, status: TaskStatus) -> &'static str {
         match status {
             TaskStatus::Planned => self.planned,
-            TaskStatus::Ok => self.ok,
+            TaskStatus::Succeeded => self.ok,
             TaskStatus::Failed => self.failed,
             TaskStatus::Skipped => self.skipped,
+            TaskStatus::Blocked => self.blocked,
+        }
+    }
+}
+
+/// The outcome of a task that ran without an execution error.
+///
+/// A skipped task remains a valid dependency because it deliberately decided
+/// that no work was necessary. Dependency failures are tracked separately as
+/// [`TaskStatus::Blocked`] by the workflow executor.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TaskOutcome {
+    Completed,
+    Skipped { reason: String },
+}
+
+impl TaskOutcome {
+    pub fn skipped(reason: impl Into<String>) -> Self {
+        Self::Skipped {
+            reason: reason.into(),
         }
     }
 }
@@ -124,9 +150,10 @@ struct Task<K> {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum TaskStatus {
     Planned,
-    Ok,
+    Succeeded,
     Failed,
     Skipped,
+    Blocked,
 }
 
 /// A dependency graph whose task semantics are owned by the caller.
@@ -181,7 +208,7 @@ impl<K> TaskGraph<K> {
         ids
     }
 
-    pub fn failed_dependency_ids(
+    pub fn blocking_dependency_ids(
         &self,
         task: TaskNode,
         statuses: &HashMap<TaskNode, TaskStatus>,
@@ -192,7 +219,7 @@ impl<K> TaskGraph<K> {
             .filter(|dep| {
                 matches!(
                     statuses.get(dep),
-                    Some(TaskStatus::Failed | TaskStatus::Skipped)
+                    Some(TaskStatus::Failed | TaskStatus::Blocked)
                 )
             })
             .map(|dep| &self.graph[dep].id)
@@ -256,7 +283,7 @@ impl<K> Default for TaskGraph<K> {
 /// Executes a workflow graph while keeping task semantics in the caller.
 ///
 /// The graph executor handles stable ordering, dry-run output, failure policy,
-/// downstream skipping, and summary reporting. The caller still owns the task
+/// downstream blocking, and summary reporting. The caller still owns the task
 /// enum, labels, and dispatch to WRAC operations or product-specific work.
 pub fn execute_plan<K, Label, Run>(
     graph: TaskGraph<K>,
@@ -268,7 +295,7 @@ pub fn execute_plan<K, Label, Run>(
 ) -> Result<()>
 where
     Label: FnMut(&K) -> String,
-    Run: FnMut(&K) -> Result<()>,
+    Run: FnMut(&K) -> Result<TaskOutcome>,
 {
     let ordered = graph.ordered()?;
     print_plan(&graph, &ordered, dry_run, messages, &mut label_task);
@@ -284,35 +311,44 @@ where
 
     for index in &ordered {
         let index = *index;
-        // A failed dependency makes the dependent task meaningless, so continuing
-        // never tries to run downstream work with missing artifacts. Independent
-        // branches still run under FailurePolicy::Continue.
-        let failed_deps = graph
-            .failed_dependency_ids(index, &statuses)
+        // A failed or blocked dependency makes the dependent task meaningless,
+        // so continuing never runs downstream work with missing artifacts.
+        // Deliberately skipped dependencies remain valid because they completed
+        // their decision successfully and require no generated work.
+        let blocking_deps = graph
+            .blocking_dependency_ids(index, &statuses)
             .into_iter()
             .map(ToString::to_string)
             .collect::<Vec<_>>();
-        if !failed_deps.is_empty() {
-            println!("{}\n  ⏭️ {}", graph.id(index), messages.skipped);
+        let label = label_task(graph.kind(index));
+        println!("== {label} ==\n\n  {}", graph.id(index));
+        if !blocking_deps.is_empty() {
+            println!("  🚫 {}: {label}", messages.blocked);
             println!(
-                "  {} ({})",
-                messages.dependency_skip_reason,
-                failed_deps.join(", ")
+                "  {}: {} ({})",
+                messages.reason,
+                messages.dependency_block_reason,
+                blocking_deps.join(", ")
             );
             println!();
-            statuses.insert(index, TaskStatus::Skipped);
+            statuses.insert(index, TaskStatus::Blocked);
             continue;
         }
 
-        println!("{}\n  {}", graph.id(index), label_task(graph.kind(index)));
         match run_task(graph.kind(index)) {
-            Ok(()) => {
-                println!("  ✅ {}", messages.completed);
+            Ok(TaskOutcome::Completed) => {
+                println!("  ✅ {}: {label}", messages.completed);
                 println!();
-                statuses.insert(index, TaskStatus::Ok);
+                statuses.insert(index, TaskStatus::Succeeded);
+            }
+            Ok(TaskOutcome::Skipped { reason }) => {
+                println!("  ⏭️ {}: {label}", messages.skipped);
+                println!("  {}: {reason}", messages.reason);
+                println!();
+                statuses.insert(index, TaskStatus::Skipped);
             }
             Err(err) => {
-                println!("  ❌ {}", messages.failed);
+                println!("  ❌ {}: {label}", messages.failed);
                 println!("  Error: {err}");
                 statuses.insert(index, TaskStatus::Failed);
                 failures.push(format!("{}: {err}", graph.id(index)));
@@ -386,20 +422,25 @@ fn print_summary<K>(
         *counts.entry(*status).or_default() += 1;
     }
     println!(
-        "== {} ==\n\n✅ {} {} / ❌ {} {} / ⏭️ {} {}",
+        "== {} ==\n\n✅ {} {} / ❌ {} {} / ⏭️ {} {} / 🚫 {} {}",
         messages.result_heading,
         messages.ok,
-        counts.get(&TaskStatus::Ok).copied().unwrap_or(0),
+        counts.get(&TaskStatus::Succeeded).copied().unwrap_or(0),
         messages.failed,
         counts.get(&TaskStatus::Failed).copied().unwrap_or(0),
         messages.skipped,
-        counts.get(&TaskStatus::Skipped).copied().unwrap_or(0)
+        counts.get(&TaskStatus::Skipped).copied().unwrap_or(0),
+        messages.blocked,
+        counts.get(&TaskStatus::Blocked).copied().unwrap_or(0)
     );
     for index in ordered {
         let Some(status) = statuses.get(index) else {
             continue;
         };
-        if matches!(status, TaskStatus::Failed | TaskStatus::Skipped) {
+        if matches!(
+            status,
+            TaskStatus::Failed | TaskStatus::Skipped | TaskStatus::Blocked
+        ) {
             println!("{}: {}", messages.status_label(*status), graph.id(*index));
         }
     }
@@ -446,7 +487,7 @@ mod tests {
     }
 
     #[test]
-    fn execute_plan_skips_dependents_after_failed_dependencies() {
+    fn execute_plan_blocks_dependents_after_failed_dependencies() {
         let mut graph = TaskGraph::new();
         let root = graph.task(TaskId::new("root"), TestTask::Root);
         let dependent = graph.task(TaskId::new("dependent"), TestTask::Dependent);
@@ -464,7 +505,7 @@ mod tests {
                 executed.push(*task);
                 match task {
                     TestTask::Root => Err("root failed".into()),
-                    TestTask::Dependent | TestTask::Independent => Ok(()),
+                    TestTask::Dependent | TestTask::Independent => Ok(TaskOutcome::Completed),
                 }
             },
         );
@@ -473,5 +514,32 @@ mod tests {
 
         assert!(error.contains("root failed"));
         assert_eq!(executed, [TestTask::Root, TestTask::Independent]);
+    }
+
+    #[test]
+    fn execute_plan_runs_dependents_after_deliberately_skipped_dependencies() {
+        let mut graph = TaskGraph::new();
+        let root = graph.task(TaskId::new("root"), TestTask::Root);
+        let dependent = graph.task(TaskId::new("dependent"), TestTask::Dependent);
+        graph.depends_on(dependent, root);
+
+        let mut executed = Vec::new();
+        let result = execute_plan(
+            graph,
+            false,
+            FailurePolicy::Continue,
+            &WorkflowMessages::ENGLISH,
+            |task| format!("{task:?}"),
+            |task| {
+                executed.push(*task);
+                match task {
+                    TestTask::Root => Ok(TaskOutcome::skipped("nothing to build")),
+                    TestTask::Dependent | TestTask::Independent => Ok(TaskOutcome::Completed),
+                }
+            },
+        );
+
+        assert!(result.is_ok());
+        assert_eq!(executed, [TestTask::Root, TestTask::Dependent]);
     }
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -19,7 +19,7 @@ use wrac_build_ops::{
     uninstall_plugin_target, validate_plugin_target, validate_wrac_rules_for_targets,
 };
 use xtask_workflow::{
-    FailurePolicy, TaskGraph, TaskNode, WorkflowMessages, execute_plan, failure_policy,
+    FailurePolicy, TaskGraph, TaskNode, TaskOutcome, WorkflowMessages, execute_plan, failure_policy,
 };
 
 type Result<T> = wrac_build_ops::Result<T>;
@@ -333,15 +333,17 @@ fn execute_package_plan(
     )
 }
 
-fn run_task(ctx: &WracContext, profile: BuildProfile, kind: &TaskKind) -> Result<()> {
+fn run_task(ctx: &WracContext, profile: BuildProfile, kind: &TaskKind) -> Result<TaskOutcome> {
     match kind {
-        TaskKind::Clean => clean(ctx),
+        TaskKind::Clean => completed(clean(ctx)),
         TaskKind::BuildGui => build_gui(ctx),
-        TaskKind::BuildRustDefault => build_rust_plugin(ctx, profile, RustPluginBuild::Default),
-        TaskKind::BuildRustStandalone => {
-            build_rust_plugin(ctx, profile, RustPluginBuild::Standalone)
+        TaskKind::BuildRustDefault => {
+            completed(build_rust_plugin(ctx, profile, RustPluginBuild::Default))
         }
-        TaskKind::PackageClap => package_clap(ctx, profile),
+        TaskKind::BuildRustStandalone => {
+            completed(build_rust_plugin(ctx, profile, RustPluginBuild::Standalone))
+        }
+        TaskKind::PackageClap => completed(package_clap(ctx, profile)),
         TaskKind::ConfigureWrapperPlugins { vst3, au } => configure_wrapper(
             ctx,
             profile,
@@ -354,7 +356,7 @@ fn run_task(ctx: &WracContext, profile: BuildProfile, kind: &TaskKind) -> Result
         TaskKind::ConfigureWrapperStandalone => {
             configure_wrapper(ctx, profile, WrapperBuild::Standalone)
         }
-        TaskKind::BuildVst3Bundle => build_wrapper_target(
+        TaskKind::BuildVst3Bundle => completed(build_wrapper_target(
             ctx,
             profile,
             WrapperBuild::Plugins {
@@ -363,8 +365,8 @@ fn run_task(ctx: &WracContext, profile: BuildProfile, kind: &TaskKind) -> Result
             },
             WrapperTarget::Vst3,
             None,
-        ),
-        TaskKind::BuildAuBundle => build_wrapper_target(
+        )),
+        TaskKind::BuildAuBundle => completed(build_wrapper_target(
             ctx,
             profile,
             WrapperBuild::Plugins {
@@ -373,23 +375,29 @@ fn run_task(ctx: &WracContext, profile: BuildProfile, kind: &TaskKind) -> Result
             },
             WrapperTarget::Au,
             None,
-        ),
-        TaskKind::BuildAaxBundle => {
-            build_wrapper_target(ctx, profile, WrapperBuild::Aax, WrapperTarget::Aax, None)
-        }
-        TaskKind::BuildStandaloneBundle { plugin_id } => build_wrapper_target(
+        )),
+        TaskKind::BuildAaxBundle => completed(build_wrapper_target(
+            ctx,
+            profile,
+            WrapperBuild::Aax,
+            WrapperTarget::Aax,
+            None,
+        )),
+        TaskKind::BuildStandaloneBundle { plugin_id } => completed(build_wrapper_target(
             ctx,
             profile,
             WrapperBuild::Standalone,
             WrapperTarget::Standalone,
             plugin_id.as_deref(),
-        ),
-        TaskKind::LaunchStandalone { plugin_id } => launch(ctx, profile, plugin_id.as_deref()),
+        )),
+        TaskKind::LaunchStandalone { plugin_id } => {
+            completed(launch(ctx, profile, plugin_id.as_deref()))
+        }
         TaskKind::CheckInstallScope { target, scope } => {
-            check_install_dir(ctx, *scope, target.format())
+            completed(check_install_dir(ctx, *scope, target.format()))
         }
         TaskKind::InstallBundle { target, scope } => {
-            install_plugin_target(ctx, profile, *scope, *target)
+            completed(install_plugin_target(ctx, profile, *scope, *target))
         }
         TaskKind::UninstallBundle {
             target,
@@ -402,13 +410,21 @@ fn run_task(ctx: &WracContext, profile: BuildProfile, kind: &TaskKind) -> Result
             } else {
                 println!("  {}", uninstall_summary(*target, removed, missing, false));
             }
-            Ok(())
+            Ok(TaskOutcome::Completed)
         }
         TaskKind::ValidateWracRules { targets } => {
-            validate_wrac_rules_for_targets(ctx, profile, targets)
+            completed(validate_wrac_rules_for_targets(ctx, profile, targets))
         }
-        TaskKind::ValidateBundle { target } => validate_plugin_target(ctx, profile, *target),
+        TaskKind::ValidateBundle { target } => {
+            completed(validate_plugin_target(ctx, profile, *target))
+        }
     }
+}
+
+fn completed(result: Result<()>) -> Result<TaskOutcome> {
+    // Operations that cannot skip still return a workflow outcome so the
+    // workflow remains the single owner of the user-facing task result.
+    result.map(|()| TaskOutcome::Completed)
 }
 
 fn execute_build(config: &XtaskConfig, args: BuildArgs) -> Result<()> {


### PR DESCRIPTION
## Summary

- make semantic task titles the primary execution headings
- represent successful no-op tasks as `Skipped { reason }`
- distinguish skipped tasks from dependency-blocked tasks
- render child commands and operation messages as task details

## Why

The workflow executor, WRAC operations, and command runner each emitted their own status-like output. This made generic command headings more prominent than the task itself and caused an up-to-date configure to print both a skip result and a completion result.

The workflow now owns the final status for each task. A deliberate skip remains a valid dependency, while failed or blocked dependencies prevent downstream execution.

## Impact

xtask logs now identify the active task clearly, show one final result with a concrete skip reason, and report succeeded, skipped, failed, and blocked counts separately.

## Validation

- `cargo test -p xtask_workflow -p wrac_build_ops -p xtask`
- `cargo xtask quality`
- exercised the workflow through the products repository with a GUI-less CLAP plugin build