### PR TITLE
Fix clap-validator test exclusions

### DIFF
--- a/crates/wrac_build_ops/src/commands.rs
+++ b/crates/wrac_build_ops/src/commands.rs
@@ -22,8 +22,8 @@ pub use self::build::{
     build_wrapper_target, configure_wrapper, package_clap, standalone_products,
 };
 pub use self::validation::{
-    AaxValidatorConfig, ClapValidatorConfig, ExternalValidatorConfig, SkippedValidatorTest,
-    validate_plugin_target,
+    AaxValidatorConfig, ClapValidatorConfig, ClapValidatorTestExclusion, ExternalValidatorConfig,
+    SkippedValidatorTest, validate_plugin_target,
 };
 
 pub fn launch(ctx: &Context, profile: BuildProfile, plugin_id: Option<&str>) -> Result<()> {

--- a/crates/wrac_build_ops/src/commands/validation.rs
+++ b/crates/wrac_build_ops/src/commands/validation.rs
@@ -24,12 +24,18 @@ pub struct ExternalValidatorConfig {
     pub aax: AaxValidatorConfig,
 }
 
-/// clap-validator version and an optional caller-approved test exclusion.
+/// clap-validator version and caller-approved test exclusions.
 #[derive(Debug, Clone)]
 pub struct ClapValidatorConfig {
     pub version: String,
-    pub skip_test_filter: Option<String>,
-    pub skip_reason: Option<String>,
+    pub test_exclusions: Vec<ClapValidatorTestExclusion>,
+}
+
+/// A clap-validator test filter omitted by the caller, together with its reviewable reason.
+#[derive(Debug, Clone)]
+pub struct ClapValidatorTestExclusion {
+    pub filter: String,
+    pub reason: String,
 }
 
 /// Explicit AAX Validator test selection and process timeout.
@@ -58,28 +64,20 @@ pub fn validate_plugin_target(
             let clap = ctx.clap_bundle(profile);
             ensure_exists(&clap, "CLAP artifact")?;
             let validator = ensure_clap_validator(ctx, &config.clap.version)?;
-            let mut command = Command::new(validator);
-            command
-                .env("WRAC_PLUGIN_VALIDATOR", "1")
-                .arg("validate")
-                .arg(&clap)
-                .arg("--only-failed");
-            if let Some(filter) = config.clap.skip_test_filter.as_deref() {
-                let reason = config
-                    .clap
-                    .skip_reason
-                    .as_deref()
-                    .unwrap_or("no reason provided");
+            for exclusion in &config.clap.test_exclusions {
                 print_detail(
                     ctx.output_language,
-                    &format!("CLAP validator skip filter: {filter} ({reason})"),
-                    &format!("CLAP validator skip filter: {filter} ({reason})"),
+                    &format!(
+                        "CLAP validator test exclusion: {} ({})",
+                        exclusion.filter, exclusion.reason
+                    ),
+                    &format!(
+                        "CLAP validator test exclusion: {} ({})",
+                        exclusion.filter, exclusion.reason
+                    ),
                 );
-                command
-                    .arg("--test-filter")
-                    .arg(filter)
-                    .arg("--invert-filter");
             }
+            let mut command = clap_validator_command(&validator, &clap, &config.clap);
             run_with_language(command.current_dir(&ctx.root), ctx.output_language)?;
         }
         ValidateTarget::Vst3 => {
@@ -136,6 +134,20 @@ pub fn validate_plugin_target(
         }
     }
     Ok(())
+}
+
+fn clap_validator_command(validator: &Path, clap: &Path, config: &ClapValidatorConfig) -> Command {
+    let mut command = Command::new(validator);
+    command
+        .env("WRAC_PLUGIN_VALIDATOR", "1")
+        .arg("validate")
+        .arg(clap)
+        .arg("--only-failed");
+    for exclusion in &config.test_exclusions {
+        // clap-validator 0.4.1 accepts repeatable regular expressions through --exclude.
+        command.arg("--exclude").arg(&exclusion.filter);
+    }
+    command
 }
 
 fn validate_vst3_component_ids(
@@ -919,5 +931,42 @@ fn ensure_vst3_validator(ctx: &Context) -> Result<PathBuf> {
     } else {
         ensure_exists(&validator_without_config, "VST3 validator")?;
         Ok(validator_without_config)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clap_validator_command_uses_supported_exclusion_arguments() {
+        let config = ClapValidatorConfig {
+            version: "0.4.1".to_string(),
+            test_exclusions: vec![ClapValidatorTestExclusion {
+                filter: "^param-conversions$".to_string(),
+                reason: "upstream validator defect".to_string(),
+            }],
+        };
+
+        let command = clap_validator_command(
+            Path::new("clap-validator"),
+            Path::new("Example.clap"),
+            &config,
+        );
+        let args = command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            args,
+            [
+                "validate",
+                "Example.clap",
+                "--only-failed",
+                "--exclude",
+                "^param-conversions$",
+            ]
+        );
     }
 }

--- a/crates/wrac_build_ops/src/lib.rs
+++ b/crates/wrac_build_ops/src/lib.rs
@@ -18,10 +18,11 @@ pub mod targets;
 mod util;
 
 pub use commands::{
-    AaxValidatorConfig, ClapValidatorConfig, ExternalValidatorConfig, RustPluginBuild,
-    SkippedValidatorTest, WrapperBuild, WrapperTarget, build_gui, build_rust_plugin,
-    build_wrapper_target, check_install_dir, clean, configure_wrapper, install_plugin_target,
-    launch, package_clap, print_build_outputs, uninstall_plugin_target, validate_plugin_target,
+    AaxValidatorConfig, ClapValidatorConfig, ClapValidatorTestExclusion, ExternalValidatorConfig,
+    RustPluginBuild, SkippedValidatorTest, WrapperBuild, WrapperTarget, build_gui,
+    build_rust_plugin, build_wrapper_target, check_install_dir, clean, configure_wrapper,
+    install_plugin_target, launch, package_clap, print_build_outputs, uninstall_plugin_target,
+    validate_plugin_target,
 };
 pub use context::WracContext;
 pub use profile::BuildProfile;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -562,8 +562,7 @@ fn external_validator_config() -> ExternalValidatorConfig {
     ExternalValidatorConfig {
         clap: ClapValidatorConfig {
             version: "0.4.1".to_string(),
-            skip_test_filter: None,
-            skip_reason: None,
+            test_exclusions: Vec::new(),
         },
         aax: AaxValidatorConfig {
             required_tests: [


### PR DESCRIPTION
## Summary

- model clap-validator exclusions as filters paired with required reviewable reasons
- pass exclusions through the clap-validator 0.4.1 supported --exclude option
- log every exclusion and its reason before validation
- cover the generated command arguments with a regression test

## Root cause

The exclusion adapter still generated the pre-0.4.1 --test-filter and --invert-filter arguments. Its filter and reason were also independent optional fields, allowing an exclusion without an explicit justification.

## Impact

Downstream callers can temporarily exclude known upstream validator defects while keeping the reason visible in source and validation logs. The API is intentionally replaced rather than retaining the old fields.

## Checks

- cargo test -p wrac_build_ops
- cargo xtask quality