### PR TITLE
Stop declaring AUv2 wrappers sandbox-safe

### DIFF
--- a/clap_wrapper_builder/clap-wrapper/cmake/auv2_Info.plist.in
+++ b/clap_wrapper_builder/clap-wrapper/cmake/auv2_Info.plist.in
@@ -41,13 +41,7 @@
         <string>${AUV2_INSTRUMENT_TYPE}</string>
         <key>version</key>
         <integer>1</integer>
-        <key>resourceUsage</key>
-        <dict>
-          <key>network.client</key>
-          <true/>
-          <key>temporary-exception.files.all.read-write</key>
-          <true/>
-        </dict>
+        <!-- Generic wrappers may use resources that AudioComponent resourceUsage cannot express. -->
       </dict>
     </array>
   </dict>

--- a/clap_wrapper_builder/clap-wrapper/src/detail/auv2/build-helper/build-helper.cpp
+++ b/clap_wrapper_builder/clap-wrapper/src/detail/auv2/build-helper/build-helper.cpp
@@ -68,16 +68,10 @@ struct auInfo
        << "        <key>type</key>\n"
        << "        <string>" << type << "</string>\n"
        << "        <key>version</key>\n"
-       << "        <integer>" << bundleversToVersion() << "</integer>\n"
-       << "        <key>sandboxSafe</key>\n"
-       << "        <true/>\n"
-       << "        <key>resourceUsage</key>\n"
-       << "        <dict>\n"
-       << "           <key>network.client</key>\n"
-       << "           <true/>\n"
-       << "           <key>temporary-exception.files.all.read-write</key>\n"
-       << "           <true/>\n"
-       << "        </dict>\n";
+       << "        <integer>" << bundleversToVersion() << "</integer>\n";
+
+    // A generic wrapper cannot prove that a plugin only uses sandbox-declarable resources.
+    // Omitting both keys avoids incorrectly restricting plugins that use local IPC or listeners.
 
     if (!tags.empty())
     {


### PR DESCRIPTION
## Summary

- Omit `sandboxSafe` from generated AUv2 component descriptions.
- Omit the default `resourceUsage` dictionary from both plist generation paths.
- Keep the wrapper conservative when a plugin may use resources that AudioComponent metadata cannot express, such as local IPC or listeners.

## Validation

- `cargo fmt --all --check`
- `cargo clippy -p wrac_gain_plugin --all-targets -- -D warnings`
- `cargo test -p wrac_gain_plugin`
- `mise exec -- cargo xtask validate --package wrac_gain_plugin --target=au`
- Confirmed the generated AU plist contains neither `sandboxSafe` nor `resourceUsage`.