### PR TITLE
Restore AUv2 sandbox-safe metadata

### DIFF
--- a/clap_wrapper_builder/clap-wrapper/cmake/auv2_Info.plist.in
+++ b/clap_wrapper_builder/clap-wrapper/cmake/auv2_Info.plist.in
@@ -41,7 +41,13 @@
         <string>${AUV2_INSTRUMENT_TYPE}</string>
         <key>version</key>
         <integer>1</integer>
-        <!-- Generic wrappers may use resources that AudioComponent resourceUsage cannot express. -->
+        <key>resourceUsage</key>
+        <dict>
+          <key>network.client</key>
+          <true/>
+          <key>temporary-exception.files.all.read-write</key>
+          <true/>
+        </dict>
       </dict>
     </array>
   </dict>

--- a/clap_wrapper_builder/clap-wrapper/src/detail/auv2/build-helper/build-helper.cpp
+++ b/clap_wrapper_builder/clap-wrapper/src/detail/auv2/build-helper/build-helper.cpp
@@ -68,10 +68,16 @@ struct auInfo
        << "        <key>type</key>\n"
        << "        <string>" << type << "</string>\n"
        << "        <key>version</key>\n"
-       << "        <integer>" << bundleversToVersion() << "</integer>\n";
-
-    // A generic wrapper cannot prove that a plugin only uses sandbox-declarable resources.
-    // Omitting both keys avoids incorrectly restricting plugins that use local IPC or listeners.
+       << "        <integer>" << bundleversToVersion() << "</integer>\n"
+       << "        <key>sandboxSafe</key>\n"
+       << "        <true/>\n"
+       << "        <key>resourceUsage</key>\n"
+       << "        <dict>\n"
+       << "           <key>network.client</key>\n"
+       << "           <true/>\n"
+       << "           <key>temporary-exception.files.all.read-write</key>\n"
+       << "           <true/>\n"
+       << "        </dict>\n";
 
     if (!tags.empty())
     {


### PR DESCRIPTION
## Summary

- restore `sandboxSafe=true` in generated AUv2 metadata
- restore the existing `resourceUsage` declarations

## Rationale

Removing sandbox-safe metadata from the shared template can cause every downstream NovoNotes AUv2 product to ask users to lower the host security policy. That warning is an unsuitable default for the entire product line. The generic wrapper should remain sandbox-safe, while an individual product that genuinely requires undeclarable resources should opt out explicitly or move the privileged capability to an external service.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `mise exec -- cargo xtask validate --target=au`
- confirmed the generated component contains `sandboxSafe=true` and the restored `resourceUsage` dictionary