### PR TITLE
Fix AUv2 main channel capability reporting

### DIFF
--- a/clap_wrapper_builder/clap-wrapper/src/wrapasauv2.cpp
+++ b/clap_wrapper_builder/clap-wrapper/src/wrapasauv2.cpp
@@ -1480,6 +1480,8 @@ UInt32 WrapAsAUV2::SupportedNumChannels(const AUChannelInfo **outInfo)
 
     std::set<int> inSets, outSets;
 
+    // AUChannelInfo describes the main input/output pair. Including auxiliary bus channel counts
+    // advertises main-bus configurations that ValidFormat correctly rejects for element zero.
     bool hasInMain{false};
     for (int i = 0; i < numAudioInputs; ++i)
     {

--- a/clap_wrapper_builder/clap-wrapper/src/wrapasauv2.cpp
+++ b/clap_wrapper_builder/clap-wrapper/src/wrapasauv2.cpp
@@ -1485,8 +1485,11 @@ UInt32 WrapAsAUV2::SupportedNumChannels(const AUChannelInfo **outInfo)
     {
       clap_audio_port_info inf;
       ap->get(pl, i, true, &inf);
-      inSets.insert(inf.channel_count);
-      hasInMain |= (inf.flags & CLAP_AUDIO_PORT_IS_MAIN);
+      if (inf.flags & CLAP_AUDIO_PORT_IS_MAIN)
+      {
+        inSets.insert(inf.channel_count);
+        hasInMain = true;
+      }
     }
     if (!hasInMain) inSets.insert(0);
 
@@ -1495,8 +1498,11 @@ UInt32 WrapAsAUV2::SupportedNumChannels(const AUChannelInfo **outInfo)
     {
       clap_audio_port_info inf;
       ap->get(pl, i, false, &inf);
-      outSets.insert(inf.channel_count);
-      hasOutMain |= (inf.flags & CLAP_AUDIO_PORT_IS_MAIN);
+      if (inf.flags & CLAP_AUDIO_PORT_IS_MAIN)
+      {
+        outSets.insert(inf.channel_count);
+        hasOutMain = true;
+      }
     }
     if (!hasOutMain) outSets.insert(0);
 


### PR DESCRIPTION
## Summary

- report AUv2 channel capabilities from main input and output ports only
- keep the existing zero-channel fallback when no main port exists

## Root cause

`SupportedNumChannels()` combined channel counts from every bus. A differently sized auxiliary bus was therefore advertised as a supported main input/output configuration, even though `ValidFormat()` correctly rejected that channel count for the main bus.

## Validation

- built a multi-bus AUv2 plugin with a stereo main input, mono auxiliary input, and stereo main output
- confirmed `auval` reports only `[2, 2]` and completes successfully
- `git diff --check`