### PR TITLE
Support VST3 MIDI output events

### DIFF
--- a/clap_wrapper_builder/clap-wrapper/src/detail/vst3/process.cpp
+++ b/clap_wrapper_builder/clap-wrapper/src/detail/vst3/process.cpp
@@ -79,7 +79,8 @@ ProcessAdapter::~ProcessAdapter()
 void ProcessAdapter::setupProcessing(const clap_plugin_t *plugin, const clap_plugin_params_t *ext_params,
                                      Vst::BusList &audioinputs, Vst::BusList &audiooutputs,
                                      uint32_t numSamples, size_t /*numEventInputs*/,
-                                     size_t numEventOutputs, Steinberg::Vst::ParameterContainer &params,
+                                     const std::vector<int32_t> &outputEventBusByPort,
+                                     Steinberg::Vst::ParameterContainer &params,
                                      Steinberg::Vst::IComponentHandler *componenthandler,
                                      IAutomation *automation, std::vector<clap_id> &gesturedParameters,
                                      bool enablePolyPressure, bool supportsTuningNoteExpression)
@@ -88,7 +89,7 @@ void ProcessAdapter::setupProcessing(const clap_plugin_t *plugin, const clap_plu
   _ext_params = ext_params;
   _audioinputs = &audioinputs;
   _audiooutputs = &audiooutputs;
-  _numEventOutputs = numEventOutputs;
+  _outputEventBusByPort = outputEventBusByPort;
 
   parameters = &params;
   _componentHandler = componenthandler;
@@ -172,7 +173,9 @@ void ProcessAdapter::setupProcessing(const clap_plugin_t *plugin, const clap_plu
   _events.reserve(8192);
   _eventindices.clear();
   _eventindices.reserve(_events.capacity());
-  if (_numEventOutputs > 0) _sysexOutputBuffer = std::make_unique<uint8_t[]>(sysexOutputCapacity);
+  if (std::any_of(_outputEventBusByPort.begin(), _outputEventBusByPort.end(),
+                  [](int32_t busIndex) { return busIndex >= 0; }))
+    _sysexOutputBuffer = std::make_unique<uint8_t[]>(sysexOutputCapacity);
 
   _out_events.ctx = this;
 
@@ -758,22 +761,22 @@ bool ProcessAdapter::enqueueOutputEvent(const clap_event_header_t *event)
     case CLAP_EVENT_NOTE_ON:
     {
       auto nevt = reinterpret_cast<const clap_event_note *>(event);
-      if (!isValidOutputPort(nevt->port_index) || nevt->channel < 0 || nevt->channel > 15 ||
-          nevt->key < 0 || nevt->key > 127)
+      const auto busIndex = outputBusIndex(nevt->port_index);
+      if (busIndex < 0 || nevt->channel < 0 || nevt->channel > 15 || nevt->key < 0 || nevt->key > 127)
         return false;
 
-      auto oe = createNoteOnOutputEvent(nevt->header, nevt->port_index, nevt->channel, nevt->key,
+      auto oe = createNoteOnOutputEvent(nevt->header, busIndex, nevt->channel, nevt->key,
                                         static_cast<float>(nevt->velocity), nevt->note_id);
       return pushVstOutputEvent(oe);
     }
     case CLAP_EVENT_NOTE_OFF:
     {
       auto nevt = reinterpret_cast<const clap_event_note *>(event);
-      if (!isValidOutputPort(nevt->port_index) || nevt->channel < 0 || nevt->channel > 15 ||
-          nevt->key < 0 || nevt->key > 127)
+      const auto busIndex = outputBusIndex(nevt->port_index);
+      if (busIndex < 0 || nevt->channel < 0 || nevt->channel > 15 || nevt->key < 0 || nevt->key > 127)
         return false;
 
-      auto oe = createNoteOffOutputEvent(nevt->header, nevt->port_index, nevt->channel, nevt->key,
+      auto oe = createNoteOffOutputEvent(nevt->header, busIndex, nevt->channel, nevt->key,
                                          static_cast<float>(nevt->velocity), nevt->note_id);
       return pushVstOutputEvent(oe);
     }
@@ -869,7 +872,8 @@ bool ProcessAdapter::enqueueOutputEvent(const clap_event_header_t *event)
 
 bool ProcessAdapter::enqueueMidi1OutputEvent(const clap_event_midi_t &event)
 {
-  if (!isValidOutputPort(event.port_index)) return false;
+  const auto busIndex = outputBusIndex(event.port_index);
+  if (busIndex < 0) return false;
 
   const auto status = event.data[0];
   const auto message = status & 0xf0;
@@ -890,41 +894,41 @@ bool ProcessAdapter::enqueueMidi1OutputEvent(const clap_event_midi_t &event)
       case 0x90:
       {
         const bool isNoteOff = message == 0x80 || data2 == 0;
-        auto output = isNoteOff ? createNoteOffOutputEvent(event.header, event.port_index, channel,
-                                                           data1, static_cast<float>(data2) / 127.0f, -1)
-                                : createNoteOnOutputEvent(event.header, event.port_index, channel, data1,
+        auto output = isNoteOff ? createNoteOffOutputEvent(event.header, busIndex, channel, data1,
+                                                           static_cast<float>(data2) / 127.0f, -1)
+                                : createNoteOnOutputEvent(event.header, busIndex, channel, data1,
                                                           static_cast<float>(data2) / 127.0f, -1);
         return pushVstOutputEvent(output);
       }
       case 0xa0:
       {
         auto output =
-            createLegacyMidiOutputEvent(event.header, event.port_index, channel, Vst::kCtrlPolyPressure,
+            createLegacyMidiOutputEvent(event.header, busIndex, channel, Vst::kCtrlPolyPressure,
                                         static_cast<int8_t>(data1), static_cast<int8_t>(data2));
         return pushVstOutputEvent(output);
       }
       case 0xb0:
       {
-        auto output = createLegacyMidiOutputEvent(event.header, event.port_index, channel, data1,
+        auto output = createLegacyMidiOutputEvent(event.header, busIndex, channel, data1,
                                                   static_cast<int8_t>(data2));
         return pushVstOutputEvent(output);
       }
       case 0xc0:
       {
-        auto output = createLegacyMidiOutputEvent(event.header, event.port_index, channel,
+        auto output = createLegacyMidiOutputEvent(event.header, busIndex, channel,
                                                   Vst::kCtrlProgramChange, static_cast<int8_t>(data1));
         return pushVstOutputEvent(output);
       }
       case 0xd0:
       {
-        auto output = createLegacyMidiOutputEvent(event.header, event.port_index, channel,
-                                                  Vst::kAfterTouch, static_cast<int8_t>(data1));
+        auto output = createLegacyMidiOutputEvent(event.header, busIndex, channel, Vst::kAfterTouch,
+                                                  static_cast<int8_t>(data1));
         return pushVstOutputEvent(output);
       }
       case 0xe0:
       {
         auto output =
-            createLegacyMidiOutputEvent(event.header, event.port_index, channel, Vst::kPitchBend,
+            createLegacyMidiOutputEvent(event.header, busIndex, channel, Vst::kPitchBend,
                                         static_cast<int8_t>(data1), static_cast<int8_t>(data2));
         return pushVstOutputEvent(output);
       }
@@ -935,8 +939,7 @@ bool ProcessAdapter::enqueueMidi1OutputEvent(const clap_event_midi_t &event)
 
   auto pushSystemEvent = [&](uint8_t controlNumber, int8_t value = 0, int8_t value2 = 0)
   {
-    auto output =
-        createLegacyMidiOutputEvent(event.header, event.port_index, 0, controlNumber, value, value2);
+    auto output = createLegacyMidiOutputEvent(event.header, busIndex, 0, controlNumber, value, value2);
     return pushVstOutputEvent(output);
   };
 
@@ -969,9 +972,9 @@ bool ProcessAdapter::enqueueMidi1OutputEvent(const clap_event_midi_t &event)
 
 bool ProcessAdapter::enqueueSysexOutputEvent(const clap_event_midi_sysex_t &event)
 {
-  if (!isValidOutputPort(event.port_index) || event.buffer == nullptr || event.size < 2 ||
-      event.buffer[0] != 0xf0 || event.buffer[event.size - 1] != 0xf7 ||
-      event.size > sysexOutputCapacity - _sysexOutputSize)
+  const auto busIndex = outputBusIndex(event.port_index);
+  if (busIndex < 0 || event.buffer == nullptr || event.size < 2 || event.buffer[0] != 0xf0 ||
+      event.buffer[event.size - 1] != 0xf7 || event.size > sysexOutputCapacity - _sysexOutputSize)
     return false;
 
   // CLAP only keeps the source bytes alive for try_push(), while VST3 may retain the
@@ -980,7 +983,7 @@ bool ProcessAdapter::enqueueSysexOutputEvent(const clap_event_midi_sysex_t &even
   auto *bytes = _sysexOutputBuffer.get() + _sysexOutputSize;
   std::memcpy(bytes, event.buffer, event.size);
 
-  auto output = createOutputEvent(event.header, event.port_index);
+  auto output = createOutputEvent(event.header, busIndex);
   output.type = Vst::Event::kDataEvent;
   output.data.type = Vst::DataEvent::kMidiSysEx;
   output.data.size = event.size;
@@ -999,9 +1002,12 @@ bool ProcessAdapter::pushVstOutputEvent(Vst::Event &event)
          _vstdata->outputEvents->addEvent(event) == kResultOk;
 }
 
-bool ProcessAdapter::isValidOutputPort(int32_t portIndex) const
+int32_t ProcessAdapter::outputBusIndex(int32_t portIndex) const
 {
-  return portIndex >= 0 && static_cast<size_t>(portIndex) < _numEventOutputs;
+  // CLAP ports with unsupported dialects are not exposed as VST3 event buses, so their
+  // indices cannot be used as bus indices directly.
+  if (portIndex < 0 || static_cast<size_t>(portIndex) >= _outputEventBusByPort.size()) return -1;
+  return _outputEventBusByPort[portIndex];
 }
 
 void ProcessAdapter::addToActiveNotes(const clap_event_note *note)

--- a/clap_wrapper_builder/clap-wrapper/src/detail/vst3/process.cpp
+++ b/clap_wrapper_builder/clap-wrapper/src/detail/vst3/process.cpp
@@ -6,6 +6,7 @@
 
 #include "parameter.h"
 #include <algorithm>
+#include <cstring>
 
 #include <cmath>
 #include "../clap/automation.h"
@@ -14,6 +15,63 @@ namespace Clap
 {
 using namespace Steinberg;
 
+namespace
+{
+Vst::Event createOutputEvent(const clap_event_header_t &header, int32_t busIndex)
+{
+  Vst::Event event{};
+  event.busIndex = busIndex;
+  event.sampleOffset = static_cast<int32_t>(header.time);
+  event.flags = (header.flags & CLAP_EVENT_IS_LIVE) ? Vst::Event::kIsLive : 0;
+  return event;
+}
+
+Vst::Event createLegacyMidiOutputEvent(const clap_event_header_t &header, int32_t busIndex,
+                                       int16_t channel, uint8_t controlNumber, int8_t value = 0,
+                                       int8_t value2 = 0)
+{
+  auto event = createOutputEvent(header, busIndex);
+  event.type = Vst::Event::kLegacyMIDICCOutEvent;
+  event.midiCCOut.channel = static_cast<int8_t>(channel);
+  event.midiCCOut.controlNumber = controlNumber;
+  event.midiCCOut.value = value;
+  event.midiCCOut.value2 = value2;
+  return event;
+}
+
+Vst::Event createNoteOnOutputEvent(const clap_event_header_t &header, int32_t busIndex, int16_t channel,
+                                   int16_t key, float velocity, int32_t noteId)
+{
+  auto event = createOutputEvent(header, busIndex);
+  event.type = Vst::Event::kNoteOnEvent;
+  event.noteOn.channel = channel;
+  event.noteOn.pitch = key;
+  event.noteOn.velocity = std::clamp(velocity, 0.0f, 1.0f);
+  event.noteOn.length = 0;
+  event.noteOn.tuning = 0.0f;
+  event.noteOn.noteId = noteId;
+  return event;
+}
+
+Vst::Event createNoteOffOutputEvent(const clap_event_header_t &header, int32_t busIndex, int16_t channel,
+                                    int16_t key, float velocity, int32_t noteId)
+{
+  auto event = createOutputEvent(header, busIndex);
+  event.type = Vst::Event::kNoteOffEvent;
+  event.noteOff.channel = channel;
+  event.noteOff.pitch = key;
+  event.noteOff.velocity = std::clamp(velocity, 0.0f, 1.0f);
+  event.noteOff.tuning = 0.0f;
+  event.noteOff.noteId = noteId;
+  return event;
+}
+
+bool isMidiDataByte(uint8_t value)
+{
+  return value <= 0x7f;
+}
+}  // namespace
+
 ProcessAdapter::~ProcessAdapter()
 {
 }
@@ -21,8 +79,7 @@ ProcessAdapter::~ProcessAdapter()
 void ProcessAdapter::setupProcessing(const clap_plugin_t *plugin, const clap_plugin_params_t *ext_params,
                                      Vst::BusList &audioinputs, Vst::BusList &audiooutputs,
                                      uint32_t numSamples, size_t /*numEventInputs*/,
-                                     size_t /*numEventOutputs*/,
-                                     Steinberg::Vst::ParameterContainer &params,
+                                     size_t numEventOutputs, Steinberg::Vst::ParameterContainer &params,
                                      Steinberg::Vst::IComponentHandler *componenthandler,
                                      IAutomation *automation, std::vector<clap_id> &gesturedParameters,
                                      bool enablePolyPressure, bool supportsTuningNoteExpression)
@@ -31,6 +88,7 @@ void ProcessAdapter::setupProcessing(const clap_plugin_t *plugin, const clap_plu
   _ext_params = ext_params;
   _audioinputs = &audioinputs;
   _audiooutputs = &audiooutputs;
+  _numEventOutputs = numEventOutputs;
 
   parameters = &params;
   _componentHandler = componenthandler;
@@ -114,6 +172,7 @@ void ProcessAdapter::setupProcessing(const clap_plugin_t *plugin, const clap_plu
   _events.reserve(8192);
   _eventindices.clear();
   _eventindices.reserve(_events.capacity());
+  if (_numEventOutputs > 0) _sysexOutputBuffer = std::make_unique<uint8_t[]>(sysexOutputCapacity);
 
   _out_events.ctx = this;
 
@@ -160,6 +219,7 @@ void ProcessAdapter::flush()
   // minimal processing if _ext_params is existent
   if (_ext_params)
   {
+    _sysexOutputSize = 0;
     _events.clear();
     _eventindices.clear();
 
@@ -173,6 +233,7 @@ void ProcessAdapter::process(Steinberg::Vst::ProcessData &data)
 {
   // remember the ProcessData pointer during process
   _vstdata = &data;
+  _sysexOutputSize = 0;
 
   /// convert timing
   _transport.header = {sizeof(_transport), 0, CLAP_CORE_EVENT_SPACE_ID, CLAP_EVENT_TRANSPORT, 0};
@@ -690,44 +751,32 @@ void ProcessAdapter::processInputEvents(Steinberg::Vst::IEventList *eventlist)
 
 bool ProcessAdapter::enqueueOutputEvent(const clap_event_header_t *event)
 {
+  if (event->space_id != CLAP_CORE_EVENT_SPACE_ID) return false;
+
   switch (event->type)
   {
     case CLAP_EVENT_NOTE_ON:
     {
       auto nevt = reinterpret_cast<const clap_event_note *>(event);
+      if (!isValidOutputPort(nevt->port_index) || nevt->channel < 0 || nevt->channel > 15 ||
+          nevt->key < 0 || nevt->key > 127)
+        return false;
 
-      Steinberg::Vst::Event oe{};
-      oe.type = Steinberg::Vst::Event::kNoteOnEvent;
-      oe.noteOn.channel = nevt->channel;
-      oe.noteOn.pitch = nevt->key;
-      oe.noteOn.velocity = nevt->velocity;
-      oe.noteOn.length = 0;
-      oe.noteOn.tuning = 0.0f;
-      oe.noteOn.noteId = nevt->note_id;
-      oe.busIndex = 0;  // FIXME - multi-out midi still needs work
-      oe.sampleOffset = nevt->header.time;
-
-      if (_vstdata && _vstdata->outputEvents) _vstdata->outputEvents->addEvent(oe);
+      auto oe = createNoteOnOutputEvent(nevt->header, nevt->port_index, nevt->channel, nevt->key,
+                                        static_cast<float>(nevt->velocity), nevt->note_id);
+      return pushVstOutputEvent(oe);
     }
-      return true;
     case CLAP_EVENT_NOTE_OFF:
     {
       auto nevt = reinterpret_cast<const clap_event_note *>(event);
+      if (!isValidOutputPort(nevt->port_index) || nevt->channel < 0 || nevt->channel > 15 ||
+          nevt->key < 0 || nevt->key > 127)
+        return false;
 
-      Steinberg::Vst::Event oe{};
-      oe.type = Steinberg::Vst::Event::kNoteOffEvent;
-      oe.noteOff.channel = nevt->channel;
-      oe.noteOff.pitch = nevt->key;
-      oe.noteOff.velocity = nevt->velocity;
-      oe.noteOn.length = 0;
-      oe.noteOff.tuning = 0.0f;
-      oe.noteOff.noteId = nevt->note_id;
-      oe.busIndex = 0;  // FIXME - multi-out midi still needs work
-      oe.sampleOffset = nevt->header.time;
-
-      if (_vstdata && _vstdata->outputEvents) _vstdata->outputEvents->addEvent(oe);
+      auto oe = createNoteOffOutputEvent(nevt->header, nevt->port_index, nevt->channel, nevt->key,
+                                         static_cast<float>(nevt->velocity), nevt->note_id);
+      return pushVstOutputEvent(oe);
     }
-      return true;
     case CLAP_EVENT_NOTE_END:
     case CLAP_EVENT_NOTE_CHOKE:
       removeFromActiveNotes((const clap_event_note *)(event));
@@ -807,14 +856,152 @@ bool ProcessAdapter::enqueueOutputEvent(const clap_event_header_t *event)
       break;
 
     case CLAP_EVENT_MIDI:
+      return enqueueMidi1OutputEvent(*reinterpret_cast<const clap_event_midi_t *>(event));
     case CLAP_EVENT_MIDI_SYSEX:
+      return enqueueSysexOutputEvent(*reinterpret_cast<const clap_event_midi_sysex_t *>(event));
     case CLAP_EVENT_MIDI2:
-      return true;
-      break;
+      return false;
     default:
       break;
   }
   return false;
+}
+
+bool ProcessAdapter::enqueueMidi1OutputEvent(const clap_event_midi_t &event)
+{
+  if (!isValidOutputPort(event.port_index)) return false;
+
+  const auto status = event.data[0];
+  const auto message = status & 0xf0;
+  const auto channel = status & 0x0f;
+  const auto data1 = event.data[1];
+  const auto data2 = event.data[2];
+
+  // VST3 has no raw MIDI event type, so preserve every MIDI 1.0 message for which it
+  // defines an equivalent semantic or legacy output event.
+  if (status < 0xf0)
+  {
+    if (!isMidiDataByte(data1)) return false;
+    if (message != 0xc0 && message != 0xd0 && !isMidiDataByte(data2)) return false;
+
+    switch (message)
+    {
+      case 0x80:
+      case 0x90:
+      {
+        const bool isNoteOff = message == 0x80 || data2 == 0;
+        auto output = isNoteOff ? createNoteOffOutputEvent(event.header, event.port_index, channel,
+                                                           data1, static_cast<float>(data2) / 127.0f, -1)
+                                : createNoteOnOutputEvent(event.header, event.port_index, channel, data1,
+                                                          static_cast<float>(data2) / 127.0f, -1);
+        return pushVstOutputEvent(output);
+      }
+      case 0xa0:
+      {
+        auto output =
+            createLegacyMidiOutputEvent(event.header, event.port_index, channel, Vst::kCtrlPolyPressure,
+                                        static_cast<int8_t>(data1), static_cast<int8_t>(data2));
+        return pushVstOutputEvent(output);
+      }
+      case 0xb0:
+      {
+        auto output = createLegacyMidiOutputEvent(event.header, event.port_index, channel, data1,
+                                                  static_cast<int8_t>(data2));
+        return pushVstOutputEvent(output);
+      }
+      case 0xc0:
+      {
+        auto output = createLegacyMidiOutputEvent(event.header, event.port_index, channel,
+                                                  Vst::kCtrlProgramChange, static_cast<int8_t>(data1));
+        return pushVstOutputEvent(output);
+      }
+      case 0xd0:
+      {
+        auto output = createLegacyMidiOutputEvent(event.header, event.port_index, channel,
+                                                  Vst::kAfterTouch, static_cast<int8_t>(data1));
+        return pushVstOutputEvent(output);
+      }
+      case 0xe0:
+      {
+        auto output =
+            createLegacyMidiOutputEvent(event.header, event.port_index, channel, Vst::kPitchBend,
+                                        static_cast<int8_t>(data1), static_cast<int8_t>(data2));
+        return pushVstOutputEvent(output);
+      }
+      default:
+        return false;
+    }
+  }
+
+  auto pushSystemEvent = [&](uint8_t controlNumber, int8_t value = 0, int8_t value2 = 0)
+  {
+    auto output =
+        createLegacyMidiOutputEvent(event.header, event.port_index, 0, controlNumber, value, value2);
+    return pushVstOutputEvent(output);
+  };
+
+  switch (status)
+  {
+    case 0xf1:
+      return isMidiDataByte(data1) &&
+             pushSystemEvent(Vst::kCtrlQuarterFrame, static_cast<int8_t>(data1));
+    case 0xf2:
+      return isMidiDataByte(data1) && isMidiDataByte(data2) &&
+             pushSystemEvent(Vst::kSystemSongPointer, static_cast<int8_t>(data1),
+                             static_cast<int8_t>(data2));
+    case 0xf3:
+      return isMidiDataByte(data1) &&
+             pushSystemEvent(Vst::kSystemSongSelect, static_cast<int8_t>(data1));
+    case 0xf6:
+      return pushSystemEvent(Vst::kSystemTuneRequest);
+    case 0xfa:
+      return pushSystemEvent(Vst::kSystemMidiClockStart);
+    case 0xfb:
+      return pushSystemEvent(Vst::kSystemMidiClockContinue);
+    case 0xfc:
+      return pushSystemEvent(Vst::kSystemMidiClockStop);
+    case 0xfe:
+      return pushSystemEvent(Vst::kSystemActiveSensing);
+    default:
+      return false;
+  }
+}
+
+bool ProcessAdapter::enqueueSysexOutputEvent(const clap_event_midi_sysex_t &event)
+{
+  if (!isValidOutputPort(event.port_index) || event.buffer == nullptr || event.size < 2 ||
+      event.buffer[0] != 0xf0 || event.buffer[event.size - 1] != 0xf7 ||
+      event.size > sysexOutputCapacity - _sysexOutputSize)
+    return false;
+
+  // CLAP only keeps the source bytes alive for try_push(), while VST3 may retain the
+  // pointer until process() returns. Bounded preallocated storage bridges that lifetime
+  // without allocating on the realtime thread.
+  auto *bytes = _sysexOutputBuffer.get() + _sysexOutputSize;
+  std::memcpy(bytes, event.buffer, event.size);
+
+  auto output = createOutputEvent(event.header, event.port_index);
+  output.type = Vst::Event::kDataEvent;
+  output.data.type = Vst::DataEvent::kMidiSysEx;
+  output.data.size = event.size;
+  output.data.bytes = bytes;
+  if (!pushVstOutputEvent(output)) return false;
+
+  _sysexOutputSize += event.size;
+  return true;
+}
+
+bool ProcessAdapter::pushVstOutputEvent(Vst::Event &event)
+{
+  // CLAP uses the return value as backpressure, so claiming success here would silently
+  // discard an event when the VST3 host did not provide or accept an output queue.
+  return _vstdata != nullptr && _vstdata->outputEvents != nullptr &&
+         _vstdata->outputEvents->addEvent(event) == kResultOk;
+}
+
+bool ProcessAdapter::isValidOutputPort(int32_t portIndex) const
+{
+  return portIndex >= 0 && static_cast<size_t>(portIndex) < _numEventOutputs;
 }
 
 void ProcessAdapter::addToActiveNotes(const clap_event_note *note)

--- a/clap_wrapper_builder/clap-wrapper/src/detail/vst3/process.h
+++ b/clap_wrapper_builder/clap-wrapper/src/detail/vst3/process.h
@@ -91,6 +91,10 @@ class ProcessAdapter
   void processInputEvents(Steinberg::Vst::IEventList *eventlist);
 
   bool enqueueOutputEvent(const clap_event_header_t *event);
+  bool enqueueMidi1OutputEvent(const clap_event_midi_t &event);
+  bool enqueueSysexOutputEvent(const clap_event_midi_sysex_t &event);
+  bool pushVstOutputEvent(Steinberg::Vst::Event &event);
+  bool isValidOutputPort(int32_t portIndex) const;
   void addToActiveNotes(const clap_event_note *note);
   void removeFromActiveNotes(const clap_event_note *note);
 
@@ -103,6 +107,7 @@ class ProcessAdapter
   IAutomation *_automation = nullptr;
   Steinberg::Vst::BusList *_audioinputs = nullptr;
   Steinberg::Vst::BusList *_audiooutputs = nullptr;
+  size_t _numEventOutputs = 0;
 
   // for automation gestures
   std::vector<clap_id> *_gesturedParameters;
@@ -126,6 +131,12 @@ class ProcessAdapter
 
   std::unique_ptr<float[]> _silent_input;
   std::unique_ptr<float[]> _silent_output;
+
+  // A bounded block-local buffer keeps SysEx forwarding realtime-safe; try_push() reports
+  // backpressure instead of allocating if a block exceeds this capacity.
+  static constexpr size_t sysexOutputCapacity = 64 * 1024;
+  std::unique_ptr<uint8_t[]> _sysexOutputBuffer;
+  size_t _sysexOutputSize = 0;
 
   clap_process_t _processData = {-1, 0, &_transport, nullptr, nullptr, 0, 0, &_in_events, &_out_events};
 

--- a/clap_wrapper_builder/clap-wrapper/src/detail/vst3/process.h
+++ b/clap_wrapper_builder/clap-wrapper/src/detail/vst3/process.h
@@ -65,6 +65,8 @@ class ProcessAdapter
 #endif
   virtual ~ProcessAdapter();
 
+  // Indexed by CLAP output port; -1 means that VST3 omitted the port because its
+  // dialect cannot be represented by a VST3 event bus.
   void setupProcessing(const clap_plugin_t *plugin, const clap_plugin_params_t *ext_params,
                        Steinberg::Vst::BusList &audioinputs, Steinberg::Vst::BusList &audiooutputs,
                        uint32_t numSamples, size_t numEventInputs,

--- a/clap_wrapper_builder/clap-wrapper/src/detail/vst3/process.h
+++ b/clap_wrapper_builder/clap-wrapper/src/detail/vst3/process.h
@@ -67,7 +67,8 @@ class ProcessAdapter
 
   void setupProcessing(const clap_plugin_t *plugin, const clap_plugin_params_t *ext_params,
                        Steinberg::Vst::BusList &audioinputs, Steinberg::Vst::BusList &audiooutputs,
-                       uint32_t numSamples, size_t numEventInputs, size_t numEventOutputs,
+                       uint32_t numSamples, size_t numEventInputs,
+                       const std::vector<int32_t> &outputEventBusByPort,
                        Steinberg::Vst::ParameterContainer &params,
                        Steinberg::Vst::IComponentHandler *componenthandler, IAutomation *automation,
                        std::vector<clap_id> &gesturedParameters, bool enablePolyPressure,
@@ -94,7 +95,7 @@ class ProcessAdapter
   bool enqueueMidi1OutputEvent(const clap_event_midi_t &event);
   bool enqueueSysexOutputEvent(const clap_event_midi_sysex_t &event);
   bool pushVstOutputEvent(Steinberg::Vst::Event &event);
-  bool isValidOutputPort(int32_t portIndex) const;
+  int32_t outputBusIndex(int32_t portIndex) const;
   void addToActiveNotes(const clap_event_note *note);
   void removeFromActiveNotes(const clap_event_note *note);
 
@@ -107,7 +108,7 @@ class ProcessAdapter
   IAutomation *_automation = nullptr;
   Steinberg::Vst::BusList *_audioinputs = nullptr;
   Steinberg::Vst::BusList *_audiooutputs = nullptr;
-  size_t _numEventOutputs = 0;
+  std::vector<int32_t> _outputEventBusByPort;
 
   // for automation gestures
   std::vector<clap_id> *_gesturedParameters;

--- a/clap_wrapper_builder/clap-wrapper/src/wrapasvst3.cpp
+++ b/clap_wrapper_builder/clap-wrapper/src/wrapasvst3.cpp
@@ -198,7 +198,7 @@ tresult PLUGIN_API ClapAsVst3::setActive(TBool state)
     // the processAdapter needs to know a few things to intercommunicate between VST3 host and CLAP plugin.
     _processAdapter->setupProcessing(
         _plugin->_plugin, _plugin->_ext._params, this->audioInputs, this->audioOutputs,
-        this->_largestBlocksize, this->eventInputs.size(), this->eventOutputs.size(), parameters,
+        this->_largestBlocksize, this->eventInputs.size(), _outputEventBusByPort, parameters,
         componentHandler, this, _gesturedparameters, supportsnoteexpression,
         _expressionmap & clap_supported_note_expressions::AS_VST3_NOTE_EXPRESSION_TUNING);
     updateAudioBusses();
@@ -829,30 +829,31 @@ void ClapAsVst3::addAudioBusFrom(const clap_audio_port_info_t *info, bool is_inp
   }
 }
 
-void ClapAsVst3::addMIDIBusFrom(const clap_note_port_info_t *info, uint32_t index, bool is_input)
+bool ClapAsVst3::addMIDIBusFrom(const clap_note_port_info_t *info, uint32_t index, bool is_input)
 {
-  if ((info->supported_dialects & CLAP_NOTE_DIALECT_MIDI) ||
-      (info->supported_dialects & CLAP_NOTE_DIALECT_CLAP))
-  {
-    auto numchannels = 16;
-    if (_vst3specifics)
-    {
-      numchannels = _vst3specifics->getNumMIDIChannels(_plugin->_plugin, index);
-    }
+  if (!(info->supported_dialects & CLAP_NOTE_DIALECT_MIDI) &&
+      !(info->supported_dialects & CLAP_NOTE_DIALECT_CLAP))
+    return false;
 
-    Steinberg::char16 name16[256];
-    // str8tostr16 writes to position n to terminate, so don't overflow
-    // Steinberg::str8ToStr16(&name16[0], info->name, 255);
-    utf8_to_utf16l(info->name, (uint16_t *)name16, 255);
-    if (is_input)
-    {
-      addEventInput(name16, numchannels, Vst::BusTypes::kMain, Vst::BusInfo::kDefaultActive);
-    }
-    else
-    {
-      addEventOutput(name16, numchannels, Vst::BusTypes::kMain, Vst::BusInfo::kDefaultActive);
-    }
+  auto numchannels = 16;
+  if (_vst3specifics)
+  {
+    numchannels = _vst3specifics->getNumMIDIChannels(_plugin->_plugin, index);
   }
+
+  Steinberg::char16 name16[256];
+  // str8tostr16 writes to position n to terminate, so don't overflow
+  // Steinberg::str8ToStr16(&name16[0], info->name, 255);
+  utf8_to_utf16l(info->name, (uint16_t *)name16, 255);
+  if (is_input)
+  {
+    addEventInput(name16, numchannels, Vst::BusTypes::kMain, Vst::BusInfo::kDefaultActive);
+  }
+  else
+  {
+    addEventOutput(name16, numchannels, Vst::BusTypes::kMain, Vst::BusInfo::kDefaultActive);
+  }
+  return true;
 }
 
 void ClapAsVst3::updateAudioBusses()
@@ -1006,12 +1007,7 @@ void ClapAsVst3::setupMIDIBusses(const clap_plugin_t *plugin, const clap_plugin_
   auto numMIDIOutPorts = noteports->count(plugin, false);
 
   // fprintf(stderr, "\tMIDI in: %d, out: %d\n", (int)numMIDIInPorts, (int)numMIDIOutPorts);
-
-  std::vector<clap_note_port_info_t> inputs;
-  std::vector<clap_note_port_info_t> outputs;
-
-  inputs.resize(numMIDIInPorts);
-  outputs.resize(numMIDIOutPorts);
+  _outputEventBusByPort.assign(numMIDIOutPorts, -1);
 
   for (decltype(numMIDIInPorts) i = 0; i < numMIDIInPorts; ++i)
   {
@@ -1026,7 +1022,8 @@ void ClapAsVst3::setupMIDIBusses(const clap_plugin_t *plugin, const clap_plugin_
     clap_note_port_info_t info;
     if (noteports->get(plugin, i, false, &info))
     {
-      addMIDIBusFrom(&info, i, false);
+      const auto busIndex = static_cast<int32_t>(eventOutputs.size());
+      if (addMIDIBusFrom(&info, i, false)) _outputEventBusByPort[i] = busIndex;
     }
   }
 }
@@ -1456,7 +1453,7 @@ void ClapAsVst3::onIdle()
     {
       // setup a ProcessAdapter just for flush with no audio
       Clap::ProcessAdapter pa;
-      pa.setupProcessing(_plugin->_plugin, _plugin->_ext._params, audioInputs, audioOutputs, 0, 0, 0,
+      pa.setupProcessing(_plugin->_plugin, _plugin->_ext._params, audioInputs, audioOutputs, 0, 0, {},
                          this->parameters, componentHandler, this, _gesturedparameters, false, false);
       auto thisFn = _plugin->AlwaysAudioThread();  // just to pacify the clap-helper
 

--- a/clap_wrapper_builder/clap-wrapper/src/wrapasvst3.cpp
+++ b/clap_wrapper_builder/clap-wrapper/src/wrapasvst3.cpp
@@ -49,6 +49,11 @@ static_assert(std::atomic<uint32_t>::is_always_lock_free,
 static Vst::SpeakerArrangement speakerArrFromPortInfo(const clap_audio_port_info_t &info);
 static bool portInfoMatchesSpeakerArr(const clap_audio_port_info_t &info, Vst::SpeakerArrangement arr);
 static const char *clapPortTypeFromSpeakerArr(Vst::SpeakerArrangement arr);
+static bool supportsVst3EventBus(const clap_note_port_info_t &info)
+{
+  return (info.supported_dialects & CLAP_NOTE_DIALECT_MIDI) ||
+         (info.supported_dialects & CLAP_NOTE_DIALECT_CLAP);
+}
 
 DEF_CLASS_IID(ARA::IPlugInEntryPoint)
 DEF_CLASS_IID(ARA::IPlugInEntryPoint2)
@@ -829,31 +834,29 @@ void ClapAsVst3::addAudioBusFrom(const clap_audio_port_info_t *info, bool is_inp
   }
 }
 
-bool ClapAsVst3::addMIDIBusFrom(const clap_note_port_info_t *info, uint32_t index, bool is_input)
+void ClapAsVst3::addMIDIBusFrom(const clap_note_port_info_t *info, uint32_t index, bool is_input)
 {
-  if (!(info->supported_dialects & CLAP_NOTE_DIALECT_MIDI) &&
-      !(info->supported_dialects & CLAP_NOTE_DIALECT_CLAP))
-    return false;
+  if (supportsVst3EventBus(*info))
+  {
+    auto numchannels = 16;
+    if (_vst3specifics)
+    {
+      numchannels = _vst3specifics->getNumMIDIChannels(_plugin->_plugin, index);
+    }
 
-  auto numchannels = 16;
-  if (_vst3specifics)
-  {
-    numchannels = _vst3specifics->getNumMIDIChannels(_plugin->_plugin, index);
+    Steinberg::char16 name16[256];
+    // str8tostr16 writes to position n to terminate, so don't overflow
+    // Steinberg::str8ToStr16(&name16[0], info->name, 255);
+    utf8_to_utf16l(info->name, (uint16_t *)name16, 255);
+    if (is_input)
+    {
+      addEventInput(name16, numchannels, Vst::BusTypes::kMain, Vst::BusInfo::kDefaultActive);
+    }
+    else
+    {
+      addEventOutput(name16, numchannels, Vst::BusTypes::kMain, Vst::BusInfo::kDefaultActive);
+    }
   }
-
-  Steinberg::char16 name16[256];
-  // str8tostr16 writes to position n to terminate, so don't overflow
-  // Steinberg::str8ToStr16(&name16[0], info->name, 255);
-  utf8_to_utf16l(info->name, (uint16_t *)name16, 255);
-  if (is_input)
-  {
-    addEventInput(name16, numchannels, Vst::BusTypes::kMain, Vst::BusInfo::kDefaultActive);
-  }
-  else
-  {
-    addEventOutput(name16, numchannels, Vst::BusTypes::kMain, Vst::BusInfo::kDefaultActive);
-  }
-  return true;
 }
 
 void ClapAsVst3::updateAudioBusses()
@@ -1007,6 +1010,7 @@ void ClapAsVst3::setupMIDIBusses(const clap_plugin_t *plugin, const clap_plugin_
   auto numMIDIOutPorts = noteports->count(plugin, false);
 
   // fprintf(stderr, "\tMIDI in: %d, out: %d\n", (int)numMIDIInPorts, (int)numMIDIOutPorts);
+  // Unsupported CLAP dialects create gaps because VST3 does not expose a bus for those ports.
   _outputEventBusByPort.assign(numMIDIOutPorts, -1);
 
   for (decltype(numMIDIInPorts) i = 0; i < numMIDIInPorts; ++i)
@@ -1022,8 +1026,11 @@ void ClapAsVst3::setupMIDIBusses(const clap_plugin_t *plugin, const clap_plugin_
     clap_note_port_info_t info;
     if (noteports->get(plugin, i, false, &info))
     {
-      const auto busIndex = static_cast<int32_t>(eventOutputs.size());
-      if (addMIDIBusFrom(&info, i, false)) _outputEventBusByPort[i] = busIndex;
+      if (supportsVst3EventBus(info))
+      {
+        _outputEventBusByPort[i] = static_cast<int32_t>(eventOutputs.size());
+        addMIDIBusFrom(&info, i, false);
+      }
     }
   }
 }

--- a/clap_wrapper_builder/clap-wrapper/src/wrapasvst3.h
+++ b/clap_wrapper_builder/clap-wrapper/src/wrapasvst3.h
@@ -380,7 +380,7 @@ class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect,
  private:
   // helper functions
   void addAudioBusFrom(const clap_audio_port_info_t *info, bool is_input);
-  bool addMIDIBusFrom(const clap_note_port_info_t *info, uint32_t index, bool is_input);
+  void addMIDIBusFrom(const clap_note_port_info_t *info, uint32_t index, bool is_input);
   void updateAudioBusses();
 
   Vst::UnitID getOrCreateUnitInfo(const char *modulename);

--- a/clap_wrapper_builder/clap-wrapper/src/wrapasvst3.h
+++ b/clap_wrapper_builder/clap-wrapper/src/wrapasvst3.h
@@ -380,7 +380,7 @@ class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect,
  private:
   // helper functions
   void addAudioBusFrom(const clap_audio_port_info_t *info, bool is_input);
-  void addMIDIBusFrom(const clap_note_port_info_t *info, uint32_t index, bool is_input);
+  bool addMIDIBusFrom(const clap_note_port_info_t *info, uint32_t index, bool is_input);
   void updateAudioBusses();
 
   Vst::UnitID getOrCreateUnitInfo(const char *modulename);
@@ -391,6 +391,7 @@ class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect,
   std::shared_ptr<Clap::Plugin> _plugin;
   clap_plugin_as_vst3_t *_vst3specifics = nullptr;
   Clap::ProcessAdapter *_processAdapter = nullptr;
+  std::vector<int32_t> _outputEventBusByPort;
   WrappedView *_wrappedview = nullptr;
 
   void *_creationcontext;  // context from the CLAP library


### PR DESCRIPTION
## Summary

- translate CLAP MIDI 1.0 output into VST3 semantic and legacy MIDI events
- preserve output bus, sample offset, and live-event metadata
- forward SysEx through bounded preallocated storage with the required pointer lifetime
- return the VST3 host queue result instead of reporting success for discarded events

## Root cause

The VST3 process adapter accepted `CLAP_EVENT_MIDI`, `CLAP_EVENT_MIDI_SYSEX`, and
`CLAP_EVENT_MIDI2`, but returned success without forwarding them. This silently dropped
MIDI CC output, including sustain pedal CC64.

## Impact

Wrapped VST3 plugins can now emit the MIDI 1.0 messages that VST3 can represent. Unsupported
MIDI 2.0 and MIDI 1.0 system messages without VST3 equivalents are rejected explicitly.

## Validation

- clang-format 21
- VST3 wrapper build with warnings treated as errors
- `cargo clippy --manifest-path plugins/white-on-white/src-plugin/Cargo.toml --all-targets -- -D warnings`
- `cargo test --manifest-path plugins/white-on-white/src-plugin/Cargo.toml` (63 passed)
- `cargo xtask validate -p white_on_white -t vst3` (47 VST3 validator tests passed)
- Ableton Live verification of sustain pedal CC64 output
